### PR TITLE
Use Cabana communication buffer optimization

### DIFF
--- a/examples/elastic_wave.cpp
+++ b/examples/elastic_wave.cpp
@@ -53,7 +53,9 @@ int main( int argc, char* argv[] )
 
         // Create particles from mesh.
         // Does not set displacements, velocities, etc.
-        auto particles = std::make_shared<CabanaPD::Particles<memory_space>>(
+        // FIXME: use createSolver to switch backend at runtime.
+        using device_type = Kokkos::Device<exec_space, memory_space>;
+        auto particles = std::make_shared<CabanaPD::Particles<device_type>>(
             exec_space(), inputs.low_corner, inputs.high_corner,
             inputs.num_cells, halo_width );
 
@@ -85,8 +87,6 @@ int main( int argc, char* argv[] )
         };
         particles->update_particles( exec_space{}, init_functor );
 
-        // FIXME: use createSolver to switch backend at runtime.
-        using device_type = Kokkos::Device<exec_space, memory_space>;
         auto cabana_pd = CabanaPD::createSolverElastic<device_type>(
             inputs, particles, force_model );
         cabana_pd->init_force();

--- a/examples/kalthoff_winkler.cpp
+++ b/examples/kalthoff_winkler.cpp
@@ -84,7 +84,9 @@ int main( int argc, char* argv[] )
 
         // Create particles from mesh.
         // Does not set displacements, velocities, etc.
-        auto particles = std::make_shared<CabanaPD::Particles<memory_space>>(
+        // FIXME: use createSolver to switch backend at runtime.
+        using device_type = Kokkos::Device<exec_space, memory_space>;
+        auto particles = std::make_shared<CabanaPD::Particles<device_type>>(
             exec_space(), inputs.low_corner, inputs.high_corner,
             inputs.num_cells, halo_width );
 
@@ -114,8 +116,6 @@ int main( int argc, char* argv[] )
         };
         particles->update_particles( exec_space{}, init_functor );
 
-        // FIXME: use createSolver to switch backend at runtime.
-        using device_type = Kokkos::Device<exec_space, memory_space>;
         auto cabana_pd = CabanaPD::createSolverFracture<device_type>(
             inputs, particles, force_model, bc, prenotch );
         cabana_pd->init_force();

--- a/src/CabanaPD_Comm.hpp
+++ b/src/CabanaPD_Comm.hpp
@@ -170,7 +170,7 @@ struct HaloIds
     }
 };
 
-template <class DeviceType, class ParticleType>
+template <class ParticleType>
 class Comm
 {
   public:
@@ -178,7 +178,9 @@ class Comm
     int mpi_rank = -1;
     int max_export;
 
-    using device_type = DeviceType;
+    // FIXME: this should use MemorySpace directly, but Cabana::Halo currently
+    // uses DeviceType
+    using device_type = typename ParticleType::device_type;
     using halo_type = Cabana::Halo<device_type>;
     using gather_u_type =
         Cabana::Gather<halo_type, typename ParticleType::aosoa_u_type>;

--- a/src/CabanaPD_Comm.hpp
+++ b/src/CabanaPD_Comm.hpp
@@ -170,7 +170,7 @@ struct HaloIds
     }
 };
 
-template <class DeviceType>
+template <class DeviceType, class ParticleType>
 class Comm
 {
   public:
@@ -180,9 +180,16 @@ class Comm
 
     using device_type = DeviceType;
     using halo_type = Cabana::Halo<device_type>;
-    std::shared_ptr<halo_type> halo;
+    using gather_u_type =
+        Cabana::Gather<halo_type, typename ParticleType::aosoa_u_type>;
+    using gather_m_type =
+        Cabana::Gather<halo_type, typename ParticleType::aosoa_m_type>;
+    using gather_theta_type =
+        Cabana::Gather<halo_type, typename ParticleType::aosoa_theta_type>;
+    std::shared_ptr<gather_u_type> gather_u;
+    std::shared_ptr<gather_m_type> gather_m;
+    std::shared_ptr<gather_theta_type> gather_theta;
 
-    template <class ParticleType>
     Comm( ParticleType& particles, int max_export_guess = 100 )
         : max_export( max_export_guess )
     {
@@ -204,12 +211,22 @@ class Comm
         halo_ids.rebuild( *local_grid );
 
         // Create the Cabana Halo.
-        halo = std::make_shared<Cabana::Halo<device_type>>(
-            local_grid->globalGrid().comm(), particles.n_local, halo_ids._ids,
-            halo_ids._destinations, topology );
+        auto halo =
+            halo_type( local_grid->globalGrid().comm(), particles.n_local,
+                       halo_ids._ids, halo_ids._destinations, topology );
 
-        particles.resize( halo->numLocal(), halo->numGhost() );
-        particles.gather_init( *halo );
+        particles.resize( halo.numLocal(), halo.numGhost() );
+
+        // Only use this interface because we don't need to recommunicate
+        // positions or volumes.
+        Cabana::gather( halo, particles._aosoa_x );
+        Cabana::gather( halo, particles._aosoa_vol );
+
+        gather_u = std::make_shared<gather_u_type>( halo, particles._aosoa_u );
+        gather_m = std::make_shared<gather_m_type>( halo, particles._aosoa_m );
+        gather_theta =
+            std::make_shared<gather_theta_type>( halo, particles._aosoa_theta );
+        gather_u->apply();
     }
     ~Comm() {}
 
@@ -226,21 +243,9 @@ class Comm
 
     // We assume here that the particle count has not changed and no resize
     // is necessary.
-    template <class ParticleType>
-    void gather_u( ParticleType& particles )
-    {
-        particles.gather_u( *halo );
-    }
-    template <class ParticleType>
-    void gather_theta( ParticleType& particles )
-    {
-        particles.gather_theta( *halo );
-    }
-    template <class ParticleType>
-    void gather_m( ParticleType& particles )
-    {
-        particles.gather_m( *halo );
-    }
+    void gatherDisplacement() { gather_u->apply(); }
+    void gatherDilatation() { gather_theta->apply(); }
+    void gatherWeightedVolume() { gather_m->apply(); }
 };
 
 } // namespace CabanaPD

--- a/src/CabanaPD_Comm.hpp
+++ b/src/CabanaPD_Comm.hpp
@@ -209,7 +209,7 @@ class Comm
             halo_ids._destinations, topology );
 
         particles.resize( halo->numLocal(), halo->numGhost() );
-        particles.gather( *halo );
+        particles.gather_init( *halo );
     }
     ~Comm() {}
 
@@ -227,9 +227,9 @@ class Comm
     // We assume here that the particle count has not changed and no resize
     // is necessary.
     template <class ParticleType>
-    void gather( ParticleType& particles )
+    void gather_u( ParticleType& particles )
     {
-        particles.gather( *halo );
+        particles.gather_u( *halo );
     }
     template <class ParticleType>
     void gather_theta( ParticleType& particles )

--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -69,15 +69,20 @@
 #include <Cabana_Core.hpp>
 #include <Cajita.hpp>
 
+#include <CabanaPD_Comm.hpp>
+
 namespace CabanaPD
 {
 
-template <class MemorySpace, int Dimension = 3>
+// FIXME: this should use MemorySpace directly, but DeviceType enables the
+// friend class with Comm (which only uses DeviceType because Cabana::Halo
+// currently does)
+template <class DeviceType, int Dimension = 3>
 class Particles
 {
   public:
-    using memory_space = MemorySpace;
-    using device_type = typename memory_space::device_type;
+    using device_type = DeviceType;
+    using memory_space = typename device_type::memory_space;
     static constexpr int dim = Dimension;
 
     // Per particle
@@ -352,6 +357,8 @@ class Particles
         size = _aosoa_x.size();
     };
 
+    friend class Comm<Particles<device_type>>;
+
   protected:
     aosoa_x_type _aosoa_x;
     aosoa_u_type _aosoa_u;
@@ -360,11 +367,6 @@ class Particles
     aosoa_theta_type _aosoa_theta;
     aosoa_m_type _aosoa_m;
     aosoa_other_type _aosoa_other;
-
-    // FIXME: Cabana::Halo should only template on memory_space, but until it
-    // does getting the default device_type here seems best.
-    friend class Comm<typename memory_space::device_type,
-                      Particles<memory_space>>;
 };
 
 } // namespace CabanaPD

--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -353,12 +353,17 @@ class Particles
     };
 
     template <class HaloType>
-    void gather( HaloType halo )
+    void gather_init( HaloType halo )
     {
         Cabana::gather( halo, _aosoa_x );
         Cabana::gather( halo, _aosoa_u );
         Cabana::gather( halo, _aosoa_vol );
     }
+    template <class HaloType>
+    void gather_u( HaloType halo )
+    {
+        Cabana::gather( halo, _aosoa_u );
+    };
     template <class HaloType>
     void gather_theta( HaloType halo )
     {

--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -352,29 +352,6 @@ class Particles
         size = _aosoa_x.size();
     };
 
-    template <class HaloType>
-    void gather_init( HaloType halo )
-    {
-        Cabana::gather( halo, _aosoa_x );
-        Cabana::gather( halo, _aosoa_u );
-        Cabana::gather( halo, _aosoa_vol );
-    }
-    template <class HaloType>
-    void gather_u( HaloType halo )
-    {
-        Cabana::gather( halo, _aosoa_u );
-    };
-    template <class HaloType>
-    void gather_theta( HaloType halo )
-    {
-        Cabana::gather( halo, _aosoa_theta );
-    }
-    template <class HaloType>
-    void gather_m( HaloType halo )
-    {
-        Cabana::gather( halo, _aosoa_m );
-    }
-
   protected:
     aosoa_x_type _aosoa_x;
     aosoa_u_type _aosoa_u;
@@ -383,6 +360,11 @@ class Particles
     aosoa_theta_type _aosoa_theta;
     aosoa_m_type _aosoa_m;
     aosoa_other_type _aosoa_other;
+
+    // FIXME: Cabana::Halo should only template on memory_space, but until it
+    // does getting the default device_type here seems best.
+    friend class Comm<typename memory_space::device_type,
+                      Particles<memory_space>>;
 };
 
 } // namespace CabanaPD

--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -97,9 +97,9 @@ class SolverElastic
     using exec_space = typename DeviceType::execution_space;
     using memory_space = typename DeviceType::memory_space;
 
-    using particle_type = Particles<memory_space>;
+    using particle_type = Particles<DeviceType>;
     using integrator_type = Integrator<exec_space>;
-    using comm_type = Comm<DeviceType, particle_type>;
+    using comm_type = Comm<particle_type>;
     using force_model_type = ForceModel;
     using force_type = Force<exec_space, force_model_type>;
     using neighbor_type =

--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -201,7 +201,7 @@ class SolverElastic
 
             // Update ghost particles.
             comm_timer.reset();
-            comm->gather( *particles );
+            comm->gather_u( *particles );
             comm_time += comm_timer.seconds();
 
             // Reset forces
@@ -384,7 +384,7 @@ class SolverFracture : public SolverElastic<DeviceType, ForceModel>
 
             // Update ghost particles.
             comm_timer.reset();
-            comm->gather( *particles );
+            comm->gather_u( *particles );
             comm_time += comm_timer.seconds();
 
             // Reset forces

--- a/unit_test/tstComm.hpp
+++ b/unit_test/tstComm.hpp
@@ -39,7 +39,6 @@ namespace Test
 void testHalo()
 {
     using exec_space = TEST_EXECSPACE;
-    using mem_space = TEST_MEMSPACE;
     using device_type = TEST_DEVICE;
 
     std::array<double, 3> box_min = { -1.0, -1.0, -1.0 };
@@ -50,8 +49,9 @@ void testHalo()
     int halo_width = 2;
     // FIXME: This is for m = 1; should be calculated from m
     int expected_n = 6;
-    CabanaPD::Particles<mem_space> particles( exec_space(), box_min, box_max,
-                                              num_cells, halo_width );
+    using particles_type = CabanaPD::Particles<device_type>;
+    particles_type particles( exec_space(), box_min, box_max, num_cells,
+                              halo_width );
     // Set ID equal to MPI rank.
     int current_rank = -1;
     MPI_Comm_rank( MPI_COMM_WORLD, &current_rank );
@@ -76,7 +76,7 @@ void testHalo()
     Cabana::deep_copy( rank_init_host, rank );
 
     // A gather is performed on construction.
-    CabanaPD::Comm<device_type> comm( particles );
+    CabanaPD::Comm<particles_type> comm( particles );
 
     HostAoSoA aosoa_host( "host_aosoa", particles.size );
     x = particles.slice_x();

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -374,7 +374,7 @@ auto createParticles( LinearTag, const double dx, const double s0 )
     std::array<int, 3> num_cells = { nc, nc, nc };
 
     // Create particles based on the mesh.
-    using ptype = CabanaPD::Particles<TEST_MEMSPACE>;
+    using ptype = CabanaPD::Particles<TEST_DEVICE>;
     ptype particles( TEST_EXECSPACE{}, box_min, box_max, num_cells, 0 );
 
     auto x = particles.slice_x();

--- a/unit_test/tstIntegrator.hpp
+++ b/unit_test/tstIntegrator.hpp
@@ -38,18 +38,17 @@ namespace Test
 void testIntegratorReversibility( int steps )
 {
     using exec_space = TEST_EXECSPACE;
-    using mem_space = TEST_MEMSPACE;
 
     std::array<double, 3> box_min = { -1.0, -1.0, -1.0 };
     std::array<double, 3> box_max = { 1.0, 1.0, 1.0 };
     std::array<int, 3> num_cells = { 10, 10, 10 };
 
-    CabanaPD::Particles<mem_space> particles( exec_space(), box_min, box_max,
-                                              num_cells, 0 );
+    CabanaPD::Particles<TEST_DEVICE> particles( exec_space(), box_min, box_max,
+                                                num_cells, 0 );
     auto x = particles.slice_x();
     std::size_t num_particle = x.size();
 
-    CabanaPD::Integrator<TEST_EXECSPACE> integrator( 0.001, 1.0 );
+    CabanaPD::Integrator<exec_space> integrator( 0.001, 1.0 );
 
     // Keep a copy of initial positions on the host
     using DataTypes = Cabana::MemberTypes<double[3]>;


### PR DESCRIPTION
Includes optimization to only communicate positions and volumes once, then uses the same buffers for all communication of weighted volume, dilatation, and displacement rather than recreating every step