### PR TITLE
Add Cabana HDF5 particle output

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   CI:
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         distro: ['ubuntu:latest']
@@ -16,6 +19,26 @@ jobs:
         backend: ['SERIAL', 'OPENMP']
         cmake_build_type: ['Debug', 'Release']
         kokkos_ver: ['3.6.01']
+        output: ['HDF5']
+        include:
+          - distro: 'ubuntu:latest'
+            cxx: 'g++'
+            backend: 'SERIAL'
+            cmake_build_type: 'Debug'
+            kokkos_ver: '3.6.01'
+            output: 'SILO'
+          - distro: 'ubuntu:latest'
+            cxx: 'g++'
+            backend: 'SERIAL'
+            cmake_build_type: 'Debug'
+            kokkos_ver: '3.6.01'
+            output: 'NONE'
+          - distro: 'ubuntu:latest'
+            cxx: 'g++'
+            backend: 'SERIAL'
+            cmake_build_type: 'Debug'
+            kokkos_ver: '3.6.01'
+            output: 'BOTH'
     runs-on: ubuntu-20.04
     container: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
     steps:
@@ -41,16 +64,26 @@ jobs:
         with:
           repository: ECP-CoPA/Cabana
           # This version is post-release 0.5
-          ref: 10cc6758fa19dce9922a5e695c173e0586eb5d70
+          ref: 4fdb7eeb3ea32557444766a917fb9252af8540d6
           path: cabana
       - name: Build Cabana
         working-directory: cabana
         run: |
+          if [[ ${{ matrix.output }} == 'HDF5' ]]; then
+            cabana_cmake_opts+=( -DCabana_REQUIRE_HDF5=ON -DCMAKE_DISABLE_FIND_PACKAGE_SILO=ON )
+          elif [[ ${{ matrix.output }} == 'SILO' ]]; then
+            cabana_cmake_opts+=( -DCabana_REQUIRE_SILO=ON -DCMAKE_DISABLE_FIND_PACKAGE_HDF5=ON )
+          elif [[ ${{ matrix.output }} == 'BOTH' ]]; then
+            cabana_cmake_opts+=( -DCabana_REQUIRE_SILO=ON -DCabana_REQUIRE_HDF5=ON )
+          else
+            cabana_cmake_opts+=( -DCMAKE_DISABLE_FIND_PACKAGE_SILO=ON -DCMAKE_DISABLE_FIND_PACKAGE_HDF5=ON )
+          fi
           cmake -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_INSTALL_PREFIX=$HOME/Cabana \
-            -DCMAKE_PREFIX_PATH="$HOME/kokkos"
+            -DCMAKE_PREFIX_PATH="$HOME/kokkos" \
+            ${cabana_cmake_opts[@]}
           cmake --build build --parallel 2
           cmake --install build
       - name: Checkout CabanaPD

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -41,7 +41,9 @@ jobs:
           cmake -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DCMAKE_INSTALL_PREFIX=$HOME/Cabana \
-            -DCMAKE_PREFIX_PATH="$HOME/kokkos"
+            -DCMAKE_PREFIX_PATH="$HOME/kokkos" \
+            -DCabana_REQUIRE_HDF5=ON \
+            -DCabana_REQUIRE_SILO=ON
           cmake --build build --parallel 2
           cmake --install build
       - name: Checkout CabanaPD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,17 +18,25 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 ##---------------------------------------------------------------------------##
 find_package(Cabana REQUIRED)
 
-macro(CabanaPD_check_enabled)
+macro(CabanaPD_check_required)
   cmake_parse_arguments(CABANA "" "OPTION" "" ${ARGN})
-
   if( NOT Cabana_ENABLE_${CABANA_OPTION} )
     message( FATAL_ERROR "Cabana must be compiled with ${CABANA_OPTION}" )
   endif()
 endmacro()
 
-CabanaPD_check_enabled( OPTION MPI )
-CabanaPD_check_enabled( OPTION CAJITA )
-CabanaPD_check_enabled( OPTION SILO )
+CabanaPD_check_required( OPTION MPI )
+CabanaPD_check_required( OPTION CAJITA )
+
+macro(CabanaPD_check_optional)
+  cmake_parse_arguments(CABANA "" "OPTION" "" ${ARGN})
+  if( Cabana_ENABLE_${CABANA_OPTION} )
+    message( STATUS "Cabana includes ${CABANA_OPTION}" )
+  endif()
+endmacro()
+
+CabanaPD_check_optional( OPTION HDF5 )
+CabanaPD_check_optional( OPTION SILO )
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CabanaPD_Config.cmakein
   ${CMAKE_CURRENT_BINARY_DIR}/CabanaPD_Config.cmake @ONLY)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CabanaPD has the following dependencies:
 |Dependency | Version  | Required | Details|
 |---------- | -------  |--------  |------- |
 |CMake      | 3.11+    | Yes      | Build system
-|Cabana     | 10cc6758 | Yes      | Performance portable particle algorithms
+|Cabana     | 4fdb7eeb | Yes      | Performance portable particle algorithms
 |GTest      | 1.10+    | No       | Unit test framework
 
 Cabana must be built with the following in order to work with CabanaPD:
@@ -17,7 +17,8 @@ Cabana must be built with the following in order to work with CabanaPD:
 |CMake      | 3.16+   | Yes      | Build system
 |MPI        | GPU-Aware if CUDA/HIP enabled | Yes | Message Passing Interface
 |Kokkos     | 3.6.0+  | Yes      | Performance portable on-node parallelism
-|SILO       | master  | Yes      | Particle output
+|HDF5       | master  | No       | Particle output
+|SILO       | master  | No       | Particle output
 
 The underlying parallel programming models are available on most systems, as is
 CMake. Those must be installed first, if not available. Kokkos and Cabana are
@@ -107,11 +108,7 @@ ctest
 ## Examples
 
 Once built and installed, CabanaPD examples can be run. Timing and energy
-information is output to file and particle output is written to files that can
-be visualized with Paraview and similar applications. The first example is an
-elastic wave propagating through a cube from an initial Gaussian radial
-displacement profile from [1]. Assuming the build paths above, the example can
-be run with:
+information is output to file and particle output is written to files (if enabled within Cabana) that can be visualized with Paraview and similar applications. The first example is an elastic wave propagating through a cube from an initial Gaussian radial displacement profile from [1]. Assuming the build paths above, the example can be run with:
 
 ```
 ./CabanaPD/build/install/bin/ElasticWave


### PR DESCRIPTION
Default to HDF5 output; if not available, use Silo output. If neither are compiled with Cabana, warn that no particle output is available