### PR TITLE
Changes to mu_ij if statements for performance improvements

### DIFF
--- a/src/CabanaPD_Force.hpp
+++ b/src/CabanaPD_Force.hpp
@@ -581,19 +581,17 @@ class Force<ExecutionSpace, ForceModel<LPS, Fracture>>
                                                                   i );
             for ( std::size_t n = 0; n < num_neighbors; n++ )
             {
-                if ( mu( i, n ) > 0 )
-                {
-                    std::size_t j =
-                        Cabana::NeighborList<NeighListType>::getNeighbor(
-                            neigh_list, i, n );
+                std::size_t j =
+                    Cabana::NeighborList<NeighListType>::getNeighbor(
+                        neigh_list, i, n );
 
-                    // Get the reference positions and displacements.
-                    double xi, r, s;
-                    getDistance( x, u, i, j, xi, r, s );
-                    double m_j =
-                        model.influence_function( xi ) * xi * xi * vol( j );
-                    m( i ) += m_j;
-                }
+                // Get the reference positions and displacements.
+                double xi, r, s;
+                getDistance( x, u, i, j, xi, r, s );
+                // Added mu to account for bond breaking.
+                double m_j = mu( i, n ) * model.influence_function( xi ) * xi *
+                             xi * vol( j );
+                m( i ) += m_j;
             }
         };
 
@@ -624,19 +622,20 @@ class Force<ExecutionSpace, ForceModel<LPS, Fracture>>
                                                                   i );
             for ( std::size_t n = 0; n < num_neighbors; n++ )
             {
-                if ( mu( i, n ) > 0 )
-                {
-                    std::size_t j =
-                        Cabana::NeighborList<NeighListType>::getNeighbor(
-                            neigh_list, i, n );
+                std::size_t j =
+                    Cabana::NeighborList<NeighListType>::getNeighbor(
+                        neigh_list, i, n );
 
-                    // Get the bond distance, displacement, and stretch.
-                    double xi, r, s;
-                    getDistance( x, u, i, j, xi, r, s );
-                    double theta_i =
-                        model.influence_function( xi ) * s * xi * xi * vol( j );
+                // Get the bond distance, displacement, and stretch.
+                double xi, r, s;
+                getDistance( x, u, i, j, xi, r, s );
+                // Added mu to account for bond breaking.
+                double theta_i = mu( i, n ) * model.influence_function( xi ) *
+                                 s * xi * xi * vol( j );
+                // m( i ) is 0 when all bonds connected to particle i are
+                // broken.
+                if ( m( i ) > 0 )
                     theta( i ) += 3.0 * theta_i / m( i );
-                }
             }
         };
 
@@ -668,42 +667,43 @@ class Force<ExecutionSpace, ForceModel<LPS, Fracture>>
                                                                   i );
             for ( std::size_t n = 0; n < num_neighbors; n++ )
             {
-                if ( mu( i, n ) > 0 )
+                double fx_i = 0.0;
+                double fy_i = 0.0;
+                double fz_i = 0.0;
+
+                std::size_t j =
+                    Cabana::NeighborList<NeighListType>::getNeighbor(
+                        neigh_list, i, n );
+
+                // Get the reference positions and displacements.
+                double xi, r, s;
+                double rx, ry, rz;
+                getDistanceComponents( x, u, i, j, xi, r, s, rx, ry, rz );
+
+                // Break if beyond critical stretch unless in no-fail zone.
+                if ( r * r >= break_coeff * xi * xi && !nofail( i ) &&
+                     !nofail( i ) )
                 {
-                    double fx_i = 0.0;
-                    double fy_i = 0.0;
-                    double fz_i = 0.0;
+                    mu( i, n ) = 0;
+                    // Note m( i ) = 0 when all bonds connected to particle i
+                    // are broken, which implies mu( i, n ) = 0 for all
+                    // neighbors of particle i. Similarly for m( j ).
+                }
+                else if ( mu( i, n ) > 0 )
+                {
+                    const double coeff =
+                        ( theta_coeff *
+                              ( theta( i ) / m( i ) + theta( j ) / m( j ) ) +
+                          s_coeff * s * ( 1.0 / m( i ) + 1.0 / m( j ) ) ) *
+                        model.influence_function( xi ) * xi * vol( j );
+                    double muij = mu( i, n );
+                    fx_i = muij * coeff * rx / r;
+                    fy_i = muij * coeff * ry / r;
+                    fz_i = muij * coeff * rz / r;
 
-                    std::size_t j =
-                        Cabana::NeighborList<NeighListType>::getNeighbor(
-                            neigh_list, i, n );
-
-                    // Get the reference positions and displacements.
-                    double xi, r, s;
-                    double rx, ry, rz;
-                    getDistanceComponents( x, u, i, j, xi, r, s, rx, ry, rz );
-
-                    // Break if beyond critical stretch unless in no-fail zone.
-                    if ( r * r >= break_coeff * xi * xi && !nofail( i ) &&
-                         !nofail( i ) )
-                        mu( i, n ) = 0;
-
-                    if ( mu( i, n ) > 0 )
-                    {
-                        const double coeff =
-                            ( theta_coeff * ( theta( i ) / m( i ) +
-                                              theta( j ) / m( j ) ) +
-                              s_coeff * s * ( 1.0 / m( i ) + 1.0 / m( j ) ) ) *
-                            model.influence_function( xi ) * xi * vol( j );
-                        double muij = mu( i, n );
-                        fx_i = muij * coeff * rx / r;
-                        fy_i = muij * coeff * ry / r;
-                        fz_i = muij * coeff * rz / r;
-
-                        f( i, 0 ) += fx_i;
-                        f( i, 1 ) += fy_i;
-                        f( i, 2 ) += fz_i;
-                    }
+                    f( i, 0 ) += fx_i;
+                    f( i, 1 ) += fy_i;
+                    f( i, 2 ) += fz_i;
                 }
             }
         };
@@ -1026,38 +1026,36 @@ class Force<ExecutionSpace, ForceModel<PMB, Fracture>>
                                                                   i );
             for ( std::size_t n = 0; n < num_neighbors; n++ )
             {
-                if ( mu( i, n ) > 0 )
+                double fx_i = 0.0;
+                double fy_i = 0.0;
+                double fz_i = 0.0;
+
+                std::size_t j =
+                    Cabana::NeighborList<NeighListType>::getNeighbor(
+                        neigh_list, i, n );
+
+                // Get the reference positions and displacements.
+                double xi, r, s;
+                double rx, ry, rz;
+                getDistanceComponents( x, u, i, j, xi, r, s, rx, ry, rz );
+
+                // Break if beyond critical stretch unless in no-fail zone.
+                if ( r * r >= break_coeff * xi * xi && !nofail( i ) &&
+                     !nofail( j ) )
                 {
-                    double fx_i = 0.0;
-                    double fy_i = 0.0;
-                    double fz_i = 0.0;
+                    mu( i, n ) = 0;
+                }
+                else if ( mu( i, n ) > 0 )
+                {
+                    const double coeff = c * s * vol( j );
+                    double muij = mu( i, n );
+                    fx_i = muij * coeff * rx / r;
+                    fy_i = muij * coeff * ry / r;
+                    fz_i = muij * coeff * rz / r;
 
-                    std::size_t j =
-                        Cabana::NeighborList<NeighListType>::getNeighbor(
-                            neigh_list, i, n );
-
-                    // Get the reference positions and displacements.
-                    double xi, r, s;
-                    double rx, ry, rz;
-                    getDistanceComponents( x, u, i, j, xi, r, s, rx, ry, rz );
-
-                    // Break if beyond critical stretch unless in no-fail zone.
-                    if ( r * r >= break_coeff * xi * xi && !nofail( i ) &&
-                         !nofail( j ) )
-                        mu( i, n ) = 0;
-
-                    if ( mu( i, n ) > 0 )
-                    {
-                        const double coeff = c * s * vol( j );
-                        double muij = mu( i, n );
-                        fx_i = muij * coeff * rx / r;
-                        fy_i = muij * coeff * ry / r;
-                        fz_i = muij * coeff * rz / r;
-
-                        f( i, 0 ) += fx_i;
-                        f( i, 1 ) += fy_i;
-                        f( i, 2 ) += fz_i;
-                    }
+                    f( i, 0 ) += fx_i;
+                    f( i, 1 ) += fy_i;
+                    f( i, 2 ) += fz_i;
                 }
             }
         };

--- a/src/CabanaPD_Force.hpp
+++ b/src/CabanaPD_Force.hpp
@@ -633,7 +633,7 @@ class Force<ExecutionSpace, ForceModel<LPS, Fracture>>
                 double theta_i = mu( i, n ) * model.influence_function( xi ) *
                                  s * xi * xi * vol( j );
                 // Check if all bonds are broken (m=0) to avoid dividing by
-                // zero. Alternatively, once could check if this bond mu(i,n) is
+                // zero. Alternatively, one could check if this bond mu(i,n) is
                 // broken, beacuse m=0 only occurs when all bonds are broken.
                 if ( m( i ) > 0 )
                     theta( i ) += 3.0 * theta_i / m( i );
@@ -1046,6 +1046,7 @@ class Force<ExecutionSpace, ForceModel<PMB, Fracture>>
                 {
                     mu( i, n ) = 0;
                 }
+                // Else if statement is only for performance.
                 else if ( mu( i, n ) > 0 )
                 {
                     const double coeff = c * s * vol( j );

--- a/src/CabanaPD_Force.hpp
+++ b/src/CabanaPD_Force.hpp
@@ -588,6 +588,7 @@ class Force<ExecutionSpace, ForceModel<LPS, Fracture>>
                 // Get the reference positions and displacements.
                 double xi, r, s;
                 getDistance( x, u, i, j, xi, r, s );
+                // mu is included to account for bond breaking.
                 double m_j = mu( i, n ) * model.influence_function( xi ) * xi *
                              xi * vol( j );
                 m( i ) += m_j;
@@ -628,6 +629,7 @@ class Force<ExecutionSpace, ForceModel<LPS, Fracture>>
                 // Get the bond distance, displacement, and stretch.
                 double xi, r, s;
                 getDistance( x, u, i, j, xi, r, s );
+                // mu is included to account for bond breaking.
                 double theta_i = mu( i, n ) * model.influence_function( xi ) *
                                  s * xi * xi * vol( j );
                 // Check if all bonds are broken (m=0) to avoid dividing by

--- a/src/CabanaPD_Force.hpp
+++ b/src/CabanaPD_Force.hpp
@@ -588,7 +588,6 @@ class Force<ExecutionSpace, ForceModel<LPS, Fracture>>
                 // Get the reference positions and displacements.
                 double xi, r, s;
                 getDistance( x, u, i, j, xi, r, s );
-                // Added mu to account for bond breaking.
                 double m_j = mu( i, n ) * model.influence_function( xi ) * xi *
                              xi * vol( j );
                 m( i ) += m_j;
@@ -629,11 +628,11 @@ class Force<ExecutionSpace, ForceModel<LPS, Fracture>>
                 // Get the bond distance, displacement, and stretch.
                 double xi, r, s;
                 getDistance( x, u, i, j, xi, r, s );
-                // Added mu to account for bond breaking.
                 double theta_i = mu( i, n ) * model.influence_function( xi ) *
                                  s * xi * xi * vol( j );
-                // m( i ) is 0 when all bonds connected to particle i are
-                // broken.
+                // Check if all bonds are broken (m=0) to avoid dividing by
+                // zero. Alternatively, once could check if this bond mu(i,n) is
+                // broken, beacuse m=0 only occurs when all bonds are broken.
                 if ( m( i ) > 0 )
                     theta( i ) += 3.0 * theta_i / m( i );
             }
@@ -685,10 +684,10 @@ class Force<ExecutionSpace, ForceModel<LPS, Fracture>>
                      !nofail( i ) )
                 {
                     mu( i, n ) = 0;
-                    // Note m( i ) = 0 when all bonds connected to particle i
-                    // are broken, which implies mu( i, n ) = 0 for all
-                    // neighbors of particle i. Similarly for m( j ).
                 }
+                // Check if this bond is broken (mu=0) to ensure m(i) and m(j)
+                // are both >0 (m=0 only occurs when all bonds are broken) to
+                // avoid dividing by zero.
                 else if ( mu( i, n ) > 0 )
                 {
                     const double coeff =


### PR DESCRIPTION
Changes made to the force calculation for performance improvement. 

Results below based on the KalthoffWinkler example with: 
- std::array<int, 3> num_cell = { 400, 800, 36 };
- double delta = 0.00150000001;
running on 1 node of Frontier with 8 GPUs.

For the PMB model:
-------------------
Changes to the force calculation reduces:
- force calculation time from 313.90 s to 294.73 s (~6.1% reduction)
- communication time from 5.12 s to 3.82 s (~25.4% reduction)
- total time from 339.62 s to 316.45 s (~6.8% reduction)

For the LPS model:
------------------
(a) Changes to the weighted volume calculation reduces communication time from 383.48 s to 371.92 s (~3% reduction)
(b) Changes to the dilatation calculation in addition to (a) reduces communication time from 383.48 s to 350.14 s (~8.7 % reduction)
(c) Changes to the force calculation in addition to (a) and (b) reduces:
- force calculation time from 394.40 s to 374.19 s (~5.1% reduction)
- communication time from 383.48 s to 350.57 s (~8.6% reduction)
- total time from 801.35 s to 769.50 s (~4% reduction)



