### PR TITLE
Fix unit for body force density

### DIFF
--- a/examples/crack_branching.cpp
+++ b/examples/crack_branching.cpp
@@ -100,7 +100,7 @@ int main( int argc, char* argv[] )
 
         // Relying on uniform grid here.
         double dy = particles->dx[1];
-        double b0 = 2e6 / dy; // Pa
+        double b0 = 2e6 / dy; // Pa/m
 
         CabanaPD::RegionBoundary plane1( low_x, high_x, low_y - dy, low_y + dy,
                                          low_z, high_z );


### PR DESCRIPTION
@streeve : "Pa" is the unit of traction. The unit of body force density is "N/m^3" which is equal to "Pa/m"