### PR TITLE
Separate Kokkos+MPI init from examples

### DIFF
--- a/examples/crack_branching.cpp
+++ b/examples/crack_branching.cpp
@@ -18,134 +18,137 @@
 
 #include <CabanaPD.hpp>
 
+// Simulate crack branching from an pre-crack.
+void crackBranchingExample( const std::string filename )
+{
+    // ====================================================
+    //                  Use default Kokkos spaces
+    // ====================================================
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using memory_space = typename exec_space::memory_space;
+
+    // ====================================================
+    //                   Read inputs
+    // ====================================================
+    CabanaPD::Inputs inputs( filename );
+
+    // ====================================================
+    //                Material parameters
+    // ====================================================
+    double rho0 = inputs["density"];
+    double E = inputs["elastic_modulus"];
+    double nu = 0.25;
+    double K = E / ( 3 * ( 1 - 2 * nu ) );
+    double G0 = inputs["fracture_energy"];
+    double delta = inputs["horizon"];
+    delta += 1e-10;
+
+    // ====================================================
+    //                  Discretization
+    // ====================================================
+    // FIXME: set halo width based on delta
+    std::array<double, 3> low_corner = inputs["low_corner"];
+    std::array<double, 3> high_corner = inputs["high_corner"];
+    std::array<int, 3> num_cells = inputs["num_cells"];
+    int m = std::floor( delta /
+                        ( ( high_corner[0] - low_corner[0] ) / num_cells[0] ) );
+    int halo_width = m + 1; // Just to be safe.
+
+    // ====================================================
+    //                    Pre-notch
+    // ====================================================
+    double height = inputs["system_size"][0];
+    double thickness = inputs["system_size"][2];
+    double L_prenotch = height / 2.0;
+    double y_prenotch1 = 0.0;
+    Kokkos::Array<double, 3> p01 = { low_corner[0], y_prenotch1,
+                                     low_corner[2] };
+    Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
+    Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
+    Kokkos::Array<Kokkos::Array<double, 3>, 1> notch_positions = { p01 };
+    CabanaPD::Prenotch<1> prenotch( v1, v2, notch_positions );
+
+    // ====================================================
+    //                    Force model
+    // ====================================================
+    using model_type = CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Fracture>;
+    model_type force_model( delta, K, G0 );
+
+    // ====================================================
+    //                 Particle generation
+    // ====================================================
+    // Does not set displacements, velocities, etc.
+    auto particles = std::make_shared<
+        CabanaPD::Particles<memory_space, typename model_type::base_model>>(
+        exec_space(), low_corner, high_corner, num_cells, halo_width );
+
+    // ====================================================
+    //                Boundary conditions
+    // ====================================================
+    double sigma0 = inputs["traction"];
+    double dy = particles->dx[1];
+    double b0 = sigma0 / dy;
+
+    CabanaPD::RegionBoundary plane1( low_corner[0], high_corner[0],
+                                     low_corner[1] - dy, low_corner[1] + dy,
+                                     low_corner[2], high_corner[2] );
+    CabanaPD::RegionBoundary plane2( low_corner[0], high_corner[0],
+                                     high_corner[1] - dy, high_corner[1] + dy,
+                                     low_corner[2], high_corner[2] );
+    std::vector<CabanaPD::RegionBoundary> planes = { plane1, plane2 };
+    auto particles_f = particles->getForce();
+    auto particles_x = particles->getReferencePosition();
+    // Create a symmetric force BC in the y-direction.
+    auto bc_op = KOKKOS_LAMBDA( const int pid )
+    {
+        // Get a modifiable copy of force.
+        auto p_f = particles_f.getParticleView( pid );
+        // Get a copy of the position.
+        auto p_x = particles_x.getParticle( pid );
+        auto ypos = Cabana::get( p_x, CabanaPD::Field::ReferencePosition(), 1 );
+        auto sign = std::abs( ypos ) / ypos;
+        Cabana::get( p_f, CabanaPD::Field::Force(), 1 ) += b0 * sign;
+    };
+    auto bc =
+        createBoundaryCondition( bc_op, exec_space{}, *particles, planes );
+
+    // ====================================================
+    //            Custom particle initialization
+    // ====================================================
+    auto rho = particles->sliceDensity();
+    auto x = particles->sliceReferencePosition();
+    auto v = particles->sliceVelocity();
+    auto f = particles->sliceForce();
+    auto nofail = particles->sliceNoFail();
+
+    auto init_functor = KOKKOS_LAMBDA( const int pid )
+    {
+        // Density
+        rho( pid ) = rho0;
+        // No-fail zone
+        if ( x( pid, 1 ) <= plane1.low_y + delta + 1e-10 ||
+             x( pid, 1 ) >= plane2.high_y - delta - 1e-10 )
+            nofail( pid ) = 1;
+    };
+    particles->updateParticles( exec_space{}, init_functor );
+
+    // ====================================================
+    //                   Simulation run
+    // ====================================================
+    auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
+        inputs, particles, force_model, bc, prenotch );
+    cabana_pd->init_force();
+    cabana_pd->run();
+}
+
+// Initialize MPI+Kokkos.
 int main( int argc, char* argv[] )
 {
     MPI_Init( &argc, &argv );
+    Kokkos::initialize( argc, argv );
 
-    {
-        // ====================================================
-        //                  Setup Kokkos
-        // ====================================================
-        Kokkos::ScopeGuard scope_guard( argc, argv );
+    crackBranchingExample( argv[1] );
 
-        using exec_space = Kokkos::DefaultExecutionSpace;
-        using memory_space = typename exec_space::memory_space;
-
-        // ====================================================
-        //                   Read inputs
-        // ====================================================
-        CabanaPD::Inputs inputs( argv[1] );
-
-        // ====================================================
-        //                Material parameters
-        // ====================================================
-        double rho0 = inputs["density"];
-        double E = inputs["elastic_modulus"];
-        double nu = 0.25;
-        double K = E / ( 3 * ( 1 - 2 * nu ) );
-        double G0 = inputs["fracture_energy"];
-        double delta = inputs["horizon"];
-        delta += 1e-10;
-
-        // ====================================================
-        //                  Discretization
-        // ====================================================
-        // FIXME: set halo width based on delta
-        std::array<double, 3> low_corner = inputs["low_corner"];
-        std::array<double, 3> high_corner = inputs["high_corner"];
-        std::array<int, 3> num_cells = inputs["num_cells"];
-        int m = std::floor(
-            delta / ( ( high_corner[0] - low_corner[0] ) / num_cells[0] ) );
-        int halo_width = m + 1; // Just to be safe.
-
-        // ====================================================
-        //                    Pre-notch
-        // ====================================================
-        double height = inputs["system_size"][0];
-        double thickness = inputs["system_size"][2];
-        double L_prenotch = height / 2.0;
-        double y_prenotch1 = 0.0;
-        Kokkos::Array<double, 3> p01 = { low_corner[0], y_prenotch1,
-                                         low_corner[2] };
-        Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
-        Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
-        Kokkos::Array<Kokkos::Array<double, 3>, 1> notch_positions = { p01 };
-        CabanaPD::Prenotch<1> prenotch( v1, v2, notch_positions );
-
-        // ====================================================
-        //                    Force model
-        // ====================================================
-        using model_type =
-            CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Fracture>;
-        model_type force_model( delta, K, G0 );
-
-        // ====================================================
-        //                 Particle generation
-        // ====================================================
-        // Does not set displacements, velocities, etc.
-        auto particles = std::make_shared<
-            CabanaPD::Particles<memory_space, typename model_type::base_model>>(
-            exec_space(), low_corner, high_corner, num_cells, halo_width );
-
-        // ====================================================
-        //                Boundary conditions
-        // ====================================================
-        double sigma0 = inputs["traction"];
-        double dy = particles->dx[1];
-        double b0 = sigma0 / dy;
-
-        CabanaPD::RegionBoundary plane1( low_corner[0], high_corner[0],
-                                         low_corner[1] - dy, low_corner[1] + dy,
-                                         low_corner[2], high_corner[2] );
-        CabanaPD::RegionBoundary plane2(
-            low_corner[0], high_corner[0], high_corner[1] - dy,
-            high_corner[1] + dy, low_corner[2], high_corner[2] );
-        std::vector<CabanaPD::RegionBoundary> planes = { plane1, plane2 };
-        auto particles_f = particles->getForce();
-        auto particles_x = particles->getReferencePosition();
-        // Create a symmetric force BC in the y-direction.
-        auto bc_op = KOKKOS_LAMBDA( const int pid )
-        {
-            // Get a modifiable copy of force.
-            auto p_f = particles_f.getParticleView( pid );
-            // Get a copy of the position.
-            auto p_x = particles_x.getParticle( pid );
-            auto ypos =
-                Cabana::get( p_x, CabanaPD::Field::ReferencePosition(), 1 );
-            auto sign = std::abs( ypos ) / ypos;
-            Cabana::get( p_f, CabanaPD::Field::Force(), 1 ) += b0 * sign;
-        };
-        auto bc =
-            createBoundaryCondition( bc_op, exec_space{}, *particles, planes );
-
-        // ====================================================
-        //            Custom particle initialization
-        // ====================================================
-        auto rho = particles->sliceDensity();
-        auto x = particles->sliceReferencePosition();
-        auto v = particles->sliceVelocity();
-        auto f = particles->sliceForce();
-        auto nofail = particles->sliceNoFail();
-
-        auto init_functor = KOKKOS_LAMBDA( const int pid )
-        {
-            // Density
-            rho( pid ) = rho0;
-            // No-fail zone
-            if ( x( pid, 1 ) <= plane1.low_y + delta + 1e-10 ||
-                 x( pid, 1 ) >= plane2.high_y - delta - 1e-10 )
-                nofail( pid ) = 1;
-        };
-        particles->updateParticles( exec_space{}, init_functor );
-
-        // ====================================================
-        //                   Simulation run
-        // ====================================================
-        auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
-            inputs, particles, force_model, bc, prenotch );
-        cabana_pd->init_force();
-        cabana_pd->run();
-    }
-
+    Kokkos::finalize();
     MPI_Finalize();
 }

--- a/examples/elastic_wave.cpp
+++ b/examples/elastic_wave.cpp
@@ -18,147 +18,152 @@
 
 #include <CabanaPD.hpp>
 
+// Simulate elastic wave propagation from an initial displacement field.
+void elasticWaveExample( const std::string filename )
+{
+    // ====================================================
+    //                  Use default Kokkos spaces
+    // ====================================================
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using memory_space = typename exec_space::memory_space;
+
+    // ====================================================
+    //                   Read inputs
+    // ====================================================
+    CabanaPD::Inputs inputs( filename );
+
+    // ====================================================
+    //                Material parameters
+    // ====================================================
+    double rho0 = inputs["density"];
+    auto K = inputs["bulk_modulus"];
+    double G = inputs["shear_modulus"];
+    double delta = inputs["horizon"];
+    delta += 1e-10;
+
+    // ====================================================
+    //                  Discretization
+    // ====================================================
+    // FIXME: set halo width based on delta
+    std::array<double, 3> low_corner = inputs["low_corner"];
+    std::array<double, 3> high_corner = inputs["high_corner"];
+    std::array<int, 3> num_cells = inputs["num_cells"];
+    int m = std::floor( delta /
+                        ( ( high_corner[0] - low_corner[0] ) / num_cells[0] ) );
+    int halo_width = m + 1; // Just to be safe.
+
+    // ====================================================
+    //                    Force model
+    // ====================================================
+    // using model_type =
+    //    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic>;
+    // model_type force_model( delta, K );
+    using model_type =
+        CabanaPD::ForceModel<CabanaPD::LinearLPS, CabanaPD::Elastic>;
+    model_type force_model( delta, K, G );
+
+    // ====================================================
+    //                 Particle generation
+    // ====================================================
+    // Does not set displacements, velocities, etc.
+    auto particles = std::make_shared<
+        CabanaPD::Particles<memory_space, typename model_type::base_model>>(
+        exec_space(), low_corner, high_corner, num_cells, halo_width );
+
+    // ====================================================
+    //                Boundary conditions
+    // ====================================================
+    auto bc = CabanaPD::createBoundaryCondition<memory_space>(
+        CabanaPD::ZeroBCTag{} );
+
+    // ====================================================
+    //            Custom particle initialization
+    // ====================================================
+    auto rho = particles->sliceDensity();
+    auto x = particles->sliceReferencePosition();
+    auto u = particles->sliceDisplacement();
+    auto v = particles->sliceVelocity();
+
+    auto init_functor = KOKKOS_LAMBDA( const int pid )
+    {
+        // Initial conditions: displacements and velocities
+        double a = 0.001;
+        double r0 = 0.25;
+        double l = 0.07;
+        double norm =
+            std::sqrt( x( pid, 0 ) * x( pid, 0 ) + x( pid, 1 ) * x( pid, 1 ) +
+                       x( pid, 2 ) * x( pid, 2 ) );
+        double diff = norm - r0;
+        double arg = diff * diff / l / l;
+        for ( int d = 0; d < 3; d++ )
+        {
+            double comp = 0.0;
+            if ( norm > 0.0 )
+                comp = x( pid, d ) / norm;
+            u( pid, d ) = a * std::exp( -arg ) * comp;
+            v( pid, d ) = 0.0;
+        }
+        // Density
+        rho( pid ) = rho0;
+    };
+    particles->updateParticles( exec_space{}, init_functor );
+
+    // ====================================================
+    //                   Simulation run
+    // ====================================================
+    auto cabana_pd = CabanaPD::createSolverElastic<memory_space>(
+        inputs, particles, force_model, bc );
+    cabana_pd->init_force();
+    cabana_pd->run();
+
+    // ====================================================
+    //                      Outputs
+    // ====================================================
+    // Output displacement along the x-axis
+    x = particles->sliceReferencePosition();
+    u = particles->sliceDisplacement();
+    int num_cell_x = num_cells[0];
+    auto profile = Kokkos::View<double* [2], memory_space>(
+        Kokkos::ViewAllocateWithoutInitializing( "displacement_profile" ),
+        num_cell_x );
+    int mpi_rank;
+    MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
+    Kokkos::View<int*, memory_space> count( "c", 1 );
+    double dx = particles->dx[0];
+    auto measure_profile = KOKKOS_LAMBDA( const int pid )
+    {
+        if ( x( pid, 1 ) < dx / 2.0 && x( pid, 1 ) > -dx / 2.0 &&
+             x( pid, 2 ) < dx / 2.0 && x( pid, 2 ) > -dx / 2.0 )
+        {
+            auto c = Kokkos::atomic_fetch_add( &count( 0 ), 1 );
+            profile( c, 0 ) = x( pid, 0 );
+            profile( c, 1 ) = u( pid, 0 );
+        }
+    };
+    Kokkos::RangePolicy<exec_space> policy( 0, x.size() );
+    Kokkos::parallel_for( "displacement_profile", policy, measure_profile );
+    auto count_host =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace{}, count );
+    auto profile_host =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace{}, profile );
+    std::fstream fout;
+    std::string file_name = "displacement_profile.txt";
+    fout.open( file_name, std::ios::app );
+    for ( int p = 0; p < count_host( 0 ); p++ )
+    {
+        fout << mpi_rank << " " << profile_host( p, 0 ) << " "
+             << profile_host( p, 1 ) << std::endl;
+    }
+}
+
+// Initialize MPI+Kokkos.
 int main( int argc, char* argv[] )
 {
     MPI_Init( &argc, &argv );
+    Kokkos::initialize( argc, argv );
 
-    {
-        // ====================================================
-        //                  Setup Kokkos
-        // ====================================================
-        Kokkos::ScopeGuard scope_guard( argc, argv );
+    elasticWaveExample( argv[1] );
 
-        using exec_space = Kokkos::DefaultExecutionSpace;
-        using memory_space = typename exec_space::memory_space;
-
-        // ====================================================
-        //                   Read inputs
-        // ====================================================
-        CabanaPD::Inputs inputs( argv[1] );
-
-        // ====================================================
-        //                Material parameters
-        // ====================================================
-        double rho0 = inputs["density"];
-        auto K = inputs["bulk_modulus"];
-        double G = inputs["shear_modulus"];
-        double delta = inputs["horizon"];
-        delta += 1e-10;
-
-        // ====================================================
-        //                  Discretization
-        // ====================================================
-        // FIXME: set halo width based on delta
-        std::array<double, 3> low_corner = inputs["low_corner"];
-        std::array<double, 3> high_corner = inputs["high_corner"];
-        std::array<int, 3> num_cells = inputs["num_cells"];
-        int m = std::floor(
-            delta / ( ( high_corner[0] - low_corner[0] ) / num_cells[0] ) );
-        int halo_width = m + 1; // Just to be safe.
-
-        // ====================================================
-        //                    Force model
-        // ====================================================
-        // using model_type =
-        //    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic>;
-        // model_type force_model( delta, K );
-        using model_type =
-            CabanaPD::ForceModel<CabanaPD::LinearLPS, CabanaPD::Elastic>;
-        model_type force_model( delta, K, G );
-
-        // ====================================================
-        //                 Particle generation
-        // ====================================================
-        // Does not set displacements, velocities, etc.
-        auto particles = std::make_shared<
-            CabanaPD::Particles<memory_space, typename model_type::base_model>>(
-            exec_space(), low_corner, high_corner, num_cells, halo_width );
-
-        // ====================================================
-        //                Boundary conditions
-        // ====================================================
-        auto bc = CabanaPD::createBoundaryCondition<memory_space>(
-            CabanaPD::ZeroBCTag{} );
-
-        // ====================================================
-        //            Custom particle initialization
-        // ====================================================
-        auto rho = particles->sliceDensity();
-        auto x = particles->sliceReferencePosition();
-        auto u = particles->sliceDisplacement();
-        auto v = particles->sliceVelocity();
-
-        auto init_functor = KOKKOS_LAMBDA( const int pid )
-        {
-            // Initial conditions: displacements and velocities
-            double a = 0.001;
-            double r0 = 0.25;
-            double l = 0.07;
-            double norm = std::sqrt( x( pid, 0 ) * x( pid, 0 ) +
-                                     x( pid, 1 ) * x( pid, 1 ) +
-                                     x( pid, 2 ) * x( pid, 2 ) );
-            double diff = norm - r0;
-            double arg = diff * diff / l / l;
-            for ( int d = 0; d < 3; d++ )
-            {
-                double comp = 0.0;
-                if ( norm > 0.0 )
-                    comp = x( pid, d ) / norm;
-                u( pid, d ) = a * std::exp( -arg ) * comp;
-                v( pid, d ) = 0.0;
-            }
-            // Density
-            rho( pid ) = rho0;
-        };
-        particles->updateParticles( exec_space{}, init_functor );
-
-        // ====================================================
-        //                   Simulation run
-        // ====================================================
-        auto cabana_pd = CabanaPD::createSolverElastic<memory_space>(
-            inputs, particles, force_model, bc );
-        cabana_pd->init_force();
-        cabana_pd->run();
-
-        // ====================================================
-        //                      Outputs
-        // ====================================================
-        // Output displacement along the x-axis
-        x = particles->sliceReferencePosition();
-        u = particles->sliceDisplacement();
-        int num_cell_x = num_cells[0];
-        auto profile = Kokkos::View<double* [2], memory_space>(
-            Kokkos::ViewAllocateWithoutInitializing( "displacement_profile" ),
-            num_cell_x );
-        int mpi_rank;
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-        Kokkos::View<int*, memory_space> count( "c", 1 );
-        double dx = particles->dx[0];
-        auto measure_profile = KOKKOS_LAMBDA( const int pid )
-        {
-            if ( x( pid, 1 ) < dx / 2.0 && x( pid, 1 ) > -dx / 2.0 &&
-                 x( pid, 2 ) < dx / 2.0 && x( pid, 2 ) > -dx / 2.0 )
-            {
-                auto c = Kokkos::atomic_fetch_add( &count( 0 ), 1 );
-                profile( c, 0 ) = x( pid, 0 );
-                profile( c, 1 ) = u( pid, 0 );
-            }
-        };
-        Kokkos::RangePolicy<exec_space> policy( 0, x.size() );
-        Kokkos::parallel_for( "displacement_profile", policy, measure_profile );
-        auto count_host =
-            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace{}, count );
-        auto profile_host =
-            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace{}, profile );
-        std::fstream fout;
-        std::string file_name = "displacement_profile.txt";
-        fout.open( file_name, std::ios::app );
-        for ( int p = 0; p < count_host( 0 ); p++ )
-        {
-            fout << mpi_rank << " " << profile_host( p, 0 ) << " "
-                 << profile_host( p, 1 ) << std::endl;
-        }
-    }
-
+    Kokkos::finalize();
     MPI_Finalize();
 }

--- a/examples/kalthoff_winkler.cpp
+++ b/examples/kalthoff_winkler.cpp
@@ -18,126 +18,129 @@
 
 #include <CabanaPD.hpp>
 
+// Simulate the Kalthoff-Winkler experiment conditions for crack propagation in
+// a steel plate from an impactor.
+void kalthoffWinklerExample( const std::string filename )
+{
+    // ====================================================
+    //                  Use default Kokkos spaces
+    // ====================================================
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using memory_space = typename exec_space::memory_space;
+
+    // ====================================================
+    //                   Read inputs
+    // ====================================================
+    CabanaPD::Inputs inputs( filename );
+
+    // ====================================================
+    //                Material parameters
+    // ====================================================
+    double rho0 = inputs["density"];
+    double E = inputs["elastic_modulus"];
+    double nu = 1.0 / 3.0;
+    double K = E / ( 3.0 * ( 1.0 - 2.0 * nu ) );
+    double G0 = inputs["fracture_energy"];
+    // double G = E / ( 2.0 * ( 1.0 + nu ) ); // Only for LPS.
+    double delta = inputs["horizon"];
+    delta += 1e-10;
+
+    // ====================================================
+    //                  Discretization
+    // ====================================================
+    // FIXME: set halo width based on delta
+    std::array<double, 3> low_corner = inputs["low_corner"];
+    std::array<double, 3> high_corner = inputs["high_corner"];
+    std::array<int, 3> num_cells = inputs["num_cells"];
+    int m = std::floor( delta /
+                        ( ( high_corner[0] - low_corner[0] ) / num_cells[0] ) );
+    int halo_width = m + 1; // Just to be safe.
+
+    // ====================================================
+    //                   Pre-notches
+    // ====================================================
+    std::array<double, 3> system_size = inputs["system_size"];
+    double height = system_size[0];
+    double width = system_size[1];
+    double thickness = system_size[2];
+    double L_prenotch = height / 2.0;
+    double y_prenotch1 = -width / 8.0;
+    double y_prenotch2 = width / 8.0;
+    double low_x = low_corner[0];
+    double low_z = low_corner[2];
+    Kokkos::Array<double, 3> p01 = { low_x, y_prenotch1, low_z };
+    Kokkos::Array<double, 3> p02 = { low_x, y_prenotch2, low_z };
+    Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
+    Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
+    Kokkos::Array<Kokkos::Array<double, 3>, 2> notch_positions = { p01, p02 };
+    CabanaPD::Prenotch<2> prenotch( v1, v2, notch_positions );
+
+    // ====================================================
+    //                    Force model
+    // ====================================================
+    using model_type = CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Fracture>;
+    model_type force_model( delta, K, G0 );
+    // using model_type =
+    //     CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Fracture>;
+    // model_type force_model( delta, K, G, G0 );
+
+    // ====================================================
+    //                 Particle generation
+    // ====================================================
+    // Does not set displacements, velocities, etc.
+    auto particles = std::make_shared<
+        CabanaPD::Particles<memory_space, typename model_type::base_model>>(
+        exec_space(), low_corner, high_corner, num_cells, halo_width );
+
+    // ====================================================
+    //                Boundary conditions
+    // ====================================================
+    double dx = particles->dx[0];
+    double x_bc = -0.5 * height;
+    CabanaPD::RegionBoundary plane(
+        x_bc - dx, x_bc + dx * 1.25, y_prenotch1 - dx * 0.25,
+        y_prenotch2 + dx * 0.25, -thickness, thickness );
+    std::vector<CabanaPD::RegionBoundary> planes = { plane };
+    auto bc = createBoundaryCondition( CabanaPD::ForceValueBCTag{}, 0.0,
+                                       exec_space{}, *particles, planes );
+
+    // ====================================================
+    //            Custom particle initialization
+    // ====================================================
+    auto rho = particles->sliceDensity();
+    auto x = particles->sliceReferencePosition();
+    auto v = particles->sliceVelocity();
+    auto f = particles->sliceForce();
+
+    double v0 = inputs["impactor_velocity"];
+    auto init_functor = KOKKOS_LAMBDA( const int pid )
+    {
+        // Density
+        rho( pid ) = rho0;
+        // x velocity between the pre-notches
+        if ( x( pid, 1 ) > y_prenotch1 && x( pid, 1 ) < y_prenotch2 &&
+             x( pid, 0 ) < -0.5 * height + dx )
+            v( pid, 0 ) = v0;
+    };
+    particles->updateParticles( exec_space{}, init_functor );
+
+    // ====================================================
+    //                   Simulation run
+    // ====================================================
+    auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
+        inputs, particles, force_model, bc, prenotch );
+    cabana_pd->init_force();
+    cabana_pd->run();
+}
+
+// Initialize MPI+Kokkos.
 int main( int argc, char* argv[] )
 {
     MPI_Init( &argc, &argv );
+    Kokkos::initialize( argc, argv );
 
-    {
-        // ====================================================
-        //                  Setup Kokkos
-        // ====================================================
-        Kokkos::ScopeGuard scope_guard( argc, argv );
+    kalthoffWinklerExample( argv[1] );
 
-        using exec_space = Kokkos::DefaultExecutionSpace;
-        using memory_space = typename exec_space::memory_space;
-
-        // ====================================================
-        //                   Read inputs
-        // ====================================================
-        CabanaPD::Inputs inputs( argv[1] );
-
-        // ====================================================
-        //                Material parameters
-        // ====================================================
-        double rho0 = inputs["density"];
-        double E = inputs["elastic_modulus"];
-        double nu = 1.0 / 3.0;
-        double K = E / ( 3.0 * ( 1.0 - 2.0 * nu ) );
-        double G0 = inputs["fracture_energy"];
-        // double G = E / ( 2.0 * ( 1.0 + nu ) ); // Only for LPS.
-        double delta = inputs["horizon"];
-        delta += 1e-10;
-
-        // ====================================================
-        //                  Discretization
-        // ====================================================
-        // FIXME: set halo width based on delta
-        std::array<double, 3> low_corner = inputs["low_corner"];
-        std::array<double, 3> high_corner = inputs["high_corner"];
-        std::array<int, 3> num_cells = inputs["num_cells"];
-        int m = std::floor(
-            delta / ( ( high_corner[0] - low_corner[0] ) / num_cells[0] ) );
-        int halo_width = m + 1; // Just to be safe.
-
-        // ====================================================
-        //                   Pre-notches
-        // ====================================================
-        std::array<double, 3> system_size = inputs["system_size"];
-        double height = system_size[0];
-        double width = system_size[1];
-        double thickness = system_size[2];
-        double L_prenotch = height / 2.0;
-        double y_prenotch1 = -width / 8.0;
-        double y_prenotch2 = width / 8.0;
-        double low_x = low_corner[0];
-        double low_z = low_corner[2];
-        Kokkos::Array<double, 3> p01 = { low_x, y_prenotch1, low_z };
-        Kokkos::Array<double, 3> p02 = { low_x, y_prenotch2, low_z };
-        Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
-        Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
-        Kokkos::Array<Kokkos::Array<double, 3>, 2> notch_positions = { p01,
-                                                                       p02 };
-        CabanaPD::Prenotch<2> prenotch( v1, v2, notch_positions );
-
-        // ====================================================
-        //                    Force model
-        // ====================================================
-        using model_type =
-            CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Fracture>;
-        model_type force_model( delta, K, G0 );
-        // using model_type =
-        //     CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Fracture>;
-        // model_type force_model( delta, K, G, G0 );
-
-        // ====================================================
-        //                 Particle generation
-        // ====================================================
-        // Does not set displacements, velocities, etc.
-        auto particles = std::make_shared<
-            CabanaPD::Particles<memory_space, typename model_type::base_model>>(
-            exec_space(), low_corner, high_corner, num_cells, halo_width );
-
-        // ====================================================
-        //                Boundary conditions
-        // ====================================================
-        double dx = particles->dx[0];
-        double x_bc = -0.5 * height;
-        CabanaPD::RegionBoundary plane(
-            x_bc - dx, x_bc + dx * 1.25, y_prenotch1 - dx * 0.25,
-            y_prenotch2 + dx * 0.25, -thickness, thickness );
-        std::vector<CabanaPD::RegionBoundary> planes = { plane };
-        auto bc = createBoundaryCondition( CabanaPD::ForceValueBCTag{}, 0.0,
-                                           exec_space{}, *particles, planes );
-
-        // ====================================================
-        //            Custom particle initialization
-        // ====================================================
-        auto rho = particles->sliceDensity();
-        auto x = particles->sliceReferencePosition();
-        auto v = particles->sliceVelocity();
-        auto f = particles->sliceForce();
-
-        double v0 = inputs["impactor_velocity"];
-
-        auto init_functor = KOKKOS_LAMBDA( const int pid )
-        {
-            // Density
-            rho( pid ) = rho0;
-            // x velocity between the pre-notches
-            if ( x( pid, 1 ) > y_prenotch1 && x( pid, 1 ) < y_prenotch2 &&
-                 x( pid, 0 ) < -0.5 * height + dx )
-                v( pid, 0 ) = v0;
-        };
-        particles->updateParticles( exec_space{}, init_functor );
-
-        // ====================================================
-        //                   Simulation run
-        // ====================================================
-        auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
-            inputs, particles, force_model, bc, prenotch );
-        cabana_pd->init_force();
-        cabana_pd->run();
-    }
-
+    Kokkos::finalize();
     MPI_Finalize();
 }


### PR DESCRIPTION
Easier to read and create new examples (NOTE: view without space changes)