### PR TITLE
Added solver heading and separate it from run heading for consistency

### DIFF
--- a/examples/mechanics/crack_branching.cpp
+++ b/examples/mechanics/crack_branching.cpp
@@ -134,10 +134,14 @@ void crackBranchingExample( const std::string filename )
     particles->updateParticles( exec_space{}, init_functor );
 
     // ====================================================
-    //                   Simulation run
+    //                   Create solver
     // ====================================================
     auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
         inputs, particles, force_model, prenotch );
+
+    // ====================================================
+    //                   Simulation run
+    // ====================================================
     cabana_pd->init();
     cabana_pd->run( bc );
 }

--- a/examples/mechanics/elastic_wave.cpp
+++ b/examples/mechanics/elastic_wave.cpp
@@ -102,10 +102,14 @@ void elasticWaveExample( const std::string filename )
     particles->updateParticles( exec_space{}, init_functor );
 
     // ====================================================
-    //                   Simulation run
+    //                   Create solver
     // ====================================================
     auto cabana_pd = CabanaPD::createSolverElastic<memory_space>(
         inputs, particles, force_model );
+
+    // ====================================================
+    //                   Simulation run
+    // ====================================================
     cabana_pd->init();
     cabana_pd->run();
 

--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -126,10 +126,14 @@ void kalthoffWinklerExample( const std::string filename )
     particles->updateParticles( exec_space{}, init_functor );
 
     // ====================================================
-    //                   Simulation run
+    //                   Create solver
     // ====================================================
     auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
         inputs, particles, force_model, prenotch );
+
+    // ====================================================
+    //                   Simulation run
+    // ====================================================
     cabana_pd->init();
     cabana_pd->run( bc );
 }


### PR DESCRIPTION
Separate headings in mechanics example to be consistent with thermal_deformation example