### PR TITLE
Custom particle creation for LPS and thermal systems 

### DIFF
--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -565,8 +565,8 @@ class Particles<MemorySpace, LPS, TemperatureIndependent, Dimension>
         // Forward arguments to standard or custom particle creation.
         base_type::createParticles( std::forward<Args>( args )... );
         _init_timer.start();
-        _aosoa_m.resize( 0 );
-        _aosoa_theta.resize( 0 );
+        _aosoa_m.resize( n_local );
+        _aosoa_theta.resize( n_local );
         _init_timer.stop();
     }
 
@@ -717,7 +717,7 @@ class Particles<MemorySpace, PMB, TemperatureDependent, Dimension>
     {
         // Forward arguments to standard or custom particle creation.
         base_type::createParticles( std::forward<Args>( args )... );
-        _aosoa_temp.resize( 0 );
+        _aosoa_temp.resize( n_local );
     }
 
     auto sliceTemperature()

--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -559,10 +559,11 @@ class Particles<MemorySpace, LPS, TemperatureIndependent, Dimension>
         _init_timer.stop();
     }
 
-    template <class ExecSpace>
-    void createParticles( const ExecSpace& exec_space )
+    template <typename... Args>
+    void createParticles( Args&&... args )
     {
-        base_type::createParticles( exec_space );
+        // Forward arguments to standard or custom particle creation.
+        base_type::createParticles( std::forward<Args>( args )... );
         _init_timer.start();
         _aosoa_m.resize( 0 );
         _aosoa_theta.resize( 0 );
@@ -711,10 +712,11 @@ class Particles<MemorySpace, PMB, TemperatureDependent, Dimension>
         init_temp();
     }
 
-    template <class ExecSpace>
-    void createParticles( const ExecSpace& exec_space )
+    template <typename... Args>
+    void createParticles( Args&&... args )
     {
-        base_type::createParticles( exec_space );
+        // Forward arguments to standard or custom particle creation.
+        base_type::createParticles( std::forward<Args>( args )... );
         _aosoa_temp.resize( 0 );
     }
 


### PR DESCRIPTION
Previous version only allowed standard (dense) particle creation with LPS/temperature. Expanded to enable custom creation

Closes #115 