### PR TITLE
Add particle class creation functions

### DIFF
--- a/examples/mechanics/crack_branching.cpp
+++ b/examples/mechanics/crack_branching.cpp
@@ -49,10 +49,6 @@ void crackBranchingExample( const std::string filename )
     // FIXME: set halo width based on delta
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
-    std::array<int, 3> num_cells = inputs["num_cells"];
-    int m = std::floor( delta /
-                        ( ( high_corner[0] - low_corner[0] ) / num_cells[0] ) );
-    int halo_width = m + 1; // Just to be safe.
 
     // ====================================================
     //                    Pre-notch
@@ -77,11 +73,9 @@ void crackBranchingExample( const std::string filename )
     // ====================================================
     //                 Particle generation
     // ====================================================
-    // Does not set displacements, velocities, etc.
-    auto particles = std::make_shared<
-        CabanaPD::Particles<memory_space, typename model_type::base_model,
-                            typename model_type::thermal_type>>(
-        exec_space(), low_corner, high_corner, num_cells, halo_width );
+    // Note that individual inputs can be passed instead (see other examples).
+    auto particles = CabanaPD::createParticles<memory_space, model_type>(
+        exec_space{}, inputs );
 
     // ====================================================
     //                Boundary conditions

--- a/examples/mechanics/elastic_wave.cpp
+++ b/examples/mechanics/elastic_wave.cpp
@@ -44,7 +44,6 @@ void elasticWaveExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    // FIXME: set halo width based on delta
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
     std::array<int, 3> num_cells = inputs["num_cells"];
@@ -62,10 +61,7 @@ void elasticWaveExample( const std::string filename )
     // ====================================================
     //                 Particle generation
     // ====================================================
-    // Does not set displacements, velocities, etc.
-    auto particles = std::make_shared<
-        CabanaPD::Particles<memory_space, typename model_type::base_model,
-                            typename model_type::thermal_type>>(
+    auto particles = CabanaPD::createParticles<memory_space, model_type>(
         exec_space(), low_corner, high_corner, num_cells, halo_width );
 
     // ====================================================

--- a/examples/mechanics/fragmenting_cylinder.cpp
+++ b/examples/mechanics/fragmenting_cylinder.cpp
@@ -69,10 +69,7 @@ void fragmentingCylinderExample( const std::string filename )
     // ====================================================
     //                 Particle generation
     // ====================================================
-    // Does not set displacements, velocities, etc.
-    auto particles = std::make_shared<
-        CabanaPD::Particles<memory_space, typename model_type::base_model,
-                            typename model_type::thermal_type>>(
+    auto particles = CabanaPD::createParticles<memory_space, model_type>(
         exec_space(), low_corner, high_corner, num_cells, halo_width );
 
     // ====================================================
@@ -142,12 +139,8 @@ void fragmentingCylinderExample( const std::string filename )
     // ====================================================
     //                   Simulation run
     // ====================================================
-
-    // Define empty pre-notch
-    CabanaPD::Prenotch<0> prenotch;
-
     auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
-        inputs, particles, force_model, prenotch );
+        inputs, particles, force_model );
     cabana_pd->init();
     cabana_pd->run();
 }

--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -88,9 +88,7 @@ void kalthoffWinklerExample( const std::string filename )
     //                 Particle generation
     // ====================================================
     // Does not set displacements, velocities, etc.
-    auto particles = std::make_shared<
-        CabanaPD::Particles<memory_space, typename model_type::base_model,
-                            typename model_type::thermal_type>>(
+    auto particles = CabanaPD::createParticles<memory_space, model_type>(
         exec_space(), low_corner, high_corner, num_cells, halo_width );
 
     // ====================================================

--- a/examples/thermomechanics/thermal_crack.cpp
+++ b/examples/thermomechanics/thermal_crack.cpp
@@ -71,9 +71,9 @@ void thermalCrackExample( const std::string filename )
     //                 Particle generation
     // ====================================================
     // Does not set displacements, velocities, etc.
-    auto particles = std::make_shared<
-        CabanaPD::Particles<memory_space, model_type, thermal_type>>(
-        exec_space(), low_corner, high_corner, num_cells, halo_width );
+    auto particles =
+        CabanaPD::createParticles<memory_space, model_type, thermal_type>(
+            exec_space(), low_corner, high_corner, num_cells, halo_width );
 
     // ====================================================
     //            Custom particle initialization

--- a/examples/thermomechanics/thermal_deformation.cpp
+++ b/examples/thermomechanics/thermal_deformation.cpp
@@ -67,9 +67,9 @@ void thermalDeformationExample( const std::string filename )
     //                 Particle generation
     // ====================================================
     // Does not set displacements, velocities, etc.
-    auto particles = std::make_shared<
-        CabanaPD::Particles<memory_space, model_type, thermal_type>>(
-        exec_space(), low_corner, high_corner, num_cells, halo_width );
+    auto particles =
+        CabanaPD::createParticles<memory_space, model_type, thermal_type>(
+            exec_space(), low_corner, high_corner, num_cells, halo_width );
 
     // ====================================================
     //            Custom particle initialization


### PR DESCRIPTION
Includes option for passing input class directly (example in crack branching)

Unrelated change: unneeded empty prenotch in fragmentation problem 

