### PR TITLE
Changed b.c. region in KW example for consistency with the particle grid

### DIFF
--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -99,8 +99,8 @@ void kalthoffWinklerExample( const std::string filename )
     double dx = particles->dx[0];
     double x_bc = -0.5 * height;
     CabanaPD::RegionBoundary<CabanaPD::RectangularPrism> plane(
-        x_bc - dx, x_bc + dx * 1.25, y_prenotch1 - dx * 0.25,
-        y_prenotch2 + dx * 0.25, -thickness, thickness );
+        x_bc - dx, x_bc + dx, y_prenotch1 - 0.25 * dx, y_prenotch2 + 0.25 * dx,
+        -thickness, thickness );
     auto bc = createBoundaryCondition( CabanaPD::ForceValueBCTag{}, 0.0,
                                        exec_space{}, *particles, plane );
 


### PR DESCRIPTION
Modified the boundary region ("plane") for clarity. It is assumed we use a cell-centered grid of particles, so that the leftmost particles are located in the x-direction at x_bc + 0.5*dx. We can consider extending the plane definition, if needed.