### PR TITLE
Enable custom init in particle construction

### DIFF
--- a/examples/mechanics/fragmenting_cylinder.cpp
+++ b/examples/mechanics/fragmenting_cylinder.cpp
@@ -67,13 +67,7 @@ void fragmentingCylinderExample( const std::string filename )
     // model_type force_model( delta, K, G, G0 );
 
     // ====================================================
-    //                 Particle generation
-    // ====================================================
-    auto particles = CabanaPD::createParticles<memory_space, model_type>(
-        exec_space(), low_corner, high_corner, num_cells, halo_width );
-
-    // ====================================================
-    //            Custom particle initialization
+    //    Custom particle generation and initialization
     // ====================================================
     double x_center = 0.5 * ( low_corner[0] + high_corner[0] );
     double y_center = 0.5 * ( low_corner[1] + high_corner[1] );
@@ -90,7 +84,9 @@ void fragmentingCylinderExample( const std::string filename )
             return false;
         return true;
     };
-    particles->createParticles( exec_space(), init_op );
+
+    auto particles = CabanaPD::createParticles<memory_space, model_type>(
+        exec_space(), low_corner, high_corner, num_cells, halo_width, init_op );
 
     auto rho = particles->sliceDensity();
     auto x = particles->sliceReferencePosition();

--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -955,8 +955,9 @@ class Particles<MemorySpace, ModelType, ThermalType, EnergyOutput, Dimension>
 
 template <typename MemorySpace, typename ModelType, typename ExecSpace,
           typename OutputType>
-auto createParticles( ExecSpace exec_space, CabanaPD::Inputs inputs,
-                      OutputType )
+auto createParticles(
+    ExecSpace exec_space, CabanaPD::Inputs inputs, OutputType,
+    typename std::enable_if<( is_output<OutputType>::value ), int>::type* = 0 )
 {
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
@@ -974,11 +975,11 @@ auto createParticles( ExecSpace exec_space, CabanaPD::Inputs inputs,
 
 template <typename MemorySpace, typename ModelType, typename ExecSpace,
           std::size_t Dim, typename OutputType>
-auto createParticles( const ExecSpace& exec_space,
-                      std::array<double, Dim> low_corner,
-                      std::array<double, Dim> high_corner,
-                      const std::array<int, Dim> num_cells,
-                      const int max_halo_width, OutputType )
+auto createParticles(
+    const ExecSpace& exec_space, std::array<double, Dim> low_corner,
+    std::array<double, Dim> high_corner, const std::array<int, Dim> num_cells,
+    const int max_halo_width, OutputType,
+    typename std::enable_if<( is_output<OutputType>::value ), int>::type* = 0 )
 {
     return std::make_shared<
         CabanaPD::Particles<MemorySpace, typename ModelType::base_model,
@@ -992,7 +993,8 @@ auto createParticles(
     const ExecSpace& exec_space, std::array<double, Dim> low_corner,
     std::array<double, Dim> high_corner, const std::array<int, Dim> num_cells,
     const int max_halo_width, OutputType,
-    typename std::enable_if<( is_temperature_dependent<ThermalType>::value ),
+    typename std::enable_if<( is_temperature_dependent<ThermalType>::value &&
+                              is_output<OutputType>::value ),
                             int>::type* = 0 )
 {
     return std::make_shared<CabanaPD::Particles<
@@ -1021,6 +1023,33 @@ auto createParticles( const ExecSpace& exec_space,
         EnergyOutput{} );
 }
 
+template <typename MemorySpace, typename ModelType, typename ExecSpace,
+          class UserFunctor, std::size_t Dim, typename OutputType>
+auto createParticles(
+    const ExecSpace& exec_space, std::array<double, Dim> low_corner,
+    std::array<double, Dim> high_corner, const std::array<int, Dim> num_cells,
+    const int max_halo_width, UserFunctor user, OutputType,
+    typename std::enable_if<( is_output<OutputType>::value ), int>::type* = 0 )
+{
+    return std::make_shared<
+        CabanaPD::Particles<MemorySpace, typename ModelType::base_model,
+                            typename ModelType::thermal_type, OutputType>>(
+        exec_space, low_corner, high_corner, num_cells, max_halo_width, user );
+}
+
+template <typename MemorySpace, typename ModelType, typename ExecSpace,
+          class UserFunctor, std::size_t Dim>
+auto createParticles( const ExecSpace& exec_space,
+                      std::array<double, Dim> low_corner,
+                      std::array<double, Dim> high_corner,
+                      const std::array<int, Dim> num_cells,
+                      const int max_halo_width, UserFunctor user )
+{
+    return createParticles<MemorySpace, ModelType, ExecSpace, UserFunctor, Dim>(
+        exec_space, low_corner, high_corner, num_cells, max_halo_width, user,
+        EnergyOutput{} );
+}
+
 template <typename MemorySpace, typename ModelType, typename ThermalType,
           typename ExecSpace, std::size_t Dim>
 auto createParticles(
@@ -1038,11 +1067,11 @@ auto createParticles(
 template <typename MemorySpace, typename ModelType, typename ExecSpace,
           typename PositionType, typename VolumeType, std::size_t Dim,
           typename OutputType>
-auto createParticles( const ExecSpace& exec_space, const PositionType& x,
-                      const VolumeType& vol, std::array<double, Dim> low_corner,
-                      std::array<double, Dim> high_corner,
-                      const std::array<int, Dim> num_cells,
-                      const int max_halo_width, OutputType )
+auto createParticles(
+    const ExecSpace& exec_space, const PositionType& x, const VolumeType& vol,
+    std::array<double, Dim> low_corner, std::array<double, Dim> high_corner,
+    const std::array<int, Dim> num_cells, const int max_halo_width, OutputType,
+    typename std::enable_if<( is_output<OutputType>::value ), int>::type* = 0 )
 {
     return std::make_shared<
         CabanaPD::Particles<MemorySpace, typename ModelType::base_model,
@@ -1058,7 +1087,8 @@ auto createParticles(
     const ExecSpace& exec_space, const PositionType& x, const VolumeType& vol,
     std::array<double, Dim> low_corner, std::array<double, Dim> high_corner,
     const std::array<int, Dim> num_cells, const int max_halo_width, OutputType,
-    typename std::enable_if<( is_temperature_dependent<ThermalType>::value ),
+    typename std::enable_if<( is_temperature_dependent<ThermalType>::value &&
+                              is_output<OutputType>::value ),
                             int>::type* = 0 )
 {
     return std::make_shared<CabanaPD::Particles<

--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -296,9 +296,10 @@ class Particles<MemorySpace, PMB, TemperatureIndependent, BaseOutput, Dimension>
                            typename plist_x_type::particle_type& particle )
         {
             // Customize new particle.
+            // NOTE: we fill information for all particles because only the
+            // positions are correctly selectively created. This will only work
+            // when setting all values uniformly, as is currently the case!
             bool create = user_create( pid, px );
-            if ( !create )
-                return create;
 
             // Set the particle position.
             for ( int d = 0; d < 3; d++ )

--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -90,6 +90,19 @@ struct EnergyOutput
 };
 
 template <class>
+struct is_output : public std::false_type
+{
+};
+template <>
+struct is_output<BaseOutput> : public std::true_type
+{
+};
+template <>
+struct is_output<EnergyOutput> : public std::true_type
+{
+};
+
+template <class>
 struct is_energy_output : public std::false_type
 {
 };


### PR DESCRIPTION
Simplify the fragmenting cylinder example in the process. Note that this only works with the uniform values across all particles currently assumed (volume is the most obvious example) since only the positions are selectively assigned. This just means that even particles not created should be initialized. For further custom creation a split loop will be necessary. 