### PR TITLE
Enable createParticles for thermal examples

### DIFF
--- a/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
@@ -70,8 +70,7 @@ void thermalDeformationHeatTransferExample( const std::string filename )
     // ====================================================
     // Does not set displacements, velocities, etc.
     auto particles =
-        std::make_shared<CabanaPD::Particles<memory_space, model_type,
-                                             typename thermal_type::base_type>>(
+        CabanaPD::createParticles<memory_space, model_type, thermal_type>(
             exec_space(), low_corner, high_corner, num_cells, halo_width );
 
     // ====================================================

--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -833,18 +833,15 @@ auto createParticles( const ExecSpace& exec_space,
 
 template <typename MemorySpace, typename ModelType, typename ThermalType,
           typename ExecSpace, std::size_t Dim>
-auto createParticles( const ExecSpace& exec_space,
-                      std::array<double, Dim> low_corner,
-                      std::array<double, Dim> high_corner,
-                      const std::array<int, Dim> num_cells,
-                      const int max_halo_width,
-                      typename std::enable_if<
-                          (std::is_same_v<ThermalType, TemperatureDependent> ||
-                           std::is_same_v<ThermalType, TemperatureIndependent>),
-                          int>::type* = 0 )
+auto createParticles(
+    const ExecSpace& exec_space, std::array<double, Dim> low_corner,
+    std::array<double, Dim> high_corner, const std::array<int, Dim> num_cells,
+    const int max_halo_width,
+    typename std::enable_if<( is_temperature_dependent<ThermalType>::value ),
+                            int>::type* = 0 )
 {
-    return std::make_shared<
-        CabanaPD::Particles<MemorySpace, ModelType, ThermalType>>(
+    return std::make_shared<CabanaPD::Particles<
+        MemorySpace, ModelType, typename ThermalType::base_type>>(
         exec_space, low_corner, high_corner, num_cells, max_halo_width );
 }
 

--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -25,9 +25,11 @@ struct Fracture
 // Thermal types.
 struct TemperatureIndependent
 {
+    using base_type = TemperatureIndependent;
 };
 struct TemperatureDependent
 {
+    using base_type = TemperatureDependent;
 };
 struct DynamicTemperature : public TemperatureDependent
 {


### PR DESCRIPTION
Follow on to #108 for `createParticles` with heat transfer 