### PR TITLE
Make energy optional

### DIFF
--- a/src/CabanaPD_Force.hpp
+++ b/src/CabanaPD_Force.hpp
@@ -252,25 +252,27 @@ template <class ForceType, class ParticleType, class ParallelType>
 double computeEnergy( ForceType& force, ParticleType& particles,
                       const ParallelType& neigh_op_tag )
 {
-    auto n_local = particles.n_local;
-    auto x = particles.sliceReferencePosition();
-    auto u = particles.sliceDisplacement();
-    auto f = particles.sliceForce();
-    auto W = particles.sliceStrainEnergy();
-    auto vol = particles.sliceVolume();
+    double energy = 0.0;
+    if constexpr ( is_energy_output<typename ParticleType::output_type>::value )
+    {
+        auto n_local = particles.n_local;
+        auto x = particles.sliceReferencePosition();
+        auto u = particles.sliceDisplacement();
+        auto f = particles.sliceForce();
+        auto W = particles.sliceStrainEnergy();
+        auto vol = particles.sliceVolume();
 
-    // Reset energy.
-    Cabana::deep_copy( W, 0.0 );
+        // Reset energy.
+        Cabana::deep_copy( W, 0.0 );
 
-    double energy;
-    // if ( _half_neigh )
-    //    energy = computeEnergy_half( force, x, u,
-    //                                  n_local, neigh_op_tag );
-    // else
-    energy =
-        force.computeEnergyFull( W, x, u, particles, n_local, neigh_op_tag );
-    Kokkos::fence();
-
+        // if ( _half_neigh )
+        //    energy = computeEnergy_half( force, x, u,
+        //                                  n_local, neigh_op_tag );
+        // else
+        energy = force.computeEnergyFull( W, x, u, particles, n_local,
+                                          neigh_op_tag );
+        Kokkos::fence();
+    }
     return energy;
 }
 
@@ -303,31 +305,32 @@ void computeForce( ForceType& force, ParticleType& particles, NeighborView& mu,
     Kokkos::fence();
 }
 
-// Energy and damage.
 template <class ForceType, class ParticleType, class NeighborView,
           class ParallelType>
 double computeEnergy( ForceType& force, ParticleType& particles,
                       NeighborView& mu, const ParallelType& neigh_op_tag )
 {
-    auto n_local = particles.n_local;
-    auto x = particles.sliceReferencePosition();
-    auto u = particles.sliceDisplacement();
-    auto f = particles.sliceForce();
-    auto W = particles.sliceStrainEnergy();
-    auto phi = particles.sliceDamage();
+    double energy = 0.0;
+    if constexpr ( is_energy_output<typename ParticleType::output_type>::value )
+    {
+        auto n_local = particles.n_local;
+        auto x = particles.sliceReferencePosition();
+        auto u = particles.sliceDisplacement();
+        auto f = particles.sliceForce();
+        auto W = particles.sliceStrainEnergy();
+        auto phi = particles.sliceDamage();
 
-    // Reset energy.
-    Cabana::deep_copy( W, 0.0 );
+        // Reset energy.
+        Cabana::deep_copy( W, 0.0 );
 
-    double energy;
-    // if ( _half_neigh )
-    //    energy = computeEnergy_half( force, x, u,
-    //                                  n_local, neigh_op_tag );
-    // else
-    energy = force.computeEnergyFull( W, x, u, phi, particles, mu, n_local,
-                                      neigh_op_tag );
-    Kokkos::fence();
-
+        // if ( _half_neigh )
+        //    energy = computeEnergy_half( force, x, u,
+        //                                  n_local, neigh_op_tag );
+        // else
+        energy = force.computeEnergyFull( W, x, u, phi, particles, mu, n_local,
+                                          neigh_op_tag );
+        Kokkos::fence();
+    }
     return energy;
 }
 

--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -72,5 +72,21 @@ struct LinearLPS
 {
 };
 
+struct BaseOutput
+{
+};
+struct EnergyOutput
+{
+};
+
+template <class>
+struct is_energy_output : public std::false_type
+{
+};
+template <>
+struct is_energy_output<EnergyOutput> : public std::true_type
+{
+};
+
 } // namespace CabanaPD
 #endif

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -379,7 +379,7 @@ computeReferenceForceX( QuadraticTag,
 //---------------------------------------------------------------------------//
 template <class ModelType>
 CabanaPD::Particles<TEST_MEMSPACE, typename ModelType::base_model,
-                    typename ModelType::thermal_type>
+                    typename ModelType::thermal_type, CabanaPD::EnergyOutput>
 createParticles( ModelType, LinearTag, const double dx, const double s0 )
 {
     std::array<double, 3> box_min = { -1.0, -1.0, -1.0 };
@@ -390,7 +390,8 @@ createParticles( ModelType, LinearTag, const double dx, const double s0 )
     // Create particles based on the mesh.
     using ptype =
         CabanaPD::Particles<TEST_MEMSPACE, typename ModelType::base_model,
-                            typename ModelType::thermal_type>;
+                            typename ModelType::thermal_type,
+                            CabanaPD::EnergyOutput>;
     ptype particles( TEST_EXECSPACE{}, box_min, box_max, num_cells, 0 );
 
     auto x = particles.sliceReferencePosition();
@@ -410,7 +411,7 @@ createParticles( ModelType, LinearTag, const double dx, const double s0 )
 
 template <class ModelType>
 CabanaPD::Particles<TEST_MEMSPACE, typename ModelType::base_model,
-                    typename ModelType::thermal_type>
+                    typename ModelType::thermal_type, CabanaPD::EnergyOutput>
 createParticles( ModelType, QuadraticTag, const double dx, const double s0 )
 {
     std::array<double, 3> box_min = { -1.0, -1.0, -1.0 };
@@ -421,7 +422,8 @@ createParticles( ModelType, QuadraticTag, const double dx, const double s0 )
     // Create particles based on the mesh.
     using ptype =
         CabanaPD::Particles<TEST_MEMSPACE, typename ModelType::base_model,
-                            typename ModelType::thermal_type>;
+                            typename ModelType::thermal_type,
+                            CabanaPD::EnergyOutput>;
     ptype particles( TEST_EXECSPACE{}, box_min, box_max, num_cells, 0 );
     auto x = particles.sliceReferencePosition();
     auto u = particles.sliceDisplacement();


### PR DESCRIPTION
- Separates output fields from those for primary updates
- Makes energy output fully optional (on by default)
- Also includes damage calculation (fused kernel with energy)
- Greatly simplifies calls to Cabana output with variadic fields 
- Preparing for optional stress in #137, blocked by this PR