### PR TITLE
Rename model tags

### DIFF
--- a/examples/mechanics/crack_branching.cpp
+++ b/examples/mechanics/crack_branching.cpp
@@ -67,7 +67,7 @@ void crackBranchingExample( const std::string filename )
     // ====================================================
     //                    Force model
     // ====================================================
-    using model_type = CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Fracture>;
+    using model_type = CabanaPD::ForceModel<CabanaPD::PMB>;
     model_type force_model( delta, K, G0 );
 
     // ====================================================

--- a/examples/mechanics/elastic_wave.cpp
+++ b/examples/mechanics/elastic_wave.cpp
@@ -55,7 +55,8 @@ void elasticWaveExample( const std::string filename )
     //                    Force model
     // ====================================================
     using model_type =
-        CabanaPD::ForceModel<CabanaPD::LinearLPS, CabanaPD::Elastic>;
+        CabanaPD::ForceModel<CabanaPD::LinearLPS, CabanaPD::Elastic,
+                             CabanaPD::NoFracture>;
     model_type force_model( delta, K, G );
 
     // ====================================================
@@ -100,7 +101,7 @@ void elasticWaveExample( const std::string filename )
     // ====================================================
     //                   Create solver
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverElastic<memory_space>(
+    auto cabana_pd = CabanaPD::createSolverNoFracture<memory_space>(
         inputs, particles, force_model );
 
     // ====================================================

--- a/examples/mechanics/fragmenting_cylinder.cpp
+++ b/examples/mechanics/fragmenting_cylinder.cpp
@@ -60,7 +60,7 @@ void fragmentingCylinderExample( const std::string filename )
     // ====================================================
     //                    Force model
     // ====================================================
-    using model_type = CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Fracture>;
+    using model_type = CabanaPD::ForceModel<CabanaPD::PMB>;
     model_type force_model( delta, K, G0 );
     // using model_type =
     //      CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Fracture>;

--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -78,10 +78,10 @@ void kalthoffWinklerExample( const std::string filename )
     // ====================================================
     //                    Force model
     // ====================================================
-    using model_type = CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Fracture>;
+    using model_type = CabanaPD::ForceModel<CabanaPD::PMB>;
     model_type force_model( delta, K, G0 );
     // using model_type =
-    //     CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Fracture>;
+    //     CabanaPD::ForceModel<CabanaPD::LPS>;
     // model_type force_model( delta, K, G, G0 );
 
     // ====================================================

--- a/examples/thermomechanics/thermal_deformation.cpp
+++ b/examples/thermomechanics/thermal_deformation.cpp
@@ -81,13 +81,14 @@ void thermalDeformationExample( const std::string filename )
     // ====================================================
     //                    Force model
     // ====================================================
-    auto force_model = CabanaPD::createForceModel(
-        model_type{}, CabanaPD::Elastic{}, *particles, delta, K, alpha, temp0 );
+    auto force_model =
+        CabanaPD::createForceModel( model_type{}, CabanaPD::NoFracture{},
+                                    *particles, delta, K, alpha, temp0 );
 
     // ====================================================
     //                   Create solver
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverElastic<memory_space>(
+    auto cabana_pd = CabanaPD::createSolverNoFracture<memory_space>(
         inputs, particles, force_model );
 
     // ====================================================

--- a/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
@@ -91,13 +91,13 @@ void thermalDeformationHeatTransferExample( const std::string filename )
     //                    Force model
     // ====================================================
     auto force_model = CabanaPD::createForceModel(
-        model_type{}, CabanaPD::Elastic{}, *particles, delta, K, kappa, cp,
+        model_type{}, CabanaPD::NoFracture{}, *particles, delta, K, kappa, cp,
         alpha, temp0 );
 
     // ====================================================
     //                   Create solver
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverElastic<memory_space>(
+    auto cabana_pd = CabanaPD::createSolverNoFracture<memory_space>(
         inputs, particles, force_model );
 
     // ====================================================

--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -111,7 +111,7 @@ struct BaseDynamicTemperatureModel
     }
 };
 
-template <typename ModelType, typename PlasticityType = Elastic,
+template <typename PeridynamicsModelType, typename MechanicsModelType = Elastic,
           typename DamageType = Fracture,
           typename ThermalType = TemperatureIndependent, typename... DataTypes>
 struct ForceModel;

--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -111,7 +111,8 @@ struct BaseDynamicTemperatureModel
     }
 };
 
-template <typename ModelType, typename DamageType,
+template <typename ModelType, typename PlasticityType = Elastic,
+          typename DamageType = Fracture,
           typename ThermalType = TemperatureIndependent, typename... DataTypes>
 struct ForceModel;
 

--- a/src/CabanaPD_HeatTransfer.hpp
+++ b/src/CabanaPD_HeatTransfer.hpp
@@ -36,7 +36,7 @@ class HeatTransfer : public Force<MemorySpace, BaseForceModel>
     using base_type::_neigh_list;
     using model_type = ModelType;
     static_assert(
-        std::is_same_v<typename model_type::fracture_type, Elastic> );
+        std::is_same_v<typename model_type::fracture_type, NoFracture> );
 
     // Running with mechanics as well; no reason to rebuild neighbors.
     template <class NeighborType>

--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -93,7 +93,7 @@ class SolverBase
 
 template <class MemorySpace, class InputType, class ParticleType,
           class ForceModelType, class ContactModelType = NoContact>
-class SolverElastic
+class SolverNoFracture
 {
   public:
     using memory_space = MemorySpace;
@@ -114,9 +114,9 @@ class SolverElastic
     using contact_type = Force<memory_space, ContactModelType>;
     using contact_model_type = ContactModelType;
 
-    SolverElastic( input_type _inputs,
-                   std::shared_ptr<particle_type> _particles,
-                   force_model_type force_model )
+    SolverNoFracture( input_type _inputs,
+                      std::shared_ptr<particle_type> _particles,
+                      force_model_type force_model )
         : inputs( _inputs )
         , particles( _particles )
         , _init_time( 0.0 )
@@ -124,10 +124,10 @@ class SolverElastic
         setup( force_model );
     }
 
-    SolverElastic( input_type _inputs,
-                   std::shared_ptr<particle_type> _particles,
-                   force_model_type force_model,
-                   contact_model_type contact_model )
+    SolverNoFracture( input_type _inputs,
+                      std::shared_ptr<particle_type> _particles,
+                      force_model_type force_model,
+                      contact_model_type contact_model )
         : inputs( _inputs )
         , particles( _particles )
         , _init_time( 0.0 )
@@ -488,12 +488,12 @@ class SolverElastic
 template <class MemorySpace, class InputType, class ParticleType,
           class ForceModelType, class ContactModelType = NoContact>
 class SolverFracture
-    : public SolverElastic<MemorySpace, InputType, ParticleType, ForceModelType,
-                           ContactModelType>
+    : public SolverNoFracture<MemorySpace, InputType, ParticleType,
+                              ForceModelType, ContactModelType>
 {
   public:
-    using base_type = SolverElastic<MemorySpace, InputType, ParticleType,
-                                    ForceModelType, ContactModelType>;
+    using base_type = SolverNoFracture<MemorySpace, InputType, ParticleType,
+                                       ForceModelType, ContactModelType>;
     using exec_space = typename base_type::exec_space;
     using memory_space = typename base_type::memory_space;
 
@@ -735,24 +735,26 @@ class SolverFracture
 
 template <class MemorySpace, class InputsType, class ParticleType,
           class ForceModelType>
-auto createSolverElastic( InputsType inputs,
-                          std::shared_ptr<ParticleType> particles,
-                          ForceModelType model )
+auto createSolverNoFracture( InputsType inputs,
+                             std::shared_ptr<ParticleType> particles,
+                             ForceModelType model )
 {
-    return std::make_shared<
-        SolverElastic<MemorySpace, InputsType, ParticleType, ForceModelType>>(
+    return std::make_shared<SolverNoFracture<MemorySpace, InputsType,
+                                             ParticleType, ForceModelType>>(
         inputs, particles, model );
 }
 
 template <class MemorySpace, class InputsType, class ParticleType,
           class ForceModelType, class ContactModelType>
-auto createSolverElastic( InputsType inputs,
-                          std::shared_ptr<ParticleType> particles,
-                          ForceModelType model, ContactModelType contact_model )
+auto createSolverNoFracture( InputsType inputs,
+                             std::shared_ptr<ParticleType> particles,
+                             ForceModelType model,
+                             ContactModelType contact_model )
 {
-    return std::make_shared<SolverElastic<MemorySpace, InputsType, ParticleType,
-                                          ForceModelType, ContactModelType>>(
-        inputs, particles, model, contact_model );
+    return std::make_shared<
+        SolverNoFracture<MemorySpace, InputsType, ParticleType, ForceModelType,
+                         ContactModelType>>( inputs, particles, model,
+                                             contact_model );
 }
 
 template <class MemorySpace, class InputsType, class ParticleType,

--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -15,15 +15,19 @@
 namespace CabanaPD
 {
 // Fracture tags.
-struct Elastic
+struct NoFracture
 {
 };
 struct Fracture
 {
 };
 
-// Contact and DEM (contact without PD) tags.
+// Mechanics tags.
+struct Elastic
+{
+};
 
+// Contact and DEM (contact without PD) tags.
 struct NoContact
 {
 };
@@ -37,6 +41,7 @@ struct TemperatureIndependent
 {
     using base_type = TemperatureIndependent;
 };
+
 struct TemperatureDependent
 {
     using base_type = TemperatureDependent;

--- a/src/force/CabanaPD_ContactModels.hpp
+++ b/src/force/CabanaPD_ContactModels.hpp
@@ -42,7 +42,7 @@ struct NormalRepulsionModel : public ContactModel
 {
     // FIXME: This is for use as the primary force model.
     using base_model = PMB;
-    using fracture_type = Elastic;
+    using fracture_type = NoFracture;
     using thermal_type = TemperatureIndependent;
 
     using ContactModel::delta;

--- a/src/force/CabanaPD_ForceModels_LPS.hpp
+++ b/src/force/CabanaPD_ForceModels_LPS.hpp
@@ -18,11 +18,11 @@
 namespace CabanaPD
 {
 template <>
-struct ForceModel<LPS, Elastic> : public BaseForceModel
+struct ForceModel<LPS, Elastic, NoFracture> : public BaseForceModel
 {
     using base_type = BaseForceModel;
     using base_model = LPS;
-    using fracture_type = Elastic;
+    using fracture_type = NoFracture;
     using thermal_type = TemperatureIndependent;
 
     using base_type::delta;
@@ -34,7 +34,6 @@ struct ForceModel<LPS, Elastic> : public BaseForceModel
     double theta_coeff;
     double s_coeff;
 
-    ForceModel(){};
     ForceModel( const double _delta, const double _K, const double _G,
                 const int _influence = 0 )
         : base_type( _delta )
@@ -63,9 +62,10 @@ struct ForceModel<LPS, Elastic> : public BaseForceModel
 };
 
 template <>
-struct ForceModel<LPS, Fracture> : public ForceModel<LPS, Elastic>
+struct ForceModel<LPS, Elastic, Fracture>
+    : public ForceModel<LPS, Elastic, NoFracture>
 {
-    using base_type = ForceModel<LPS, Elastic>;
+    using base_type = ForceModel<LPS, Elastic, NoFracture>;
     using base_model = typename base_type::base_model;
     using fracture_type = Fracture;
     using thermal_type = base_type::thermal_type;
@@ -80,7 +80,6 @@ struct ForceModel<LPS, Fracture> : public ForceModel<LPS, Elastic>
     double s0;
     double bond_break_coeff;
 
-    ForceModel() {}
     ForceModel( const double _delta, const double _K, const double _G,
                 const double _G0, const int _influence = 0 )
         : base_type( _delta, _K, _G, _influence )
@@ -106,9 +105,10 @@ struct ForceModel<LPS, Fracture> : public ForceModel<LPS, Elastic>
 };
 
 template <>
-struct ForceModel<LinearLPS, Elastic> : public ForceModel<LPS, Elastic>
+struct ForceModel<LinearLPS, Elastic, NoFracture>
+    : public ForceModel<LPS, Elastic, NoFracture>
 {
-    using base_type = ForceModel<LPS, Elastic>;
+    using base_type = ForceModel<LPS, Elastic, NoFracture>;
     using base_model = typename base_type::base_model;
     using fracture_type = typename base_type::fracture_type;
     using thermal_type = base_type::thermal_type;
@@ -124,9 +124,10 @@ struct ForceModel<LinearLPS, Elastic> : public ForceModel<LPS, Elastic>
 };
 
 template <>
-struct ForceModel<LinearLPS, Fracture> : public ForceModel<LPS, Fracture>
+struct ForceModel<LinearLPS, Elastic, Fracture>
+    : public ForceModel<LPS, Elastic, Fracture>
 {
-    using base_type = ForceModel<LPS, Fracture>;
+    using base_type = ForceModel<LPS, Elastic, Fracture>;
     using base_model = typename base_type::base_model;
     using fracture_type = typename base_type::fracture_type;
     using thermal_type = base_type::thermal_type;

--- a/src/force/CabanaPD_ForceModels_PMB.hpp
+++ b/src/force/CabanaPD_ForceModels_PMB.hpp
@@ -19,11 +19,12 @@
 namespace CabanaPD
 {
 template <>
-struct ForceModel<PMB, Elastic, TemperatureIndependent> : public BaseForceModel
+struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
+    : public BaseForceModel
 {
     using base_type = BaseForceModel;
     using base_model = PMB;
-    using fracture_type = Elastic;
+    using fracture_type = NoFracture;
     using thermal_type = TemperatureIndependent;
 
     using base_type::delta;
@@ -31,7 +32,6 @@ struct ForceModel<PMB, Elastic, TemperatureIndependent> : public BaseForceModel
     double c;
     double K;
 
-    ForceModel(){};
     ForceModel( const double delta, const double K )
         : base_type( delta )
     {
@@ -54,10 +54,10 @@ struct ForceModel<PMB, Elastic, TemperatureIndependent> : public BaseForceModel
 };
 
 template <>
-struct ForceModel<PMB, Fracture, TemperatureIndependent>
-    : public ForceModel<PMB, Elastic, TemperatureIndependent>
+struct ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
+    : public ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
 {
-    using base_type = ForceModel<PMB, Elastic>;
+    using base_type = ForceModel<PMB, Elastic, NoFracture>;
     using base_model = typename base_type::base_model;
     using fracture_type = Fracture;
     using thermal_type = base_type::thermal_type;
@@ -69,7 +69,6 @@ struct ForceModel<PMB, Fracture, TemperatureIndependent>
     double s0;
     double bond_break_coeff;
 
-    ForceModel() {}
     ForceModel( const double delta, const double K, const double G0 )
         : base_type( delta, K )
     {
@@ -101,10 +100,10 @@ struct ForceModel<PMB, Fracture, TemperatureIndependent>
 };
 
 template <>
-struct ForceModel<LinearPMB, Elastic, TemperatureIndependent>
-    : public ForceModel<PMB, Elastic, TemperatureIndependent>
+struct ForceModel<LinearPMB, Elastic, NoFracture, TemperatureIndependent>
+    : public ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
 {
-    using base_type = ForceModel<PMB, Elastic>;
+    using base_type = ForceModel<PMB, Elastic, NoFracture>;
     using base_model = typename base_type::base_model;
     using fracture_type = typename base_type::fracture_type;
     using thermal_type = base_type::thermal_type;
@@ -117,10 +116,10 @@ struct ForceModel<LinearPMB, Elastic, TemperatureIndependent>
 };
 
 template <>
-struct ForceModel<LinearPMB, Fracture, TemperatureIndependent>
-    : public ForceModel<PMB, Fracture, TemperatureIndependent>
+struct ForceModel<LinearPMB, Elastic, Fracture, TemperatureIndependent>
+    : public ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
 {
-    using base_type = ForceModel<PMB, Fracture>;
+    using base_type = ForceModel<PMB>;
     using base_model = typename base_type::base_model;
     using fracture_type = typename base_type::fracture_type;
     using thermal_type = base_type::thermal_type;
@@ -137,14 +136,16 @@ struct ForceModel<LinearPMB, Fracture, TemperatureIndependent>
 };
 
 template <typename TemperatureType>
-struct ForceModel<PMB, Elastic, TemperatureDependent, TemperatureType>
-    : public ForceModel<PMB, Elastic, TemperatureIndependent>,
+struct ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
+                  TemperatureType>
+    : public ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>,
       BaseTemperatureModel<TemperatureType>
 {
-    using base_type = ForceModel<PMB, Elastic, TemperatureIndependent>;
+    using base_type =
+        ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>;
     using base_temperature_type = BaseTemperatureModel<TemperatureType>;
     using base_model = PMB;
-    using fracture_type = Elastic;
+    using fracture_type = NoFracture;
     using thermal_type = TemperatureDependent;
 
     using base_type::c;
@@ -158,7 +159,6 @@ struct ForceModel<PMB, Elastic, TemperatureDependent, TemperatureType>
     // Explicitly use the temperature-dependent stretch.
     using base_temperature_type::thermalStretch;
 
-    // ForceModel(){};
     ForceModel( const double _delta, const double _K,
                 const TemperatureType _temp, const double _alpha,
                 const double _temp0 = 0.0 )
@@ -176,22 +176,33 @@ struct ForceModel<PMB, Elastic, TemperatureDependent, TemperatureType>
     }
 };
 
+// Default to Fracture.
 template <typename ParticleType>
-auto createForceModel( PMB, Elastic, ParticleType particles, const double delta,
+auto createForceModel( PMB model, ParticleType particles, const double delta,
                        const double K, const double alpha, const double temp0 )
+{
+    return createForceModel( model, Fracture{}, particles, delta, K, alpha,
+                             temp0 );
+}
+
+template <typename ParticleType>
+auto createForceModel( PMB, NoFracture, ParticleType particles,
+                       const double delta, const double K, const double alpha,
+                       const double temp0 )
 {
     auto temp = particles.sliceTemperature();
     using temp_type = decltype( temp );
-    return ForceModel<PMB, Elastic, TemperatureDependent, temp_type>(
-        delta, K, temp, alpha, temp0 );
+    return ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
+                      temp_type>( delta, K, temp, alpha, temp0 );
 }
 
 template <typename TemperatureType>
-struct ForceModel<PMB, Fracture, TemperatureDependent, TemperatureType>
-    : public ForceModel<PMB, Fracture, TemperatureIndependent>,
+struct ForceModel<PMB, Elastic, Fracture, TemperatureDependent, TemperatureType>
+    : public ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>,
       BaseTemperatureModel<TemperatureType>
 {
-    using base_type = ForceModel<PMB, Fracture, TemperatureIndependent>;
+    using base_type =
+        ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>;
     using base_temperature_type = BaseTemperatureModel<TemperatureType>;
     using base_model = typename base_type::base_model;
     using fracture_type = typename base_type::fracture_type;
@@ -213,7 +224,6 @@ struct ForceModel<PMB, Fracture, TemperatureDependent, TemperatureType>
     // Explicitly use the temperature-dependent stretch.
     using base_temperature_type::thermalStretch;
 
-    // ForceModel(){};
     ForceModel( const double _delta, const double _K, const double _G0,
                 const TemperatureType _temp, const double _alpha,
                 const double _temp0 = 0.0 )
@@ -248,20 +258,21 @@ auto createForceModel( PMB, Fracture, ParticleType particles,
 {
     auto temp = particles.sliceTemperature();
     using temp_type = decltype( temp );
-    return ForceModel<PMB, Fracture, TemperatureDependent, temp_type>(
+    return ForceModel<PMB, Elastic, Fracture, TemperatureDependent, temp_type>(
         delta, K, G0, temp, alpha, temp0 );
 }
 
 template <typename TemperatureType>
-struct ForceModel<PMB, Elastic, DynamicTemperature, TemperatureType>
-    : public ForceModel<PMB, Elastic, TemperatureDependent, TemperatureType>,
+struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>
+    : public ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
+                        TemperatureType>,
       BaseDynamicTemperatureModel
 {
-    using base_type =
-        ForceModel<PMB, Elastic, TemperatureDependent, TemperatureType>;
+    using base_type = ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
+                                 TemperatureType>;
     using base_temperature_type = BaseDynamicTemperatureModel;
     using base_model = PMB;
-    using fracture_type = Elastic;
+    using fracture_type = NoFracture;
     using thermal_type = DynamicTemperature;
 
     using base_type::c;
@@ -279,7 +290,6 @@ struct ForceModel<PMB, Elastic, DynamicTemperature, TemperatureType>
     // Explicitly use the temperature-dependent stretch.
     using base_type::thermalStretch;
 
-    // ForceModel(){};
     ForceModel( const double _delta, const double _K,
                 const TemperatureType _temp, const double _kappa,
                 const double _cp, const double _alpha,
@@ -304,14 +314,14 @@ struct ForceModel<PMB, Elastic, DynamicTemperature, TemperatureType>
 };
 
 template <typename ParticleType>
-auto createForceModel( PMB, Elastic, ParticleType particles, const double delta,
-                       const double K, const double kappa, const double cp,
-                       const double alpha, const double temp0,
+auto createForceModel( PMB, NoFracture, ParticleType particles,
+                       const double delta, const double K, const double kappa,
+                       const double cp, const double alpha, const double temp0,
                        const bool constant_microconductivity = true )
 {
     auto temp = particles.sliceTemperature();
     using temp_type = decltype( temp );
-    return ForceModel<PMB, Elastic, DynamicTemperature, temp_type>(
+    return ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, temp_type>(
         delta, K, temp, kappa, cp, alpha, temp0, constant_microconductivity );
 }
 
@@ -346,7 +356,6 @@ struct ForceModel<PMB, Fracture, DynamicTemperature, TemperatureType>
     // Explicitly use the temperature-dependent stretch.
     using base_type::thermalStretch;
 
-    // ForceModel(){};
     ForceModel( const double _delta, const double _K, const double _G0,
                 const TemperatureType _temp, const double _kappa,
                 const double _cp, const double _alpha,
@@ -379,7 +388,7 @@ auto createForceModel( PMB, Fracture, ParticleType particles,
 {
     auto temp = particles.sliceTemperature();
     using temp_type = decltype( temp );
-    return ForceModel<PMB, Fracture, DynamicTemperature, temp_type>(
+    return ForceModel<PMB, Elastic, Fracture, DynamicTemperature, temp_type>(
         delta, K, G0, temp, kappa, cp, alpha, temp0,
         constant_microconductivity );
 }

--- a/src/force/CabanaPD_Force_LPS.hpp
+++ b/src/force/CabanaPD_Force_LPS.hpp
@@ -70,13 +70,14 @@
 namespace CabanaPD
 {
 template <class MemorySpace>
-class Force<MemorySpace, ForceModel<LPS, Elastic>>
+class Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>
     : public Force<MemorySpace, BaseForceModel>
 {
   protected:
     using base_type = Force<MemorySpace, BaseForceModel>;
     using base_type::_half_neigh;
-    ForceModel<LPS, Elastic> _model;
+    using model_type = ForceModel<LPS, Elastic, NoFracture>;
+    model_type _model;
 
     using base_type::_energy_timer;
     using base_type::_timer;
@@ -89,7 +90,7 @@ class Force<MemorySpace, ForceModel<LPS, Elastic>>
 
     template <class ParticleType>
     Force( const bool half_neigh, ParticleType& particles,
-           const ForceModel<LPS, Elastic> model )
+           const model_type model )
         : base_type( half_neigh, model.delta, particles )
         , _model( model )
     {
@@ -259,13 +260,14 @@ class Force<MemorySpace, ForceModel<LPS, Elastic>>
 };
 
 template <class MemorySpace>
-class Force<MemorySpace, ForceModel<LPS, Fracture>>
-    : public Force<MemorySpace, ForceModel<LPS, Elastic>>
+class Force<MemorySpace, ForceModel<LPS, Elastic, Fracture>>
+    : public Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>
 {
   protected:
-    using base_type = Force<MemorySpace, ForceModel<LPS, Elastic>>;
+    using base_type = Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>;
     using base_type::_half_neigh;
-    ForceModel<LPS, Fracture> _model;
+    using model_type = ForceModel<LPS, Elastic, Fracture>;
+    model_type _model;
 
     using base_type::_energy_timer;
     using base_type::_timer;
@@ -278,7 +280,7 @@ class Force<MemorySpace, ForceModel<LPS, Fracture>>
 
     template <class ParticleType>
     Force( const bool half_neigh, const ParticleType& particles,
-           const ForceModel<LPS, Fracture> model )
+           const model_type model )
         : base_type( half_neigh, particles, model )
         , _model( model )
     {
@@ -511,12 +513,13 @@ class Force<MemorySpace, ForceModel<LPS, Fracture>>
 };
 
 template <class MemorySpace>
-class Force<MemorySpace, ForceModel<LinearLPS, Elastic>>
-    : public Force<MemorySpace, ForceModel<LPS, Elastic>>
+class Force<MemorySpace, ForceModel<LinearLPS, Elastic, NoFracture>>
+    : public Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>
 {
   protected:
-    using base_type = Force<MemorySpace, ForceModel<LPS, Elastic>>;
-    ForceModel<LinearLPS, Elastic> _model;
+    using base_type = Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>;
+    using model_type = ForceModel<LinearLPS, Elastic, NoFracture>;
+    model_type _model;
 
     using base_type::_energy_timer;
     using base_type::_timer;
@@ -529,7 +532,7 @@ class Force<MemorySpace, ForceModel<LinearLPS, Elastic>>
 
     template <class ParticleType>
     Force( const bool half_neigh, ParticleType& particles,
-           const ForceModel<LinearLPS, Elastic> model )
+           const model_type model )
         : base_type( half_neigh, particles, model )
         , _model( model )
     {

--- a/src/force/CabanaPD_Force_PMB.hpp
+++ b/src/force/CabanaPD_Force_PMB.hpp
@@ -71,13 +71,13 @@
 namespace CabanaPD
 {
 template <class MemorySpace, class... ModelParams>
-class Force<MemorySpace, ForceModel<PMB, Elastic, ModelParams...>>
+class Force<MemorySpace, ForceModel<PMB, Elastic, NoFracture, ModelParams...>>
     : public Force<MemorySpace, BaseForceModel>
 {
   public:
     // Using the default exec_space.
     using exec_space = typename MemorySpace::execution_space;
-    using model_type = ForceModel<PMB, Elastic, ModelParams...>;
+    using model_type = ForceModel<PMB, Elastic, NoFracture, ModelParams...>;
     using base_type = Force<MemorySpace, BaseForceModel>;
     using neighbor_list_type = typename base_type::neighbor_list_type;
     using base_type::_neigh_list;
@@ -181,13 +181,13 @@ class Force<MemorySpace, ForceModel<PMB, Elastic, ModelParams...>>
 };
 
 template <class MemorySpace, class... ModelParams>
-class Force<MemorySpace, ForceModel<PMB, Fracture, ModelParams...>>
+class Force<MemorySpace, ForceModel<PMB, Elastic, Fracture, ModelParams...>>
     : public Force<MemorySpace, BaseForceModel>
 {
   public:
     // Using the default exec_space.
     using exec_space = typename MemorySpace::execution_space;
-    using model_type = ForceModel<PMB, Fracture, ModelParams...>;
+    using model_type = ForceModel<PMB, Elastic, Fracture, ModelParams...>;
     using base_type = Force<MemorySpace, BaseForceModel>;
     using neighbor_list_type = typename base_type::neighbor_list_type;
     using base_type::_neigh_list;
@@ -328,13 +328,15 @@ class Force<MemorySpace, ForceModel<PMB, Fracture, ModelParams...>>
 };
 
 template <class MemorySpace, class... ModelParams>
-class Force<MemorySpace, ForceModel<LinearPMB, Elastic, ModelParams...>>
+class Force<MemorySpace,
+            ForceModel<LinearPMB, Elastic, NoFracture, ModelParams...>>
     : public Force<MemorySpace, BaseForceModel>
 {
   public:
     // Using the default exec_space.
     using exec_space = typename MemorySpace::execution_space;
-    using model_type = ForceModel<LinearPMB, Elastic, TemperatureIndependent>;
+    using model_type =
+        ForceModel<LinearPMB, Elastic, NoFracture, TemperatureIndependent>;
     using base_type = Force<MemorySpace, BaseForceModel>;
     using neighbor_list_type = typename base_type::neighbor_list_type;
     using base_type::_neigh_list;

--- a/src/force/CabanaPD_HertzianContact.hpp
+++ b/src/force/CabanaPD_HertzianContact.hpp
@@ -24,7 +24,7 @@ struct HertzianModel : public ContactModel
 {
     // FIXME: This is for use as the primary force model.
     using base_model = PMB;
-    using fracture_type = Elastic;
+    using fracture_type = NoFracture;
     using thermal_type = TemperatureIndependent;
 
     using ContactModel::Rc; // Contact horizon (should be > 2*radius)

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -56,7 +56,8 @@ struct QuadraticTag
 // Simplified here because the stretch is constant.
 template <class DamageType>
 double computeReferenceStrainEnergyDensity(
-    LinearTag, CabanaPD::ForceModel<CabanaPD::PMB, DamageType> model,
+    LinearTag,
+    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
     const int m, const double s0, const double )
 {
     double W = 0.0;
@@ -81,7 +82,8 @@ double computeReferenceStrainEnergyDensity(
 
 template <class DamageType>
 double computeReferenceStrainEnergyDensity(
-    QuadraticTag, CabanaPD::ForceModel<CabanaPD::PMB, DamageType> model,
+    QuadraticTag,
+    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
     const int m, const double u11, const double x )
 {
     double W = 0.0;
@@ -120,10 +122,10 @@ double computeReferenceForceX( LinearTag, ModelType, const int, const double,
 // Get the PMB force (at one point).
 // Assumes zero y/z displacement components.
 template <class DamageType>
-double
-computeReferenceForceX( QuadraticTag,
-                        CabanaPD::ForceModel<CabanaPD::PMB, DamageType> model,
-                        const int m, const double u11, const double x )
+double computeReferenceForceX(
+    QuadraticTag,
+    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
+    const int m, const double u11, const double x )
 {
     double fx = 0.0;
     double dx = model.delta / m;
@@ -249,7 +251,8 @@ double computeReferenceNeighbors( const double delta, const int m )
 // Get the LPS strain energy density (at one point).
 template <class DamageType>
 double computeReferenceStrainEnergyDensity(
-    LinearTag, CabanaPD::ForceModel<CabanaPD::LPS, DamageType> model,
+    LinearTag,
+    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
     const int m, const double s0, const double )
 {
     double W = 0.0;
@@ -285,7 +288,8 @@ double computeReferenceStrainEnergyDensity(
 
 template <class DamageType>
 double computeReferenceStrainEnergyDensity(
-    QuadraticTag, CabanaPD::ForceModel<CabanaPD::LPS, DamageType> model,
+    QuadraticTag,
+    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
     const int m, const double u11, const double x )
 {
     double W = 0.0;
@@ -331,10 +335,10 @@ double computeReferenceStrainEnergyDensity(
 // Get the LPS strain energy density (at one point).
 // Assumes zero y/z displacement components.
 template <class DamageType>
-double
-computeReferenceForceX( QuadraticTag,
-                        CabanaPD::ForceModel<CabanaPD::LPS, DamageType> model,
-                        const int m, const double u11, const double x )
+double computeReferenceForceX(
+    QuadraticTag,
+    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
+    const int m, const double u11, const double x )
 {
     double fx = 0.0;
     double dx = model.delta / m;
@@ -534,7 +538,8 @@ void checkParticle( QuadraticTag tag, ModelType model, const double s0,
 
 template <class DamageType>
 void checkAnalyticalStrainEnergy(
-    LinearTag, CabanaPD::ForceModel<CabanaPD::PMB, DamageType> model,
+    LinearTag,
+    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
     const double s0, const double W, const double )
 {
     // Relatively large error for small m.
@@ -545,7 +550,8 @@ void checkAnalyticalStrainEnergy(
 
 template <class DamageType>
 void checkAnalyticalStrainEnergy(
-    LinearTag, CabanaPD::ForceModel<CabanaPD::LPS, DamageType> model,
+    LinearTag,
+    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
     const double s0, const double W, const double )
 {
     // LPS is exact.
@@ -555,7 +561,8 @@ void checkAnalyticalStrainEnergy(
 
 template <class DamageType>
 void checkAnalyticalStrainEnergy(
-    QuadraticTag, CabanaPD::ForceModel<CabanaPD::PMB, DamageType> model,
+    QuadraticTag,
+    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
     const double u11, const double W, const double x )
 {
     double threshold = W * 0.05;
@@ -567,7 +574,8 @@ void checkAnalyticalStrainEnergy(
 
 template <class DamageType>
 void checkAnalyticalStrainEnergy(
-    QuadraticTag, CabanaPD::ForceModel<CabanaPD::LPS, DamageType> model,
+    QuadraticTag,
+    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
     const double u11, const double W, const double x )
 {
     double threshold = W * 0.20;
@@ -580,7 +588,8 @@ void checkAnalyticalStrainEnergy(
 
 template <class DamageType>
 void checkAnalyticalForce(
-    QuadraticTag, CabanaPD::ForceModel<CabanaPD::PMB, DamageType> model,
+    QuadraticTag,
+    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
     const double s0, const double fx )
 {
     double threshold = fx * 0.10;
@@ -590,7 +599,8 @@ void checkAnalyticalForce(
 
 template <class DamageType>
 void checkAnalyticalForce(
-    QuadraticTag, CabanaPD::ForceModel<CabanaPD::LPS, DamageType> model,
+    QuadraticTag,
+    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
     const double s0, const double fx )
 {
     double threshold = fx * 0.10;
@@ -599,15 +609,17 @@ void checkAnalyticalForce(
 }
 
 template <class DamageType>
-void checkAnalyticalDilatation( CabanaPD::ForceModel<CabanaPD::PMB, DamageType>,
-                                LinearTag, const double, const double theta )
+void checkAnalyticalDilatation(
+    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType>,
+    LinearTag, const double, const double theta )
 {
     EXPECT_FLOAT_EQ( 0.0, theta );
 }
 
 template <class DamageType>
-void checkAnalyticalDilatation( CabanaPD::ForceModel<CabanaPD::LPS, DamageType>,
-                                LinearTag, const double s0, const double theta )
+void checkAnalyticalDilatation(
+    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType>,
+    LinearTag, const double s0, const double theta )
 {
     EXPECT_FLOAT_EQ( 3 * s0, theta );
 }
@@ -654,7 +666,7 @@ void initializeForce( ModelType, ForceType& force, ParticleType& particles )
 }
 
 template <class ForceType, class ParticleType>
-void initializeForce( CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Fracture>,
+void initializeForce( CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic>,
                       ForceType& force, ParticleType& particles )
 {
     auto max_neighbors = force.getMaxLocalNeighbors();
@@ -745,7 +757,8 @@ TEST( TEST_CATEGORY, test_force_pmb )
     double dx = 2.0 / 11.0;
     double delta = dx * m;
     double K = 1.0;
-    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic> model( delta, K );
+    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, CabanaPD::NoFracture>
+        model( delta, K );
     testForce( model, NoDamageTag{}, dx, m, 1.1, LinearTag{}, 0.1 );
     testForce( model, NoDamageTag{}, dx, m, 1.1, QuadraticTag{}, 0.01 );
 }
@@ -755,8 +768,9 @@ TEST( TEST_CATEGORY, test_force_linear_pmb )
     double dx = 2.0 / 11.0;
     double delta = dx * m;
     double K = 1.0;
-    CabanaPD::ForceModel<CabanaPD::LinearPMB, CabanaPD::Elastic> model( delta,
-                                                                        K );
+    CabanaPD::ForceModel<CabanaPD::LinearPMB, CabanaPD::Elastic,
+                         CabanaPD::NoFracture>
+        model( delta, K );
     testForce( model, NoDamageTag{}, dx, m, 1.1, LinearTag{}, 0.1 );
 }
 TEST( TEST_CATEGORY, test_force_lps )
@@ -767,8 +781,8 @@ TEST( TEST_CATEGORY, test_force_lps )
     double delta = dx * m;
     double K = 1.0;
     double G = 0.5;
-    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic> model( delta, K, G,
-                                                                  1 );
+    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, CabanaPD::NoFracture>
+        model( delta, K, G, 1 );
     testForce( model, NoDamageTag{}, dx, m, 2.1, LinearTag{}, 0.1 );
     testForce( model, NoDamageTag{}, dx, m, 2.1, QuadraticTag{}, 0.01 );
 }
@@ -779,8 +793,9 @@ TEST( TEST_CATEGORY, test_force_linear_lps )
     double delta = dx * m;
     double K = 1.0;
     double G = 0.5;
-    CabanaPD::ForceModel<CabanaPD::LinearLPS, CabanaPD::Elastic> model(
-        delta, K, G, 1 );
+    CabanaPD::ForceModel<CabanaPD::LinearLPS, CabanaPD::Elastic,
+                         CabanaPD::NoFracture>
+        model( delta, K, G, 1 );
     testForce( model, NoDamageTag{}, dx, m, 2.1, LinearTag{}, 0.1 );
 }
 
@@ -793,8 +808,7 @@ TEST( TEST_CATEGORY, test_force_pmb_damage )
     double K = 1.0;
     // Large value to make sure no bonds break.
     double G0 = 1000.0;
-    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Fracture> model( delta, K,
-                                                                   G0 );
+    CabanaPD::ForceModel<CabanaPD::PMB> model( delta, K, G0 );
     testForce( model, DamageTag{}, dx, m, 1.1, LinearTag{}, 0.1 );
     testForce( model, DamageTag{}, dx, m, 1.1, QuadraticTag{}, 0.01 );
 }
@@ -806,8 +820,7 @@ TEST( TEST_CATEGORY, test_force_lps_damage )
     double K = 1.0;
     double G = 0.5;
     double G0 = 1000.0;
-    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Fracture> model( delta, K, G,
-                                                                   G0, 1 );
+    CabanaPD::ForceModel<CabanaPD::LPS> model( delta, K, G, G0, 1 );
     testForce( model, DamageTag{}, dx, m, 2.1, LinearTag{}, 0.1 );
     testForce( model, DamageTag{}, dx, m, 2.1, QuadraticTag{}, 0.01 );
 }

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -36,6 +36,8 @@
 #include <force/CabanaPD_Force_LPS.hpp>
 #include <force/CabanaPD_Force_PMB.hpp>
 
+#include <type_traits>
+
 namespace Test
 {
 struct LinearTag
@@ -54,11 +56,12 @@ struct QuadraticTag
 //---------------------------------------------------------------------------//
 // Get the PMB strain energy density (at the center point).
 // Simplified here because the stretch is constant.
-template <class DamageType>
+template <class ModelType>
 double computeReferenceStrainEnergyDensity(
-    LinearTag,
-    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
-    const int m, const double s0, const double )
+    LinearTag, ModelType model, const int m, const double s0, const double,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::PMB>::value ),
+        int>::type* = 0 )
 {
     double W = 0.0;
     double dx = model.delta / m;
@@ -80,11 +83,13 @@ double computeReferenceStrainEnergyDensity(
     return W;
 }
 
-template <class DamageType>
+template <class ModelType>
 double computeReferenceStrainEnergyDensity(
-    QuadraticTag,
-    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
-    const int m, const double u11, const double x )
+    QuadraticTag, ModelType model, const int m, const double u11,
+    const double x,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::PMB>::value ),
+        int>::type* = 0 )
 {
     double W = 0.0;
     double dx = model.delta / m;
@@ -121,11 +126,13 @@ double computeReferenceForceX( LinearTag, ModelType, const int, const double,
 
 // Get the PMB force (at one point).
 // Assumes zero y/z displacement components.
-template <class DamageType>
+template <class ModelType>
 double computeReferenceForceX(
-    QuadraticTag,
-    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
-    const int m, const double u11, const double x )
+    QuadraticTag, ModelType model, const int m, const double u11,
+    const double x,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::PMB>::value ),
+        int>::type* = 0 )
 {
     double fx = 0.0;
     double dx = model.delta / m;
@@ -249,11 +256,12 @@ double computeReferenceNeighbors( const double delta, const int m )
 }
 
 // Get the LPS strain energy density (at one point).
-template <class DamageType>
+template <class ModelType>
 double computeReferenceStrainEnergyDensity(
-    LinearTag,
-    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
-    const int m, const double s0, const double )
+    LinearTag, ModelType model, const int m, const double s0, const double,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::LPS>::value ),
+        int>::type* = 0 )
 {
     double W = 0.0;
     double dx = model.delta / m;
@@ -286,11 +294,13 @@ double computeReferenceStrainEnergyDensity(
     return W;
 }
 
-template <class DamageType>
+template <class ModelType>
 double computeReferenceStrainEnergyDensity(
-    QuadraticTag,
-    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
-    const int m, const double u11, const double x )
+    QuadraticTag, ModelType model, const int m, const double u11,
+    const double x,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::LPS>::value ),
+        int>::type* = 0 )
 {
     double W = 0.0;
     double dx = model.delta / m;
@@ -334,11 +344,13 @@ double computeReferenceStrainEnergyDensity(
 
 // Get the LPS strain energy density (at one point).
 // Assumes zero y/z displacement components.
-template <class DamageType>
+template <class ModelType>
 double computeReferenceForceX(
-    QuadraticTag,
-    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
-    const int m, const double u11, const double x )
+    QuadraticTag, ModelType model, const int m, const double u11,
+    const double x,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::LPS>::value ),
+        int>::type* = 0 )
 {
     double fx = 0.0;
     double dx = model.delta / m;
@@ -536,11 +548,12 @@ void checkParticle( QuadraticTag tag, ModelType model, const double s0,
     checkAnalyticalStrainEnergy( tag, model, s0, W, x );
 }
 
-template <class DamageType>
+template <class ModelType>
 void checkAnalyticalStrainEnergy(
-    LinearTag,
-    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
-    const double s0, const double W, const double )
+    LinearTag, ModelType model, const double s0, const double W, const double,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::PMB>::value ),
+        int>::type* = 0 )
 {
     // Relatively large error for small m.
     double threshold = W * 0.15;
@@ -548,22 +561,25 @@ void checkAnalyticalStrainEnergy(
     EXPECT_NEAR( W, analytical_W, threshold );
 }
 
-template <class DamageType>
+template <class ModelType>
 void checkAnalyticalStrainEnergy(
-    LinearTag,
-    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
-    const double s0, const double W, const double )
+    LinearTag, ModelType model, const double s0, const double W, const double,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::LPS>::value ),
+        int>::type* = 0 )
 {
     // LPS is exact.
     double analytical_W = 9.0 / 2.0 * model.K * s0 * s0;
     EXPECT_FLOAT_EQ( W, analytical_W );
 }
 
-template <class DamageType>
+template <class ModelType>
 void checkAnalyticalStrainEnergy(
-    QuadraticTag,
-    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
-    const double u11, const double W, const double x )
+    QuadraticTag, ModelType model, const double u11, const double W,
+    const double x,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::PMB>::value ),
+        int>::type* = 0 )
 {
     double threshold = W * 0.05;
     double analytical_W =
@@ -572,11 +588,13 @@ void checkAnalyticalStrainEnergy(
     EXPECT_NEAR( W, analytical_W, threshold );
 }
 
-template <class DamageType>
+template <class ModelType>
 void checkAnalyticalStrainEnergy(
-    QuadraticTag,
-    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
-    const double u11, const double W, const double x )
+    QuadraticTag, ModelType model, const double u11, const double W,
+    const double x,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::LPS>::value ),
+        int>::type* = 0 )
 {
     double threshold = W * 0.20;
     double analytical_W =
@@ -586,40 +604,46 @@ void checkAnalyticalStrainEnergy(
     EXPECT_NEAR( W, analytical_W, threshold );
 }
 
-template <class DamageType>
+template <class ModelType>
 void checkAnalyticalForce(
-    QuadraticTag,
-    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType> model,
-    const double s0, const double fx )
+    QuadraticTag, ModelType model, const double s0, const double fx,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::PMB>::value ),
+        int>::type* = 0 )
 {
     double threshold = fx * 0.10;
     double analytical_f = 18.0 / 5.0 * model.K * s0;
     EXPECT_NEAR( fx, analytical_f, threshold );
 }
 
-template <class DamageType>
+template <class ModelType>
 void checkAnalyticalForce(
-    QuadraticTag,
-    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType> model,
-    const double s0, const double fx )
+    QuadraticTag, ModelType model, const double s0, const double fx,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::LPS>::value ),
+        int>::type* = 0 )
 {
     double threshold = fx * 0.10;
     double analytical_f = 2.0 * ( model.K + 4.0 / 3.0 * model.G ) * s0;
     EXPECT_NEAR( fx, analytical_f, threshold );
 }
 
-template <class DamageType>
+template <class ModelType>
 void checkAnalyticalDilatation(
-    CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, DamageType>,
-    LinearTag, const double, const double theta )
+    ModelType, LinearTag, const double, const double theta,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::PMB>::value ),
+        int>::type* = 0 )
 {
     EXPECT_FLOAT_EQ( 0.0, theta );
 }
 
-template <class DamageType>
+template <class ModelType>
 void checkAnalyticalDilatation(
-    CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, DamageType>,
-    LinearTag, const double s0, const double theta )
+    ModelType, LinearTag, const double s0, const double theta,
+    typename std::enable_if<
+        ( std::is_same<typename ModelType::base_model, CabanaPD::LPS>::value ),
+        int>::type* = 0 )
 {
     EXPECT_FLOAT_EQ( 3 * s0, theta );
 }
@@ -630,15 +654,8 @@ void checkAnalyticalDilatation( ModelType, QuadraticTag, const double,
 {
 }
 
-struct DamageTag
-{
-};
-struct NoDamageTag
-{
-};
-
 template <class ForceType, class ParticleType>
-double computeEnergyAndForce( NoDamageTag, ForceType force,
+double computeEnergyAndForce( CabanaPD::NoFracture, ForceType force,
                               ParticleType& particles, const int )
 {
     computeForce( force, particles, Cabana::SerialOpTag() );
@@ -646,7 +663,7 @@ double computeEnergyAndForce( NoDamageTag, ForceType force,
     return Phi;
 }
 template <class ForceType, class ParticleType>
-double computeEnergyAndForce( DamageTag, ForceType force,
+double computeEnergyAndForce( CabanaPD::Fracture, ForceType force,
                               ParticleType& particles, const int max_neighbors )
 {
     Kokkos::View<int**, TEST_MEMSPACE> mu(
@@ -695,10 +712,10 @@ void copyTheta( CabanaPD::LPS, ParticleType particles, AoSoAType aosoa_host )
 //---------------------------------------------------------------------------//
 // Main test function.
 //---------------------------------------------------------------------------//
-template <class ModelType, class TestType, class DamageType>
-void testForce( ModelType model, const DamageType damage_tag, const double dx,
-                const double m, const double boundary_width,
-                const TestType test_tag, const double s0 )
+template <class ModelType, class TestType>
+void testForce( ModelType model, const double dx, const double m,
+                const double boundary_width, const TestType test_tag,
+                const double s0 )
 {
     auto particles = createParticles( model, test_tag, dx, s0 );
 
@@ -717,8 +734,9 @@ void testForce( ModelType model, const DamageType damage_tag, const double dx,
     unsigned int max_neighbors;
     unsigned long long total_neighbors;
     force.getNeighborStatistics( max_neighbors, total_neighbors );
-    double Phi =
-        computeEnergyAndForce( damage_tag, force, particles, max_neighbors );
+    using fracture_type = typename ModelType::fracture_type;
+    double Phi = computeEnergyAndForce( fracture_type{}, force, particles,
+                                        max_neighbors );
 
     // Make a copy of final results on the host
     std::size_t num_particle = x.size();
@@ -759,8 +777,8 @@ TEST( TEST_CATEGORY, test_force_pmb )
     double K = 1.0;
     CabanaPD::ForceModel<CabanaPD::PMB, CabanaPD::Elastic, CabanaPD::NoFracture>
         model( delta, K );
-    testForce( model, NoDamageTag{}, dx, m, 1.1, LinearTag{}, 0.1 );
-    testForce( model, NoDamageTag{}, dx, m, 1.1, QuadraticTag{}, 0.01 );
+    testForce( model, dx, m, 1.1, LinearTag{}, 0.1 );
+    testForce( model, dx, m, 1.1, QuadraticTag{}, 0.01 );
 }
 TEST( TEST_CATEGORY, test_force_linear_pmb )
 {
@@ -771,7 +789,7 @@ TEST( TEST_CATEGORY, test_force_linear_pmb )
     CabanaPD::ForceModel<CabanaPD::LinearPMB, CabanaPD::Elastic,
                          CabanaPD::NoFracture>
         model( delta, K );
-    testForce( model, NoDamageTag{}, dx, m, 1.1, LinearTag{}, 0.1 );
+    testForce( model, dx, m, 1.1, LinearTag{}, 0.1 );
 }
 TEST( TEST_CATEGORY, test_force_lps )
 {
@@ -783,8 +801,8 @@ TEST( TEST_CATEGORY, test_force_lps )
     double G = 0.5;
     CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic, CabanaPD::NoFracture>
         model( delta, K, G, 1 );
-    testForce( model, NoDamageTag{}, dx, m, 2.1, LinearTag{}, 0.1 );
-    testForce( model, NoDamageTag{}, dx, m, 2.1, QuadraticTag{}, 0.01 );
+    testForce( model, dx, m, 2.1, LinearTag{}, 0.1 );
+    testForce( model, dx, m, 2.1, QuadraticTag{}, 0.01 );
 }
 TEST( TEST_CATEGORY, test_force_linear_lps )
 {
@@ -796,7 +814,7 @@ TEST( TEST_CATEGORY, test_force_linear_lps )
     CabanaPD::ForceModel<CabanaPD::LinearLPS, CabanaPD::Elastic,
                          CabanaPD::NoFracture>
         model( delta, K, G, 1 );
-    testForce( model, NoDamageTag{}, dx, m, 2.1, LinearTag{}, 0.1 );
+    testForce( model, dx, m, 2.1, LinearTag{}, 0.1 );
 }
 
 // Tests without damage, but using damage models.
@@ -809,8 +827,8 @@ TEST( TEST_CATEGORY, test_force_pmb_damage )
     // Large value to make sure no bonds break.
     double G0 = 1000.0;
     CabanaPD::ForceModel<CabanaPD::PMB> model( delta, K, G0 );
-    testForce( model, DamageTag{}, dx, m, 1.1, LinearTag{}, 0.1 );
-    testForce( model, DamageTag{}, dx, m, 1.1, QuadraticTag{}, 0.01 );
+    testForce( model, dx, m, 1.1, LinearTag{}, 0.1 );
+    testForce( model, dx, m, 1.1, QuadraticTag{}, 0.01 );
 }
 TEST( TEST_CATEGORY, test_force_lps_damage )
 {
@@ -821,7 +839,7 @@ TEST( TEST_CATEGORY, test_force_lps_damage )
     double G = 0.5;
     double G0 = 1000.0;
     CabanaPD::ForceModel<CabanaPD::LPS> model( delta, K, G, G0, 1 );
-    testForce( model, DamageTag{}, dx, m, 2.1, LinearTag{}, 0.1 );
-    testForce( model, DamageTag{}, dx, m, 2.1, QuadraticTag{}, 0.01 );
+    testForce( model, dx, m, 2.1, LinearTag{}, 0.1 );
+    testForce( model, dx, m, 2.1, QuadraticTag{}, 0.01 );
 }
 } // end namespace Test

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -676,15 +676,22 @@ double computeEnergyAndForce( CabanaPD::Fracture, ForceType force,
 }
 
 template <class ModelType, class ForceType, class ParticleType>
-void initializeForce( ModelType, ForceType& force, ParticleType& particles )
+void initializeForce(
+    ModelType, ForceType& force, ParticleType& particles,
+    typename std::enable_if<( std::is_same<typename ModelType::fracture_type,
+                                           CabanaPD::NoFracture>::value ),
+                            int>::type* = 0 )
 {
     force.computeWeightedVolume( particles, Cabana::SerialOpTag() );
     force.computeDilatation( particles, Cabana::SerialOpTag() );
 }
 
-template <class ForceType, class ParticleType>
-void initializeForce( CabanaPD::ForceModel<CabanaPD::LPS, CabanaPD::Elastic>,
-                      ForceType& force, ParticleType& particles )
+template <class ModelType, class ForceType, class ParticleType>
+void initializeForce(
+    ModelType, ForceType& force, ParticleType& particles,
+    typename std::enable_if<( std::is_same<typename ModelType::fracture_type,
+                                           CabanaPD::Fracture>::value ),
+                            int>::type* = 0 )
 {
     auto max_neighbors = force.getMaxLocalNeighbors();
     Kokkos::View<int**, TEST_MEMSPACE> mu( "broken_bonds", particles.numLocal(),

--- a/unit_test/tstHertz.hpp
+++ b/unit_test/tstHertz.hpp
@@ -122,7 +122,7 @@ void testHertzianContact( const std::string filename )
     // ====================================================
     //  Simulation run
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverElastic<memory_space>(
+    auto cabana_pd = CabanaPD::createSolverNoFracture<memory_space>(
         inputs, particles, contact_model );
     cabana_pd->init();
     cabana_pd->run();


### PR DESCRIPTION
Extracted from plasticity #142 

Fracture is now the default; similarly elastic is the default in preparation for plasticity models.