### PR TITLE
Move force details into models

### DIFF
--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -21,11 +21,8 @@ struct BaseForceModel
 {
     double delta;
 
-    BaseForceModel(){};
     BaseForceModel( const double _delta )
         : delta( _delta ){};
-
-    BaseForceModel( const BaseForceModel& model ) { delta = model.delta; }
 
     // No-op for temperature.
     KOKKOS_INLINE_FUNCTION
@@ -55,12 +52,6 @@ struct BaseTemperatureModel
         temperature = model.temperature;
     }
 
-    void set_param( const double _alpha, const double _temp0 )
-    {
-        alpha = _alpha;
-        temp0 = _temp0;
-    }
-
     void update( const TemperatureType _temp ) { temperature = _temp; }
 
     // Update stretch with temperature effects.
@@ -87,12 +78,6 @@ struct BaseDynamicTemperatureModel
     BaseDynamicTemperatureModel( const double _delta, const double _kappa,
                                  const double _cp,
                                  const bool _constant_microconductivity = true )
-    {
-        set_param( _delta, _kappa, _cp, _constant_microconductivity );
-    }
-
-    void set_param( const double _delta, const double _kappa, const double _cp,
-                    const bool _constant_microconductivity )
     {
         delta = _delta;
         kappa = _kappa;

--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -464,7 +464,6 @@ class SolverNoFracture
     // Optional modules.
     std::shared_ptr<heat_transfer_type> heat_transfer;
     std::shared_ptr<contact_type> contact;
-    contact_model_type contact_model;
 
     // Output files.
     std::string output_file;

--- a/src/force/CabanaPD_ContactModels.hpp
+++ b/src/force/CabanaPD_ContactModels.hpp
@@ -58,6 +58,15 @@ struct NormalRepulsionModel : public ContactModel
         // This could inherit from PMB (same c)
         c = 18.0 * K / ( pi * delta * delta * delta * delta );
     }
+
+    KOKKOS_INLINE_FUNCTION
+    auto forceCoeff( const double r, const double vol ) const
+    {
+        // Contact "stretch"
+        const double sc = ( r - Rc ) / delta;
+        // Normal repulsion uses a 15 factor compared to the PMB force
+        return 15.0 * c * sc * vol;
+    }
 };
 
 template <>

--- a/src/force/CabanaPD_ContactModels.hpp
+++ b/src/force/CabanaPD_ContactModels.hpp
@@ -28,7 +28,6 @@ struct ContactModel
     double delta;
     double Rc;
 
-    ContactModel(){};
     // PD horizon
     // Contact radius
     ContactModel( const double _delta, const double _Rc )
@@ -51,18 +50,10 @@ struct NormalRepulsionModel : public ContactModel
     double c;
     double K;
 
-    NormalRepulsionModel(){};
     NormalRepulsionModel( const double delta, const double Rc, const double _K )
         : ContactModel( delta, Rc )
         , K( _K )
     {
-        set_param( delta, Rc, K );
-    }
-
-    void set_param( const double _delta, const double _Rc, const double _K )
-    {
-        delta = _delta;
-        Rc = _Rc;
         K = _K;
         // This could inherit from PMB (same c)
         c = 18.0 * K / ( pi * delta * delta * delta * delta );

--- a/src/force/CabanaPD_ForceModels_LPS.hpp
+++ b/src/force/CabanaPD_ForceModels_LPS.hpp
@@ -40,16 +40,9 @@ struct ForceModel<LPS, Elastic, NoFracture> : public BaseForceModel
                 const int _influence = 0 )
         : base_type( _delta )
         , influence_type( _influence )
+        , K( _K )
+        , G( _G )
     {
-        set_param( _delta, _K, _G );
-    }
-
-    void set_param( const double _delta, const double _K, const double _G )
-    {
-        delta = _delta;
-        K = _K;
-        G = _G;
-
         theta_coeff = 3.0 * K - 5.0 * G;
         s_coeff = 15.0 * G;
     }
@@ -85,15 +78,8 @@ struct ForceModel<LPS, Elastic, Fracture>
     ForceModel( const double _delta, const double _K, const double _G,
                 const double _G0, const int _influence = 0 )
         : base_type( _delta, _K, _G, _influence )
+        , G0( _G0 )
     {
-        set_param( _delta, _K, _G, _G0 );
-    }
-
-    void set_param( const double _delta, const double _K, const double _G,
-                    const double _G0 )
-    {
-        base_type::set_param( _delta, _K, _G );
-        G0 = _G0;
         if ( influence_type == 1 )
         {
             s0 = Kokkos::sqrt( 5.0 * G0 / 9.0 / K / delta ); // 1/xi

--- a/src/force/CabanaPD_ForceModels_PMB.hpp
+++ b/src/force/CabanaPD_ForceModels_PMB.hpp
@@ -40,6 +40,20 @@ struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
     {
         c = 18.0 * K / ( pi * delta * delta * delta * delta );
     }
+
+    KOKKOS_INLINE_FUNCTION
+    auto forceCoeff( const double s, const double vol ) const
+    {
+        return c * s * vol;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    auto energy( const double s, const double xi, const double vol ) const
+    {
+        // 0.25 factor is due to 1/2 from outside the integral and 1/2 from
+        // the integrand (pairwise potential).
+        return 0.25 * c * s * s * xi * vol;
+    }
 };
 
 template <>

--- a/src/force/CabanaPD_ForceModels_PMB.hpp
+++ b/src/force/CabanaPD_ForceModels_PMB.hpp
@@ -34,23 +34,10 @@ struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
     double c;
     double K;
 
-    ForceModel( const double delta, const double K )
+    ForceModel( const double delta, const double _K )
         : base_type( delta )
+        , K( _K )
     {
-        set_param( delta, K );
-    }
-
-    ForceModel( const ForceModel& model )
-        : base_type( model )
-    {
-        c = model.c;
-        K = model.K;
-    }
-
-    void set_param( const double _delta, const double _K )
-    {
-        delta = _delta;
-        K = _K;
         c = 18.0 * K / ( pi * delta * delta * delta * delta );
     }
 };
@@ -71,24 +58,10 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
     double s0;
     double bond_break_coeff;
 
-    ForceModel( const double delta, const double K, const double G0 )
+    ForceModel( const double delta, const double K, const double _G0 )
         : base_type( delta, K )
+        , G0( _G0 )
     {
-        set_param( delta, K, G0 );
-    }
-
-    ForceModel( const ForceModel& model )
-        : base_type( model )
-    {
-        G0 = model.G0;
-        s0 = model.s0;
-        bond_break_coeff = model.bond_break_coeff;
-    }
-
-    void set_param( const double _delta, const double _K, const double _G0 )
-    {
-        base_type::set_param( _delta, _K );
-        G0 = _G0;
         s0 = Kokkos::sqrt( 5.0 * G0 / 9.0 / K / delta );
         bond_break_coeff = ( 1.0 + s0 ) * ( 1.0 + s0 );
     }
@@ -167,14 +140,6 @@ struct ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
         : base_type( _delta, _K )
         , base_temperature_type( _temp, _alpha, _temp0 )
     {
-        set_param( _delta, _K, _alpha, _temp0 );
-    }
-
-    void set_param( const double _delta, const double _K, const double _alpha,
-                    const double _temp0 )
-    {
-        base_type::set_param( _delta, _K );
-        base_temperature_type::set_param( _alpha, _temp0 );
     }
 };
 
@@ -232,14 +197,6 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureDependent, TemperatureType>
         : base_type( _delta, _K, _G0 )
         , base_temperature_type( _temp, _alpha, _temp0 )
     {
-        set_param( _delta, _K, _G0, _alpha, _temp0 );
-    }
-
-    void set_param( const double _delta, const double _K, const double _G0,
-                    const double _alpha, const double _temp0 )
-    {
-        base_type::set_param( _delta, _K, _G0 );
-        base_temperature_type::set_param( _alpha, _temp0 );
     }
 
     KOKKOS_INLINE_FUNCTION
@@ -301,17 +258,6 @@ struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>
         , base_temperature_type( _delta, _kappa, _cp,
                                  _constant_microconductivity )
     {
-        set_param( _delta, _K, _kappa, _cp, _alpha, _temp0,
-                   _constant_microconductivity );
-    }
-
-    void set_param( const double _delta, const double _K, const double _kappa,
-                    const double _cp, const double _alpha, const double _temp0,
-                    const bool _constant_microconductivity )
-    {
-        base_type::set_param( _delta, _K, _alpha, _temp0 );
-        base_temperature_type::set_param( _delta, _kappa, _cp,
-                                          _constant_microconductivity );
     }
 };
 
@@ -364,20 +310,9 @@ struct ForceModel<PMB, Fracture, DynamicTemperature, TemperatureType>
                 const double _temp0 = 0.0,
                 const bool _constant_microconductivity = true )
         : base_type( _delta, _K, _G0, _temp, _alpha, _temp0 )
+        , base_temperature_type( _delta, _kappa, _cp,
+                                 _constant_microconductivity )
     {
-        set_param( _delta, _K, _G0, _kappa, _cp, _alpha, _temp0 );
-        base_temperature_type::set_param( _delta, _kappa, _cp,
-                                          _constant_microconductivity );
-    }
-
-    void set_param( const double _delta, const double _K, const double _G0,
-                    const double _kappa, const double _cp, const double _alpha,
-                    const double _temp0,
-                    const bool _constant_microconductivity )
-    {
-        base_type::set_param( _delta, _K, _G0, _alpha, _temp0 );
-        base_temperature_type::set_param( _delta, _kappa, _cp,
-                                          _constant_microconductivity );
     }
 };
 

--- a/src/force/CabanaPD_Force_HertzianContact.hpp
+++ b/src/force/CabanaPD_Force_HertzianContact.hpp
@@ -54,75 +54,44 @@ class Force<MemorySpace, HertzianModel>
                            const ParticleType& particles,
                            ParallelType& neigh_op_tag )
     {
-        auto Rc = _model.Rc;
-        auto radius = _model.radius;
-        auto Es = _model.Es;
-        auto Rs = _model.Rs;
-        auto beta = _model.beta;
         const int n_frozen = particles.frozenOffset();
         const int n_local = particles.localOffset();
 
-        const double coeff_h_n = 4.0 / 3.0 * Es * Kokkos::sqrt( Rs );
-        const double coeff_h_d = -2.0 * Kokkos::sqrt( 5.0 / 6.0 ) * beta;
-
+        auto model = _model;
         const auto vol = particles.sliceVolume();
         const auto rho = particles.sliceDensity();
         const auto y = particles.sliceCurrentPosition();
         const auto vel = particles.sliceVelocity();
 
         _neigh_timer.start();
-        _neigh_list.build( y, n_frozen, n_local, Rc, 1.0, mesh_min, mesh_max );
+        _neigh_list.build( y, n_frozen, n_local, model.Rc, 1.0, mesh_min,
+                           mesh_max );
         _neigh_timer.stop();
 
         auto contact_full = KOKKOS_LAMBDA( const int i, const int j )
         {
-            double fcx_i = 0.0;
-            double fcy_i = 0.0;
-            double fcz_i = 0.0;
-
             double xi, r, s;
             double rx, ry, rz;
             getDistanceComponents( x, u, i, j, xi, r, s, rx, ry, rz );
-
             // Contact "overlap"
-            const double delta_n = ( r - 2.0 * radius );
+            const double delta_n = ( r - 2.0 * model.radius );
 
-            // Hertz normal force coefficient
-            double coeff = 0.0;
-            double Sn = 0.0;
-            if ( delta_n < 0.0 )
-            {
-                coeff = Kokkos::min(
-                    0.0, -coeff_h_n *
-                             Kokkos::pow( Kokkos::abs( delta_n ), 3.0 / 2.0 ) );
-                Sn = 2.0 * Es * Kokkos::sqrt( Rs * Kokkos::abs( delta_n ) );
-            }
-
-            coeff /= vol( i );
-
-            fcx_i = coeff * rx / r;
-            fcy_i = coeff * ry / r;
-            fcz_i = coeff * rz / r;
-
-            fc( i, 0 ) += fcx_i;
-            fc( i, 1 ) += fcy_i;
-            fc( i, 2 ) += fcz_i;
+            const double coeff_normal =
+                model.normalForceCoeff( delta_n, vol( i ) );
+            fc( i, 0 ) += coeff_normal * rx / r;
+            fc( i, 1 ) += coeff_normal * ry / r;
+            fc( i, 2 ) += coeff_normal * rz / r;
 
             // Hertz normal force damping component
             double vx, vy, vz, vn;
             getRelativeNormalVelocityComponents( vel, i, j, rx, ry, rz, r, vx,
                                                  vy, vz, vn );
 
-            double ms = ( rho( i ) * vol( i ) ) / 2.0;
-            double fnd = coeff_h_d * Kokkos::sqrt( Sn * ms ) * vn / vol( i );
-
-            fcx_i = fnd * rx / r;
-            fcy_i = fnd * ry / r;
-            fcz_i = fnd * rz / r;
-
-            fc( i, 0 ) += fcx_i;
-            fc( i, 1 ) += fcy_i;
-            fc( i, 2 ) += fcz_i;
+            const double coeff_damp =
+                model.dampingForceCoeff( delta_n, vn, vol( i ), rho( i ) );
+            fc( i, 0 ) += coeff_damp * rx / r;
+            fc( i, 1 ) += coeff_damp * ry / r;
+            fc( i, 2 ) += coeff_damp * rz / r;
         };
 
         _timer.start();

--- a/src/force/CabanaPD_Force_HertzianContact.hpp
+++ b/src/force/CabanaPD_Force_HertzianContact.hpp
@@ -73,25 +73,16 @@ class Force<MemorySpace, HertzianModel>
             double xi, r, s;
             double rx, ry, rz;
             getDistanceComponents( x, u, i, j, xi, r, s, rx, ry, rz );
-            // Contact "overlap"
-            const double delta_n = ( r - 2.0 * model.radius );
-
-            const double coeff_normal =
-                model.normalForceCoeff( delta_n, vol( i ) );
-            fc( i, 0 ) += coeff_normal * rx / r;
-            fc( i, 1 ) += coeff_normal * ry / r;
-            fc( i, 2 ) += coeff_normal * rz / r;
 
             // Hertz normal force damping component
             double vx, vy, vz, vn;
             getRelativeNormalVelocityComponents( vel, i, j, rx, ry, rz, r, vx,
                                                  vy, vz, vn );
 
-            const double coeff_damp =
-                model.dampingForceCoeff( delta_n, vn, vol( i ), rho( i ) );
-            fc( i, 0 ) += coeff_damp * rx / r;
-            fc( i, 1 ) += coeff_damp * ry / r;
-            fc( i, 2 ) += coeff_damp * rz / r;
+            const double coeff = model.forceCoeff( r, vn, vol( i ), rho( i ) );
+            fc( i, 0 ) += coeff * rx / r;
+            fc( i, 1 ) += coeff * ry / r;
+            fc( i, 2 ) += coeff * rz / r;
         };
 
         _timer.start();

--- a/src/force/CabanaPD_Force_PMB.hpp
+++ b/src/force/CabanaPD_Force_PMB.hpp
@@ -121,7 +121,7 @@ class Force<MemorySpace, ForceModel<PMB, Elastic, NoFracture, ModelParams...>>
 
             model.thermalStretch( s, i, j );
 
-            const double coeff = model.c * s * vol( j );
+            const double coeff = model.forceCoeff( s, vol( j ) );
             fx_i = coeff * rx / r;
             fy_i = coeff * ry / r;
             fz_i = coeff * rz / r;
@@ -160,9 +160,7 @@ class Force<MemorySpace, ForceModel<PMB, Elastic, NoFracture, ModelParams...>>
 
             model.thermalStretch( s, i, j );
 
-            // 0.25 factor is due to 1/2 from outside the integral and 1/2 from
-            // the integrand (pairwise potential).
-            double w = 0.25 * model.c * s * s * xi * vol( j );
+            double w = model.energy( s, xi, vol( j ) );
             W( i ) += w;
             Phi += w * vol( i );
         };
@@ -253,7 +251,8 @@ class Force<MemorySpace, ForceModel<PMB, Elastic, Fracture, ModelParams...>>
                 // Else if statement is only for performance.
                 else if ( mu( i, n ) > 0 )
                 {
-                    const double coeff = model.c * s * vol( j );
+                    const double coeff = model.forceCoeff( s, vol( j ) );
+
                     double muij = mu( i, n );
                     fx_i = muij * coeff * rx / r;
                     fy_i = muij * coeff * ry / r;
@@ -304,9 +303,7 @@ class Force<MemorySpace, ForceModel<PMB, Elastic, Fracture, ModelParams...>>
 
                 model.thermalStretch( s, i, j );
 
-                // 0.25 factor is due to 1/2 from outside the integral and 1/2
-                // from the integrand (pairwise potential).
-                double w = mu( i, n ) * 0.25 * model.c * s * s * xi * vol( j );
+                double w = mu( i, n ) * model.energy( s, xi, vol( j ) );
                 W( i ) += w;
 
                 phi_i += mu( i, n ) * vol( j );
@@ -381,7 +378,7 @@ class Force<MemorySpace,
 
             model.thermalStretch( linear_s, i, j );
 
-            const double coeff = model.c * linear_s * vol( j );
+            const double coeff = model.forceCoeff( linear_s, vol( j ) );
             fx_i = coeff * xi_x / xi;
             fy_i = coeff * xi_y / xi;
             fz_i = coeff * xi_z / xi;
@@ -420,9 +417,7 @@ class Force<MemorySpace,
 
             model.thermalStretch( linear_s, i, j );
 
-            // 0.25 factor is due to 1/2 from outside the integral and 1/2 from
-            // the integrand (pairwise potential).
-            double w = 0.25 * model.c * linear_s * linear_s * xi * vol( j );
+            double w = model.energy( linear_s, xi, vol( j ) );
             W( i ) += w;
             Phi += w * vol( i );
         };

--- a/src/force/CabanaPD_HertzianContact.hpp
+++ b/src/force/CabanaPD_HertzianContact.hpp
@@ -40,12 +40,6 @@ struct HertzianModel : public ContactModel
                    const double _E, const double _e )
         : ContactModel( 1.0, _Rc )
     {
-        set_param( _radius, _nu, _E, _e );
-    }
-
-    void set_param( const double _radius, const double _nu, const double _E,
-                    const double _e )
-    {
         nu = _nu;
         radius = _radius;
         Rs = 0.5 * radius;

--- a/src/force/CabanaPD_HertzianContact.hpp
+++ b/src/force/CabanaPD_HertzianContact.hpp
@@ -58,8 +58,12 @@ struct HertzianModel : public ContactModel
     }
 
     KOKKOS_INLINE_FUNCTION
-    auto normalForceCoeff( const double delta_n, const double vol ) const
+    auto forceCoeff( const double r, const double vn, const double vol,
+                     const double rho ) const
     {
+        // Contact "overlap"
+        const double delta_n = ( r - 2.0 * radius );
+
         // Hertz normal force coefficient
         double coeff = 0.0;
         if ( delta_n < 0.0 )
@@ -68,20 +72,14 @@ struct HertzianModel : public ContactModel
                 0.0,
                 -coeff_h_n * Kokkos::pow( Kokkos::abs( delta_n ), 3.0 / 2.0 ) );
         }
-
         coeff /= vol;
-        return coeff;
-    }
 
-    KOKKOS_INLINE_FUNCTION
-    auto dampingForceCoeff( const double delta_n, const double vn,
-                            const double vol, const double rho ) const
-    {
+        // Damping force coefficient
         double Sn = 0.0;
         if ( delta_n < 0.0 )
             Sn = 2.0 * Es * Kokkos::sqrt( Rs * Kokkos::abs( delta_n ) );
         double ms = ( rho * vol ) / 2.0;
-        double coeff = coeff_h_d * Kokkos::sqrt( Sn * ms ) * vn / vol;
+        coeff += coeff_h_d * Kokkos::sqrt( Sn * ms ) * vn / vol;
         return coeff;
     }
 };

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -174,7 +174,7 @@ double computeReferenceWeightedVolume( ModelType model, const int m,
                 double xi = sqrt( xi_x * xi_x + xi_y * xi_y + xi_z * xi_z );
                 if ( xi > 0.0 && xi < model.delta + 1e-14 )
                     weighted_volume +=
-                        model.influence_function( xi ) * xi * xi * vol;
+                        model.influenceFunction( xi ) * xi * xi * vol;
             }
     return weighted_volume;
 }
@@ -198,8 +198,7 @@ double computeReferenceDilatation( ModelType model, const int m,
 
                 if ( xi > 0.0 && xi < model.delta + 1e-14 )
                     theta += 3.0 / weighted_volume *
-                             model.influence_function( xi ) * s0 * xi * xi *
-                             vol;
+                             model.influenceFunction( xi ) * s0 * xi * xi * vol;
             }
     return theta;
 }
@@ -231,7 +230,7 @@ double computeReferenceDilatation( ModelType model, const int m,
 
                 if ( xi > 0.0 && xi < model.delta + 1e-14 )
                     theta += 3.0 / weighted_volume *
-                             model.influence_function( xi ) * s * xi * xi * vol;
+                             model.influenceFunction( xi ) * s * xi * xi * vol;
             }
     return theta;
 }
@@ -287,8 +286,8 @@ double computeReferenceStrainEnergyDensity(
                     W += ( 1.0 / num_neighbors ) * 0.5 * model.theta_coeff /
                              3.0 * ( theta * theta ) +
                          0.5 * ( model.s_coeff / weighted_volume ) *
-                             model.influence_function( xi ) * s0 * s0 * xi *
-                             xi * vol;
+                             model.influenceFunction( xi ) * s0 * s0 * xi * xi *
+                             vol;
                 }
             }
     return W;
@@ -335,7 +334,7 @@ double computeReferenceStrainEnergyDensity(
                     W += ( 1.0 / num_neighbors ) * 0.5 * model.theta_coeff /
                              3.0 * ( theta_i * theta_j ) +
                          0.5 * ( model.s_coeff / weighted_volume ) *
-                             model.influence_function( xi ) * s * s * xi * xi *
+                             model.influenceFunction( xi ) * s * s * xi * xi *
                              vol;
                 }
             }
@@ -384,7 +383,7 @@ double computeReferenceForceX(
                             model.s_coeff * s *
                                 ( 1.0 / weighted_volume +
                                   1.0 / weighted_volume ) ) *
-                          model.influence_function( xi ) * xi * vol * rx / r;
+                          model.influenceFunction( xi ) * xi * vol * rx / r;
                 }
             }
     return fx;


### PR DESCRIPTION
First step in moving towards single force classes per pair/state/contact forms

- Remove unused "set" functions and default constructors
- Move repeated force class details into the base pmb/lps models