### PR TITLE
Unify solvers

### DIFF
--- a/examples/mechanics/crack_branching.cpp
+++ b/examples/mechanics/crack_branching.cpp
@@ -113,8 +113,8 @@ void crackBranchingExample( const std::string filename )
     // ====================================================
     //                   Create solver
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
-        inputs, particles, force_model );
+    auto cabana_pd =
+        CabanaPD::createSolver<memory_space>( inputs, particles, force_model );
 
     // ====================================================
     //                Boundary conditions

--- a/examples/mechanics/elastic_wave.cpp
+++ b/examples/mechanics/elastic_wave.cpp
@@ -101,8 +101,8 @@ void elasticWaveExample( const std::string filename )
     // ====================================================
     //                   Create solver
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverNoFracture<memory_space>(
-        inputs, particles, force_model );
+    auto cabana_pd =
+        CabanaPD::createSolver<memory_space>( inputs, particles, force_model );
 
     // ====================================================
     //                   Simulation run

--- a/examples/mechanics/fragmenting_cylinder.cpp
+++ b/examples/mechanics/fragmenting_cylinder.cpp
@@ -142,7 +142,7 @@ void fragmentingCylinderExample( const std::string filename )
         r_c *= dx[0];
         CabanaPD::NormalRepulsionModel contact_model( delta, r_c, K );
 
-        auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
+        auto cabana_pd = CabanaPD::createSolver<memory_space>(
             inputs, particles, force_model, contact_model );
         cabana_pd->init();
         cabana_pd->run();
@@ -152,7 +152,7 @@ void fragmentingCylinderExample( const std::string filename )
     // ====================================================
     else
     {
-        auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
+        auto cabana_pd = CabanaPD::createSolver<memory_space>(
             inputs, particles, force_model );
         cabana_pd->init();
         cabana_pd->run();

--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -115,8 +115,8 @@ void kalthoffWinklerExample( const std::string filename )
     // ====================================================
     //                   Create solver
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
-        inputs, particles, force_model );
+    auto cabana_pd =
+        CabanaPD::createSolver<memory_space>( inputs, particles, force_model );
 
     // ====================================================
     //                Boundary conditions

--- a/examples/thermomechanics/thermal_crack.cpp
+++ b/examples/thermomechanics/thermal_crack.cpp
@@ -92,8 +92,8 @@ void thermalCrackExample( const std::string filename )
     // ====================================================
     //                   Create solver
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverFracture<memory_space>(
-        inputs, particles, force_model );
+    auto cabana_pd =
+        CabanaPD::createSolver<memory_space>( inputs, particles, force_model );
 
     // --------------------------------------------
     //                Thermal shock

--- a/examples/thermomechanics/thermal_deformation.cpp
+++ b/examples/thermomechanics/thermal_deformation.cpp
@@ -88,8 +88,8 @@ void thermalDeformationExample( const std::string filename )
     // ====================================================
     //                   Create solver
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverNoFracture<memory_space>(
-        inputs, particles, force_model );
+    auto cabana_pd =
+        CabanaPD::createSolver<memory_space>( inputs, particles, force_model );
 
     // ====================================================
     //                   Imposed field

--- a/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
@@ -97,8 +97,8 @@ void thermalDeformationHeatTransferExample( const std::string filename )
     // ====================================================
     //                   Create solver
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverNoFracture<memory_space>(
-        inputs, particles, force_model );
+    auto cabana_pd =
+        CabanaPD::createSolver<memory_space>( inputs, particles, force_model );
 
     // ====================================================
     //                   Boundary condition

--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -21,6 +21,14 @@ struct NoFracture
 struct Fracture
 {
 };
+template <class>
+struct is_fracture : public std::false_type
+{
+};
+template <>
+struct is_fracture<Fracture> : public std::true_type
+{
+};
 
 // Mechanics tags.
 struct Elastic

--- a/unit_test/tstHertz.hpp
+++ b/unit_test/tstHertz.hpp
@@ -122,8 +122,8 @@ void testHertzianContact( const std::string filename )
     // ====================================================
     //  Simulation run
     // ====================================================
-    auto cabana_pd = CabanaPD::createSolverNoFracture<memory_space>(
-        inputs, particles, contact_model );
+    auto cabana_pd = CabanaPD::createSolver<memory_space>( inputs, particles,
+                                                           contact_model );
     cabana_pd->init();
     cabana_pd->run();
 


### PR DESCRIPTION
Fracture details (bond table) now belongs to the force class itself (as with the neighbor list)

This enables matching arguments for each force/energy update and a single solver class 

Something to consider - this exposes a prenotch option that is not functional for a non-fracture system (guarded by a static assert)