### PR TITLE
Fixed comments in examples

### DIFF
--- a/examples/mechanics/crack_branching.cpp
+++ b/examples/mechanics/crack_branching.cpp
@@ -22,7 +22,7 @@
 void crackBranchingExample( const std::string filename )
 {
     // ====================================================
-    //             Use default Kokkos spaces
+    //               Choose Kokkos spaces
     // ====================================================
     using exec_space = Kokkos::DefaultExecutionSpace;
     using memory_space = typename exec_space::memory_space;
@@ -46,7 +46,6 @@ void crackBranchingExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    // FIXME: set halo width based on delta
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
 

--- a/examples/mechanics/elastic_wave.cpp
+++ b/examples/mechanics/elastic_wave.cpp
@@ -22,7 +22,7 @@
 void elasticWaveExample( const std::string filename )
 {
     // ====================================================
-    //             Use default Kokkos spaces
+    //               Choose Kokkos spaces
     // ====================================================
     using exec_space = Kokkos::DefaultExecutionSpace;
     using memory_space = typename exec_space::memory_space;

--- a/examples/mechanics/fragmenting_cylinder.cpp
+++ b/examples/mechanics/fragmenting_cylinder.cpp
@@ -22,7 +22,7 @@
 void fragmentingCylinderExample( const std::string filename )
 {
     // ====================================================
-    //             Use default Kokkos spaces
+    //               Choose Kokkos spaces
     // ====================================================
     using exec_space = Kokkos::DefaultExecutionSpace;
     using memory_space = typename exec_space::memory_space;
@@ -49,7 +49,6 @@ void fragmentingCylinderExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    // FIXME: set halo width based on delta
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
     std::array<int, 3> num_cells = inputs["num_cells"];

--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -23,7 +23,7 @@
 void kalthoffWinklerExample( const std::string filename )
 {
     // ====================================================
-    //             Use default Kokkos spaces
+    //               Choose Kokkos spaces
     // ====================================================
     using exec_space = Kokkos::DefaultExecutionSpace;
     using memory_space = typename exec_space::memory_space;
@@ -48,7 +48,6 @@ void kalthoffWinklerExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    // FIXME: set halo width based on delta
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
     std::array<int, 3> num_cells = inputs["num_cells"];

--- a/examples/mechanics/random_cracks.cpp
+++ b/examples/mechanics/random_cracks.cpp
@@ -22,7 +22,7 @@
 void randomCracksExample( const std::string filename )
 {
     // ====================================================
-    //             Use default Kokkos spaces
+    //               Choose Kokkos spaces
     // ====================================================
     using exec_space = Kokkos::DefaultExecutionSpace;
     using memory_space = typename exec_space::memory_space;

--- a/examples/thermomechanics/thermal_crack.cpp
+++ b/examples/thermomechanics/thermal_crack.cpp
@@ -23,7 +23,7 @@
 void thermalCrackExample( const std::string filename )
 {
     // ====================================================
-    //             Use default Kokkos spaces
+    //               Choose Kokkos spaces
     // ====================================================
     using exec_space = Kokkos::DefaultExecutionSpace;
     using memory_space = typename exec_space::memory_space;
@@ -54,7 +54,6 @@ void thermalCrackExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    // FIXME: set halo width based on delta
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
     std::array<int, 3> num_cells = inputs["num_cells"];

--- a/examples/thermomechanics/thermal_deformation.cpp
+++ b/examples/thermomechanics/thermal_deformation.cpp
@@ -22,7 +22,7 @@
 void thermalDeformationExample( const std::string filename )
 {
     // ====================================================
-    //             Use default Kokkos spaces
+    //               Choose Kokkos spaces
     // ====================================================
     using exec_space = Kokkos::DefaultExecutionSpace;
     using memory_space = typename exec_space::memory_space;
@@ -50,7 +50,6 @@ void thermalDeformationExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    // FIXME: set halo width based on delta
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
     std::array<int, 3> num_cells = inputs["num_cells"];

--- a/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
@@ -22,7 +22,7 @@
 void thermalDeformationHeatTransferExample( const std::string filename )
 {
     // ====================================================
-    //             Use default Kokkos spaces
+    //               Choose Kokkos spaces
     // ====================================================
     using exec_space = Kokkos::DefaultExecutionSpace;
     using memory_space = typename exec_space::memory_space;
@@ -52,7 +52,6 @@ void thermalDeformationHeatTransferExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    // FIXME: set halo width based on delta
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
     std::array<int, 3> num_cells = inputs["num_cells"];

--- a/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
@@ -23,7 +23,7 @@ void thermalDeformationHeatTransferPrenotchedExample(
     const std::string filename )
 {
     // ====================================================
-    //             Use default Kokkos spaces
+    //               Choose Kokkos spaces
     // ====================================================
     using exec_space = Kokkos::DefaultExecutionSpace;
     using memory_space = typename exec_space::memory_space;
@@ -54,7 +54,6 @@ void thermalDeformationHeatTransferPrenotchedExample(
     // ====================================================
     //                  Discretization
     // ====================================================
-    // FIXME: set halo width based on delta
     std::array<double, 3> low_corner = inputs["low_corner"];
     std::array<double, 3> high_corner = inputs["high_corner"];
     std::array<int, 3> num_cells = inputs["num_cells"];


### PR DESCRIPTION
Changed " Use default Kokkos spaces" to "Choose Kokkos spaces" in all examples
Removed " FIXME: set halo width based on delta" in all examples 