### PR TITLE
Check boundary condition particle count

### DIFF
--- a/examples/dem/powder_fill.cpp
+++ b/examples/dem/powder_fill.cpp
@@ -141,8 +141,8 @@ void powderSettlingExample( const std::string filename )
     {
         f( pid, 2 ) -= 9.8 * rho( pid );
     };
-    auto gravity = CabanaPD::createBodyTerm(
-        body_functor, particles->referenceOffset(), true );
+    auto gravity =
+        CabanaPD::createBodyTerm( body_functor, particles->size(), true );
 
     // ====================================================
     //                   Simulation run

--- a/examples/dem/powder_fill.cpp
+++ b/examples/dem/powder_fill.cpp
@@ -141,7 +141,8 @@ void powderSettlingExample( const std::string filename )
     {
         f( pid, 2 ) -= 9.8 * rho( pid );
     };
-    auto gravity = CabanaPD::createBodyTerm( body_functor, true );
+    auto gravity = CabanaPD::createBodyTerm(
+        body_functor, particles->referenceOffset(), true );
 
     // ====================================================
     //                   Simulation run

--- a/examples/thermomechanics/thermal_crack.cpp
+++ b/examples/thermomechanics/thermal_crack.cpp
@@ -147,8 +147,8 @@ void thermalCrackExample( const std::string filename )
         // Compute particle temperature
         temp( pid ) = temp_infinity + ( temp0 - temp_infinity ) * fx * fy;
     };
-    auto body_term = CabanaPD::createBodyTerm(
-        temp_func, particles->referenceOffset(), false );
+    auto body_term =
+        CabanaPD::createBodyTerm( temp_func, particles->size(), false );
 
     // ====================================================
     //                   Simulation run

--- a/examples/thermomechanics/thermal_crack.cpp
+++ b/examples/thermomechanics/thermal_crack.cpp
@@ -147,7 +147,8 @@ void thermalCrackExample( const std::string filename )
         // Compute particle temperature
         temp( pid ) = temp_infinity + ( temp0 - temp_infinity ) * fx * fy;
     };
-    auto body_term = CabanaPD::createBodyTerm( temp_func, false );
+    auto body_term = CabanaPD::createBodyTerm(
+        temp_func, particles->referenceOffset(), false );
 
     // ====================================================
     //                   Simulation run

--- a/examples/thermomechanics/thermal_deformation.cpp
+++ b/examples/thermomechanics/thermal_deformation.cpp
@@ -103,8 +103,8 @@ void thermalDeformationExample( const std::string filename )
     {
         temp( pid ) = temp0 + 5000.0 * ( x( pid, 1 ) - low_corner_y ) * t;
     };
-    auto body_term = CabanaPD::createBodyTerm(
-        temp_func, particles->referenceOffset(), false );
+    auto body_term =
+        CabanaPD::createBodyTerm( temp_func, particles->size(), false );
 
     // ====================================================
     //                   Simulation run

--- a/examples/thermomechanics/thermal_deformation.cpp
+++ b/examples/thermomechanics/thermal_deformation.cpp
@@ -103,7 +103,8 @@ void thermalDeformationExample( const std::string filename )
     {
         temp( pid ) = temp0 + 5000.0 * ( x( pid, 1 ) - low_corner_y ) * t;
     };
-    auto body_term = CabanaPD::createBodyTerm( temp_func, false );
+    auto body_term = CabanaPD::createBodyTerm(
+        temp_func, particles->referenceOffset(), false );
 
     // ====================================================
     //                   Simulation run

--- a/src/CabanaPD_BodyTerm.hpp
+++ b/src/CabanaPD_BodyTerm.hpp
@@ -16,6 +16,7 @@
 
 #include <Cabana_Core.hpp>
 
+#include <CabanaPD_Output.hpp>
 #include <CabanaPD_Timer.hpp>
 
 namespace CabanaPD
@@ -25,13 +26,16 @@ template <class UserFunctor>
 struct BodyTerm
 {
     UserFunctor _user_functor;
+    std::size_t _particle_count;
     bool _force_update;
     bool _update_frozen;
 
     Timer _timer;
 
-    BodyTerm( UserFunctor user, const bool force, const bool update_frozen )
+    BodyTerm( UserFunctor user, const std::size_t particle_count,
+              const bool force, const bool update_frozen )
         : _user_functor( user )
+        , _particle_count( particle_count )
         , _force_update( force )
         , _update_frozen( update_frozen )
     {
@@ -42,6 +46,9 @@ struct BodyTerm
     template <class ExecSpace, class ParticleType>
     void apply( ExecSpace, ParticleType& particles, const double time )
     {
+        checkParticleCount( _particle_count, particles.referenceOffset(),
+                            "BodyTerm" );
+
         _timer.start();
         std::size_t start = particles.frozenOffset();
         if ( _update_frozen )
@@ -61,10 +68,11 @@ struct BodyTerm
 };
 
 template <class UserFunctor>
-auto createBodyTerm( UserFunctor user_functor, const bool force_update,
-                     const bool update_frozen = false )
+auto createBodyTerm( UserFunctor user_functor, const std::size_t particle_count,
+                     const bool force_update, const bool update_frozen = false )
 {
-    return BodyTerm<UserFunctor>( user_functor, force_update, update_frozen );
+    return BodyTerm<UserFunctor>( user_functor, particle_count, force_update,
+                                  update_frozen );
 }
 
 } // namespace CabanaPD

--- a/src/CabanaPD_Boundary.hpp
+++ b/src/CabanaPD_Boundary.hpp
@@ -130,9 +130,6 @@ struct BoundaryIndexSpace<MemorySpace, RegionBoundary<GeometryType>>
 
     Timer _timer;
 
-    // Default for empty case.
-    BoundaryIndexSpace() {}
-
     // Construct from region (search for boundary particles).
     template <class ExecSpace, class Particles>
     BoundaryIndexSpace( ExecSpace exec_space, Particles particles,

--- a/src/CabanaPD_Output.hpp
+++ b/src/CabanaPD_Output.hpp
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 #include <mpi.h>
@@ -60,8 +61,7 @@ void log_err( t_stream& stream, t_last&& last )
     if ( print_rank() )
     {
         stream << last << std::endl;
-        throw std::runtime_error(
-            "Aborting after error from input. See error file." );
+        throw std::runtime_error( "Aborting after error." );
     }
 }
 
@@ -71,6 +71,16 @@ void log_err( t_stream& stream, t_head&& head, t_tail&&... tail )
     if ( print_rank() )
         stream << head;
     log_err( stream, std::forward<t_tail>( tail )... );
+}
+
+void checkParticleCount( std::size_t initial, std::size_t current,
+                         std::string name )
+{
+    if ( initial != current )
+        log_err( std::cout, "\nParticle size (", std::to_string( current ),
+                 ") does not match size when ", name, " was created (",
+                 std::to_string( initial ),
+                 ").\n Likely a slice() call is missing." );
 }
 
 } // namespace CabanaPD

--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -99,7 +99,7 @@ class Particles<MemorySpace, PMB, TemperatureIndependent, BaseOutput, Dimension>
     std::size_t frozen_offset = 0;
     std::size_t local_offset = 0;
     std::size_t num_ghost = 0;
-    std::size_t size = 0;
+    std::size_t _size = 0;
 
     // x, u, f (vector matching system dimension).
     using vector_type = Cabana::MemberTypes<double[dim]>;
@@ -464,7 +464,9 @@ class Particles<MemorySpace, PMB, TemperatureIndependent, BaseOutput, Dimension>
     auto numLocal() const { return local_offset - frozen_offset; }
     auto localOffset() const { return local_offset; }
     auto numGhost() const { return num_ghost; }
-    auto referenceOffset() const { return size; }
+    // This is currently size because contact ghosts are not added yet.
+    auto referenceOffset() const { return _size; }
+    auto size() const { return _size; }
     auto numGlobal() const { return num_global; }
 
     auto sliceReferencePosition()
@@ -567,7 +569,7 @@ class Particles<MemorySpace, PMB, TemperatureIndependent, BaseOutput, Dimension>
 
         local_offset = new_local;
         num_ghost = new_ghost;
-        size = new_local + new_ghost;
+        _size = new_local + new_ghost;
 
         _plist_x.aosoa().resize( referenceOffset() );
         _aosoa_u.resize( referenceOffset() );
@@ -577,9 +579,9 @@ class Particles<MemorySpace, PMB, TemperatureIndependent, BaseOutput, Dimension>
         _aosoa_other.resize( localOffset() );
         _aosoa_nofail.resize( referenceOffset() );
 
-        size = _plist_x.size();
+        _size = _plist_x.size();
         if ( create_frozen )
-            frozen_offset = size;
+            frozen_offset = _size;
         _timer.stop();
     };
 


### PR DESCRIPTION
If BC or body terms are created prior to ghost particles (or are otherwise out of date by the time it is applied in the solver) many issues ensue due to out of date slices

Change required for body term interface