### PR TITLE
Variadic boundary conditions

### DIFF
--- a/examples/mechanics/crack_branching.cpp
+++ b/examples/mechanics/crack_branching.cpp
@@ -86,8 +86,6 @@ void crackBranchingExample( const std::string filename )
     CabanaPD::RegionBoundary<CabanaPD::RectangularPrism> plane2(
         low_corner[0], high_corner[0], high_corner[1] - dy, high_corner[1] + dy,
         low_corner[2], high_corner[2] );
-    std::vector<CabanaPD::RegionBoundary<CabanaPD::RectangularPrism>> planes = {
-        plane1, plane2 };
 
     // ====================================================
     //            Custom particle initialization
@@ -130,8 +128,8 @@ void crackBranchingExample( const std::string filename )
         auto sign = std::abs( ypos ) / ypos;
         f( pid, 1 ) += b0 * sign;
     };
-    auto bc = createBoundaryCondition( bc_op, exec_space{}, *particles, planes,
-                                       true );
+    auto bc = createBoundaryCondition( bc_op, exec_space{}, *particles, true,
+                                       plane1, plane2 );
 
     // ====================================================
     //                   Simulation run

--- a/examples/mechanics/dogbone_tensile_test.cpp
+++ b/examples/mechanics/dogbone_tensile_test.cpp
@@ -189,10 +189,9 @@ void tensileTestExample( const std::string filename )
     //                Boundary conditions
     // ====================================================
     // Reset forces on both grips.
-    std::vector<CabanaPD::RegionBoundary<CabanaPD::RectangularPrism>> grips = {
-        left_grip, right_grip };
-    auto bc = createBoundaryCondition( CabanaPD::ForceValueBCTag{}, 0.0,
-                                       exec_space{}, *particles, grips, true );
+    auto bc =
+        createBoundaryCondition( CabanaPD::ForceValueBCTag{}, 0.0, exec_space{},
+                                 *particles, left_grip, right_grip );
 
     // ====================================================
     //                   Simulation run

--- a/examples/mechanics/random_cracks.cpp
+++ b/examples/mechanics/random_cracks.cpp
@@ -138,8 +138,6 @@ void randomCracksExample( const std::string filename )
     CabanaPD::RegionBoundary<CabanaPD::RectangularPrism> plane2(
         low_corner[0], high_corner[0], high_corner[1] - dy, high_corner[1] + dy,
         low_corner[2], high_corner[2] );
-    std::vector<CabanaPD::RegionBoundary<CabanaPD::RectangularPrism>> planes = {
-        plane1, plane2 };
 
     // ====================================================
     //            Custom particle initialization
@@ -182,8 +180,8 @@ void randomCracksExample( const std::string filename )
         auto sign = std::abs( ypos ) / ypos;
         f( pid, 1 ) += b0 * sign;
     };
-    auto bc = createBoundaryCondition( bc_op, exec_space{}, *particles, planes,
-                                       true );
+    auto bc = createBoundaryCondition( bc_op, exec_space{}, *particles, true,
+                                       plane1, plane2 );
 
     // ====================================================
     //                   Simulation run

--- a/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
@@ -123,9 +123,8 @@ void thermalDeformationHeatTransferExample( const std::string filename )
         temp( pid ) = 0.0;
     };
 
-    std::vector<plane_type> planes = { plane1, plane2 };
     auto bc = CabanaPD::createBoundaryCondition(
-        temp_bc, exec_space{}, *particles, planes, false, 1.0 );
+        temp_bc, exec_space{}, *particles, false, plane1, plane2 );
 
     // ====================================================
     //                   Simulation run

--- a/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
@@ -160,9 +160,8 @@ void thermalDeformationHeatTransferPrenotchedExample(
         temp( pid ) = 0.0;
     };
 
-    std::vector<plane_type> planes = { plane };
-    auto bc = CabanaPD::createBoundaryCondition(
-        temp_bc, exec_space{}, *particles, planes, false, 1.0 );
+    auto bc = CabanaPD::createBoundaryCondition( temp_bc, exec_space{},
+                                                 *particles, false, plane );
 
     // ====================================================
     //                   Simulation run


### PR DESCRIPTION
Remove the need for user-level vectors; enables different region types for a single BC

For now, remove the user-level allocation guess (not being used). Could be added back with extra constructors instead 