### PR TITLE
fixup: remove unused thermal stretch in heat transfer

### DIFF
--- a/src/CabanaPD_HeatTransfer.hpp
+++ b/src/CabanaPD_HeatTransfer.hpp
@@ -181,8 +181,6 @@ class HeatTransfer<MemorySpace, ForceModel<PMB, MechanicsType, Fracture,
                 double xi, r, s;
                 getDistance( x, u, i, j, xi, r, s );
 
-                model.thermalStretch( s, i, j );
-
                 // Only include unbroken bonds.
                 if ( mu( i, n ) > 0 )
                 {


### PR DESCRIPTION
Copied from forces; not used 