### PR TITLE
Rewrite model with tagged functor interfaces

### DIFF
--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -37,12 +37,21 @@ struct BaseForceModel
     BaseForceModel( const double _delta )
         : delta( _delta ){};
 
+    auto cutoff() const { return delta; }
+
     // Only needed for models which store bond properties.
     void updateBonds( const int, const int ) {}
 };
 
+struct BaseNoFractureModel
+{
+    using fracture_type = NoFracture;
+};
+
 struct BaseFractureModel
 {
+    using fracture_type = Fracture;
+
     double G0;
     double s0;
     double bond_break_coeff;
@@ -152,10 +161,10 @@ struct ThermalFractureModel
     using base_fracture_type = BaseFractureModel;
     using base_temperature_type =
         BaseTemperatureModel<TemperatureDependent, TemperatureType>;
-    using base_temperature_type::thermal_type;
+    using typename base_fracture_type::fracture_type;
+    using typename base_temperature_type::thermal_type;
 
     // Does not use the base bond_break_coeff.
-    using base_fracture_type::G0;
     using base_fracture_type::s0;
     using base_temperature_type::alpha;
     using base_temperature_type::temp0;

--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -17,6 +17,19 @@
 
 namespace CabanaPD
 {
+struct ForceCoeffTag
+{
+};
+struct EnergyTag
+{
+};
+struct CriticalStretchTag
+{
+};
+struct ThermalStretchTag
+{
+};
+
 struct BaseForceModel
 {
     double delta;
@@ -26,10 +39,56 @@ struct BaseForceModel
 
     // Only needed for models which store bond properties.
     void updateBonds( const int, const int ) {}
+};
+
+struct BaseFractureModel
+{
+    double G0;
+    double s0;
+    double bond_break_coeff;
+
+    BaseFractureModel( const double _delta, const double _K, const double _G0,
+                       const int influence_type = 1 )
+        : G0( _G0 )
+    {
+        s0 = Kokkos::sqrt( 5.0 * G0 / 9.0 / _K / _delta ); // 1/xi
+        if ( influence_type == 0 )
+            s0 = Kokkos::sqrt( 8.0 * G0 / 15.0 / _K / _delta ); // 1
+
+        bond_break_coeff = ( 1.0 + s0 ) * ( 1.0 + s0 );
+    };
+
+    // Constructor to work with plasticity.
+    BaseFractureModel( const double _G0, const double _s0 )
+        : G0( _G0 )
+        , s0( _s0 )
+    {
+        bond_break_coeff = ( 1.0 + s0 ) * ( 1.0 + s0 );
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    double operator()( CriticalStretchTag, const int, const int, const double r,
+                       const double xi ) const
+    {
+        return r * r >= bond_break_coeff * xi * xi;
+    }
+};
+
+template <typename ThermalType, typename... TemperatureType>
+struct BaseTemperatureModel;
+
+template <>
+struct BaseTemperatureModel<TemperatureIndependent>
+{
+    using thermal_type = TemperatureIndependent;
 
     // No-op for temperature.
     KOKKOS_INLINE_FUNCTION
-    void thermalStretch( double&, const int, const int ) const {}
+    double operator()( ThermalStretchTag, const int, const int,
+                       const double s ) const
+    {
+        return s;
+    }
 };
 
 template <class MemorySpace>
@@ -50,15 +109,16 @@ class BasePlasticity
 };
 
 template <typename TemperatureType>
-struct BaseTemperatureModel
+struct BaseTemperatureModel<TemperatureDependent, TemperatureType>
 {
+    using thermal_type = TemperatureDependent;
+
     double alpha;
     double temp0;
 
     // Temperature field
     TemperatureType temperature;
 
-    BaseTemperatureModel(){};
     BaseTemperatureModel( const TemperatureType _temp, const double _alpha,
                           const double _temp0 )
         : alpha( _alpha )
@@ -76,10 +136,51 @@ struct BaseTemperatureModel
 
     // Update stretch with temperature effects.
     KOKKOS_INLINE_FUNCTION
-    void thermalStretch( double& s, const int i, const int j ) const
+    double operator()( ThermalStretchTag, const int i, const int j,
+                       const double s ) const
     {
         double temp_avg = 0.5 * ( temperature( i ) + temperature( j ) ) - temp0;
-        s -= alpha * temp_avg;
+        return s - ( alpha * temp_avg );
+    }
+};
+
+template <typename TemperatureType>
+struct ThermalFractureModel
+    : public BaseFractureModel,
+      BaseTemperatureModel<TemperatureDependent, TemperatureType>
+{
+    using base_fracture_type = BaseFractureModel;
+    using base_temperature_type =
+        BaseTemperatureModel<TemperatureDependent, TemperatureType>;
+    using base_temperature_type::thermal_type;
+
+    // Does not use the base bond_break_coeff.
+    using base_fracture_type::G0;
+    using base_fracture_type::s0;
+    using base_temperature_type::alpha;
+    using base_temperature_type::temp0;
+    using base_temperature_type::temperature;
+
+    // Does not use the base critical stretch.
+    using base_temperature_type::operator();
+
+    ThermalFractureModel( const double _delta, const double _K,
+                          const double _G0, const TemperatureType _temp,
+                          const double _alpha, const double _temp0,
+                          const int influence_type = 1 )
+        : base_fracture_type( _delta, _K, _G0, influence_type )
+        , base_temperature_type( _temp, _alpha, _temp0 )
+    {
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    double operator()( CriticalStretchTag, const int i, const int j,
+                       const double r, const double xi ) const
+    {
+        double temp_avg = 0.5 * ( temperature( i ) + temperature( j ) ) - temp0;
+        double bond_break_coeff =
+            ( 1.0 + s0 + alpha * temp_avg ) * ( 1.0 + s0 + alpha * temp_avg );
+        return r * r >= bond_break_coeff * xi * xi;
     }
 };
 
@@ -88,6 +189,8 @@ struct BaseTemperatureModel
 // above).
 struct BaseDynamicTemperatureModel
 {
+    using thermal_type = DynamicTemperature;
+
     double delta;
 
     double thermal_coeff;

--- a/src/CabanaPD_HeatTransfer.hpp
+++ b/src/CabanaPD_HeatTransfer.hpp
@@ -144,7 +144,7 @@ class HeatTransfer<MemorySpace, ForceModel<PMB, MechanicsType, Fracture,
                   const model_type model )
         : base_type( half_neigh, force,
                      typename base_type::model_type(
-                         PMB{}, NoFracture{}, model.delta, model.K,
+                         PMB{}, NoFracture{}, model.cutoff(), model.K,
                          model.temperature, model.kappa, model.cp, model.alpha,
                          model.temp0, model.constant_microconductivity ) )
         , fracture_type( force.getBrokenBonds() )

--- a/src/force/CabanaPD_PMB.hpp
+++ b/src/force/CabanaPD_PMB.hpp
@@ -96,7 +96,7 @@ class Force<MemorySpace,
     template <class ParticleType>
     Force( const bool half_neigh, const ParticleType& particles,
            const model_type model )
-        : base_type( half_neigh, model.delta, particles )
+        : base_type( half_neigh, model.cutoff(), particles )
         , _model( model )
     {
     }
@@ -263,7 +263,7 @@ class Force<MemorySpace,
     template <class ParticleType>
     Force( const bool half_neigh, const ParticleType& particles,
            const model_type model )
-        : base_type( half_neigh, model.delta, particles )
+        : base_type( half_neigh, model.cutoff(), particles )
         , fracture_type( particles.localOffset(),
                          base_type::getMaxLocalNeighbors() )
         , _model( model )

--- a/src/force/CabanaPD_PMB.hpp
+++ b/src/force/CabanaPD_PMB.hpp
@@ -122,9 +122,9 @@ class Force<MemorySpace,
             double rx, ry, rz;
             getDistance( x, u, i, j, xi, r, s, rx, ry, rz );
 
-            model.thermalStretch( s, i, j );
+            s = model( ThermalStretchTag{}, i, j, s );
 
-            const double coeff = model.forceCoeff( i, j, s, vol( j ) );
+            const double coeff = model( ForceCoeffTag{}, i, j, s, vol( j ) );
             fx_i = coeff * rx / r;
             fy_i = coeff * ry / r;
             fz_i = coeff * rz / r;
@@ -161,9 +161,9 @@ class Force<MemorySpace,
             double xi, r, s;
             getDistance( x, u, i, j, xi, r, s );
 
-            model.thermalStretch( s, i, j );
+            s = model( ThermalStretchTag{}, i, j, s );
 
-            double w = model.energy( i, j, s, xi, vol( j ) );
+            double w = model( EnergyTag{}, i, j, s, xi, vol( j ) );
             W( i ) += w;
             Phi += w * vol( i );
         };
@@ -201,10 +201,10 @@ class Force<MemorySpace,
             double xi_x, xi_y, xi_z;
             getDistance( x, u, i, j, xi, r, s, rx, ry, rz, xi_x, xi_y, xi_z );
 
-            model.thermalStretch( s, i, j );
+            s = model( ThermalStretchTag{}, i, j, s );
 
-            double coeff = model.forceCoeff( i, j, s, vol( j ) );
-            coeff *= 0.5;
+            const double coeff =
+                0.5 * model( ForceCoeffTag{}, i, j, s, vol( j ) );
             const double fx_i = coeff * rx / r;
             const double fy_i = coeff * ry / r;
             const double fz_i = coeff * rz / r;
@@ -313,18 +313,20 @@ class Force<MemorySpace,
                 double rx, ry, rz;
                 getDistance( x, u, i, j, xi, r, s, rx, ry, rz );
 
-                model.thermalStretch( s, i, j );
+                s = model( ThermalStretchTag{}, i, j, s );
 
                 // Break if beyond critical stretch unless in no-fail zone.
-                if ( model.criticalStretch( i, j, r, xi ) && !nofail( i ) &&
-                     !nofail( j ) )
+                if ( model( CriticalStretchTag{}, i, j, r, xi ) &&
+                     !nofail( i ) && !nofail( j ) )
                 {
                     mu( i, n ) = 0;
                 }
                 // Else if statement is only for performance.
                 else if ( mu( i, n ) > 0 )
                 {
-                    const double coeff = model.forceCoeff( i, n, s, vol( j ) );
+                    const double coeff =
+                        model( ForceCoeffTag{}, i, n, s, vol( j ) );
+
                     double muij = mu( i, n );
                     fx_i = muij * coeff * rx / r;
                     fy_i = muij * coeff * ry / r;
@@ -374,9 +376,10 @@ class Force<MemorySpace,
                 double xi, r, s;
                 getDistance( x, u, i, j, xi, r, s );
 
-                model.thermalStretch( s, i, j );
+                s = model( ThermalStretchTag{}, i, j, s );
 
-                double w = mu( i, n ) * model.energy( i, n, s, xi, vol( j ) );
+                double w =
+                    mu( i, n ) * model( EnergyTag{}, i, j, s, xi, vol( j ) );
                 W( i ) += w;
 
                 phi_i += mu( i, n ) * vol( j );
@@ -427,10 +430,10 @@ class Force<MemorySpace,
                 getDistance( x, u, i, j, xi, r, s, rx, ry, rz, xi_x, xi_y,
                              xi_z );
 
-                model.thermalStretch( s, i, j );
+                s = model( ThermalStretchTag{}, i, j, s );
 
-                double coeff = model.forceCoeff( i, n, s, vol( j ) );
-                coeff *= 0.5;
+                const double coeff =
+                    0.5 * model( ForceCoeffTag{}, i, n, s, vol( j ) );
                 const double muij = mu( i, n );
                 const double fx_i = muij * coeff * rx / r;
                 const double fy_i = muij * coeff * ry / r;
@@ -486,7 +489,7 @@ class Force<MemorySpace,
     template <class ParticleType>
     Force( const bool half_neigh, const ParticleType& particles,
            const model_type model )
-        : base_type( half_neigh, model.delta, particles )
+        : base_type( half_neigh, model.cutoff(), particles )
         , _model( model )
     {
     }
@@ -512,9 +515,10 @@ class Force<MemorySpace,
             double xi_x, xi_y, xi_z;
             getLinearizedDistance( x, u, i, j, xi, linear_s, xi_x, xi_y, xi_z );
 
-            model.thermalStretch( linear_s, i, j );
+            linear_s = model( ThermalStretchTag{}, i, j, linear_s );
 
-            const double coeff = model.forceCoeff( i, j, linear_s, vol( j ) );
+            const double coeff =
+                model( ForceCoeffTag{}, i, j, linear_s, vol( j ) );
             fx_i = coeff * xi_x / xi;
             fy_i = coeff * xi_y / xi;
             fz_i = coeff * xi_z / xi;
@@ -551,9 +555,9 @@ class Force<MemorySpace,
             double xi, linear_s;
             getLinearizedDistance( x, u, i, j, xi, linear_s );
 
-            model.thermalStretch( linear_s, i, j );
+            linear_s = model( ThermalStretchTag{}, i, j, linear_s );
 
-            double w = model.energy( i, j, linear_s, xi, vol( j ) );
+            double w = model( EnergyTag{}, i, j, linear_s, xi, vol( j ) );
             W( i ) += w;
             Phi += w * vol( i );
         };
@@ -590,10 +594,10 @@ class Force<MemorySpace,
             double xi_x, xi_y, xi_z;
             getLinearizedDistance( x, u, i, j, xi, linear_s, xi_x, xi_y, xi_z );
 
-            model.thermalStretch( linear_s, i, j );
+            linear_s = model( ThermalStretchTag{}, i, j, linear_s );
 
-            double coeff = model.forceCoeff( i, j, linear_s, vol( j ) );
-            coeff *= 0.5;
+            const double coeff =
+                0.5 * model( ForceCoeffTag{}, i, j, linear_s, vol( j ) );
             const double fx_i = coeff * xi_x / xi;
             const double fy_i = coeff * xi_y / xi;
             const double fz_i = coeff * xi_z / xi;

--- a/src/force_models/CabanaPD_LPS.hpp
+++ b/src/force_models/CabanaPD_LPS.hpp
@@ -27,8 +27,6 @@ struct BaseForceModelLPS<Elastic> : public BaseForceModel
 {
     using base_type = BaseForceModel;
     using base_model = LPS;
-    using fracture_type = NoFracture;
-    using thermal_type = TemperatureIndependent;
 
     using base_type::delta;
 
@@ -124,7 +122,6 @@ struct ForceModel<LPS, Elastic, NoFracture, TemperatureIndependent>
     using thermal_type = typename base_temperature_type::thermal_type;
 
     using base_type::base_type;
-    using base_type::delta;
     using base_type::operator();
     using base_temperature_type::operator();
 };
@@ -149,10 +146,8 @@ struct ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>
     using base_fracture_type::s0;
     using base_type::base_type;
     using base_type::delta;
-    using base_type::G;
     using base_type::influence_type;
     using base_type::K;
-    using base_type::s_coeff;
 
     using base_type::operator();
     using base_fracture_type::operator();
@@ -213,13 +208,6 @@ struct ForceModel<LinearLPS, Elastic, NoFracture, TemperatureIndependent>
     {
     }
 
-    using base_type::delta;
-    using base_type::G;
-    using base_type::influence_type;
-    using base_type::K;
-    using base_type::s_coeff;
-    using base_type::theta_coeff;
-
     using base_type::base_type;
     using base_type::operator();
 };
@@ -241,17 +229,6 @@ struct ForceModel<LinearLPS, Elastic, Fracture, TemperatureIndependent>
         : base_type( base_model{}, std::forward<Args>( args )... )
     {
     }
-
-    using base_type::delta;
-    using base_type::G;
-    using base_type::influence_type;
-    using base_type::K;
-    using base_type::s_coeff;
-    using base_type::theta_coeff;
-
-    using base_type::bond_break_coeff;
-    using base_type::G0;
-    using base_type::s0;
 
     using base_type::base_type;
     using base_type::operator();

--- a/src/force_models/CabanaPD_LPS.hpp
+++ b/src/force_models/CabanaPD_LPS.hpp
@@ -19,8 +19,11 @@
 
 namespace CabanaPD
 {
+template <typename MechanicsModelType>
+struct BaseForceModelLPS;
+
 template <>
-struct ForceModel<LPS, Elastic, NoFracture> : public BaseForceModel
+struct BaseForceModelLPS<Elastic> : public BaseForceModel
 {
     using base_type = BaseForceModel;
     using base_model = LPS;
@@ -36,8 +39,8 @@ struct ForceModel<LPS, Elastic, NoFracture> : public BaseForceModel
     double theta_coeff;
     double s_coeff;
 
-    ForceModel( LPS, NoFracture, const double _delta, const double _K,
-                const double _G, const int _influence = 0 )
+    BaseForceModelLPS( LPS, NoFracture, const double _delta, const double _K,
+                       const double _G, const int _influence = 0 )
         : base_type( _delta )
         , influence_type( _influence )
         , K( _K )
@@ -46,8 +49,9 @@ struct ForceModel<LPS, Elastic, NoFracture> : public BaseForceModel
         init();
     }
 
-    ForceModel( LPS, Elastic, NoFracture, const double _delta, const double _K,
-                const double _G, const int _influence = 0 )
+    BaseForceModelLPS( LPS, Elastic, NoFracture, const double _delta,
+                       const double _K, const double _G,
+                       const int _influence = 0 )
         : base_type( _delta )
         , influence_type( _influence )
         , K( _K )
@@ -84,7 +88,8 @@ struct ForceModel<LPS, Elastic, NoFracture> : public BaseForceModel
         return 3.0 * theta_i / m_i;
     }
 
-    KOKKOS_INLINE_FUNCTION auto forceCoeff( const double s, const double xi,
+    KOKKOS_INLINE_FUNCTION auto operator()( ForceCoeffTag, const int, const int,
+                                            const double s, const double xi,
                                             const double vol, const double m_i,
                                             const double m_j,
                                             const double theta_i,
@@ -96,9 +101,9 @@ struct ForceModel<LPS, Elastic, NoFracture> : public BaseForceModel
     }
 
     KOKKOS_INLINE_FUNCTION
-    auto energy( const double s, const double xi, const double vol,
-                 const double m_i, const double theta_i,
-                 const double num_bonds ) const
+    auto operator()( EnergyTag, const int, const int, const double s,
+                     const double xi, const double vol, const double m_i,
+                     const double theta_i, const double num_bonds ) const
     {
         return 1.0 / num_bonds * 0.5 * theta_coeff / 3.0 *
                    ( theta_i * theta_i ) +
@@ -108,28 +113,55 @@ struct ForceModel<LPS, Elastic, NoFracture> : public BaseForceModel
 };
 
 template <>
-struct ForceModel<LPS, Elastic, Fracture>
-    : public ForceModel<LPS, Elastic, NoFracture>
+struct ForceModel<LPS, Elastic, NoFracture, TemperatureIndependent>
+    : public BaseForceModelLPS<Elastic>,
+      BaseTemperatureModel<TemperatureIndependent>
+
 {
-    using base_type = ForceModel<LPS, Elastic, NoFracture>;
+    using base_type = BaseForceModelLPS<Elastic>;
+    using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
+    using fracture_type = NoFracture;
+    using thermal_type = typename base_temperature_type::thermal_type;
+
+    using base_type::base_type;
+    using base_type::delta;
+    using base_type::operator();
+    using base_temperature_type::operator();
+};
+
+template <>
+struct ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>
+    : public BaseForceModelLPS<Elastic>,
+      BaseFractureModel,
+      BaseTemperatureModel<TemperatureIndependent>
+{
+    using base_type = BaseForceModelLPS<Elastic>;
+    using base_fracture_type = BaseFractureModel;
+    using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
+
+    using model_type = LPS;
     using base_model = typename base_type::base_model;
     using fracture_type = Fracture;
-    using thermal_type = base_type::thermal_type;
+    using thermal_type = base_temperature_type::thermal_type;
 
+    using base_fracture_type::bond_break_coeff;
+    using base_fracture_type::G0;
+    using base_fracture_type::s0;
+    using base_type::base_type;
     using base_type::delta;
     using base_type::G;
     using base_type::influence_type;
     using base_type::K;
     using base_type::s_coeff;
-    using base_type::theta_coeff;
-    double G0;
-    double s0;
-    double bond_break_coeff;
+
+    using base_type::operator();
+    using base_fracture_type::operator();
+    using base_temperature_type::operator();
 
     ForceModel( LPS model, const double _delta, const double _K,
                 const double _G, const double _G0, const int _influence = 0 )
         : base_type( model, NoFracture{}, _delta, _K, _G, _influence )
-        , G0( _G0 )
+        , base_fracture_type( _delta, _K, _G0, _influence )
     {
         init();
     }
@@ -137,7 +169,7 @@ struct ForceModel<LPS, Elastic, Fracture>
     ForceModel( LPS model, Fracture, const double _delta, const double _K,
                 const double _G, const double _G0, const int _influence = 0 )
         : base_type( model, NoFracture{}, _delta, _K, _G, _influence )
-        , G0( _G0 )
+        , base_fracture_type( _delta, _K, _G0, _influence )
     {
         init();
     }
@@ -146,7 +178,7 @@ struct ForceModel<LPS, Elastic, Fracture>
                 const double _K, const double _G, const double _G0,
                 const int _influence = 0 )
         : base_type( model, elastic, NoFracture{}, _delta, _K, _G, _influence )
-        , G0( _G0 )
+        , base_fracture_type( _delta, _K, _G0, _influence )
     {
         init();
     }
@@ -166,13 +198,14 @@ struct ForceModel<LPS, Elastic, Fracture>
 };
 
 template <>
-struct ForceModel<LinearLPS, Elastic, NoFracture>
-    : public ForceModel<LPS, Elastic, NoFracture>
+struct ForceModel<LinearLPS, Elastic, NoFracture, TemperatureIndependent>
+    : public ForceModel<LPS, Elastic, NoFracture, TemperatureIndependent>
 {
-    using base_type = ForceModel<LPS, Elastic, NoFracture>;
+    using base_type =
+        ForceModel<LPS, Elastic, NoFracture, TemperatureIndependent>;
+    using base_temperature_type = typename base_type::base_temperature_type;
     using base_model = typename base_type::base_model;
     using fracture_type = typename base_type::fracture_type;
-    using thermal_type = base_type::thermal_type;
 
     template <typename... Args>
     ForceModel( LinearLPS, Args&&... args )
@@ -186,13 +219,19 @@ struct ForceModel<LinearLPS, Elastic, NoFracture>
     using base_type::K;
     using base_type::s_coeff;
     using base_type::theta_coeff;
+
+    using base_type::base_type;
+    using base_type::operator();
 };
 
 template <>
-struct ForceModel<LinearLPS, Elastic, Fracture>
-    : public ForceModel<LPS, Elastic, Fracture>
+struct ForceModel<LinearLPS, Elastic, Fracture, TemperatureIndependent>
+    : public ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>
 {
-    using base_type = ForceModel<LPS, Elastic, Fracture>;
+    using base_type =
+        ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>;
+
+    using model_type = LinearLPS;
     using base_model = typename base_type::base_model;
     using fracture_type = typename base_type::fracture_type;
     using thermal_type = base_type::thermal_type;
@@ -213,6 +252,9 @@ struct ForceModel<LinearLPS, Elastic, Fracture>
     using base_type::bond_break_coeff;
     using base_type::G0;
     using base_type::s0;
+
+    using base_type::base_type;
+    using base_type::operator();
 };
 
 template <typename ModelType>

--- a/src/force_models/CabanaPD_PMB.hpp
+++ b/src/force_models/CabanaPD_PMB.hpp
@@ -30,8 +30,7 @@ struct BaseForceModelPMB<Elastic> : public BaseForceModel
     using base_type = BaseForceModel;
     using model_type = PMB;
     using base_model = PMB;
-    using fracture_type = NoFracture;
-    using thermal_type = TemperatureIndependent;
+    using mechanics_type = Elastic;
 
     using base_type::delta;
 
@@ -79,8 +78,7 @@ struct BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>
     using base_type = BaseForceModelPMB<Elastic>;
     using base_fracture_type = BaseFractureModel;
     using base_plasticity_type = BasePlasticity<MemorySpace>;
-    using base_type::base_model;
-    using fracture_type = Fracture;
+
     using mechanics_type = ElasticPerfectlyPlastic;
 
     using base_plasticity_type::_s_p;
@@ -144,15 +142,11 @@ struct BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>
 template <>
 struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
     : public BaseForceModelPMB<Elastic>,
+      BaseNoFractureModel,
       BaseTemperatureModel<TemperatureIndependent>
 {
     using base_type = BaseForceModelPMB<Elastic>;
     using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
-
-    using base_type::base_model;
-    using fracture_type = NoFracture;
-    using mechanics_type = Elastic;
-    using thermal_type = base_type::thermal_type;
 
     using base_type::base_type;
     using base_type::delta;
@@ -169,18 +163,6 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
     using base_type = BaseForceModelPMB<Elastic>;
     using base_fracture_type = BaseFractureModel;
     using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
-
-    using model_type = typename base_type::model_type;
-    using base_type::base_model;
-    using fracture_type = Fracture;
-    using thermal_type = base_temperature_type::thermal_type;
-
-    using base_fracture_type::bond_break_coeff;
-    using base_fracture_type::G0;
-    using base_fracture_type::s0;
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
 
     using base_type::operator();
     using base_fracture_type::operator();
@@ -219,20 +201,6 @@ struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
     using base_type = BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>;
     using base_fracture_type = BaseFractureModel;
     using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
-    using typename base_type::base_model;
-    using fracture_type = Fracture;
-    using mechanics_type = ElasticPerfectlyPlastic;
-    using typename base_type::thermal_type;
-
-    using base_fracture_type::bond_break_coeff;
-    using base_fracture_type::G0;
-    using base_fracture_type::s0;
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
-
-    using base_type::_s_p;
-    double s_Y;
 
     using base_type::operator();
     using base_fracture_type::operator();
@@ -258,18 +226,10 @@ struct ForceModel<LinearPMB, Elastic, NoFracture, TemperatureIndependent>
 {
     using base_type =
         ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>;
-
     using model_type = LinearPMB;
-    using base_type::base_model;
-    using base_type::fracture_type;
-    using thermal_type = typename base_temperature_type::thermal_type;
 
     using base_type::base_type;
     using base_type::operator();
-
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
 
     template <typename... Args>
     ForceModel( LinearPMB, Args... args )
@@ -286,19 +246,7 @@ struct ForceModel<LinearPMB, Elastic, Fracture, TemperatureIndependent>
         ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>;
 
     using model_type = LinearPMB;
-    using base_type::base_model;
-    using base_type::fracture_type;
-    using mechanics_type = Elastic;
-    using thermal_type = base_type::thermal_type;
 
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
-
-    using base_type::base_type;
-    using base_type::bond_break_coeff;
-    using base_type::G0;
-    using base_type::s0;
     using base_type::operator();
 
     template <typename... Args>
@@ -336,24 +284,12 @@ template <typename TemperatureType>
 struct ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
                   TemperatureType>
     : public BaseForceModelPMB<Elastic>,
+      BaseNoFractureModel,
       BaseTemperatureModel<TemperatureDependent, TemperatureType>
 {
     using base_type = BaseForceModelPMB<Elastic>;
     using base_temperature_type =
         BaseTemperatureModel<TemperatureDependent, TemperatureType>;
-
-    using model_type = PMB;
-    using base_model = PMB;
-    using fracture_type = NoFracture;
-    using thermal_type = TemperatureDependent;
-
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
-
-    // Thermal parameters
-    using base_temperature_type::alpha;
-    using base_temperature_type::temp0;
 
     using base_type::operator();
     using base_temperature_type::operator();
@@ -374,23 +310,6 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureDependent, TemperatureType>
 {
     using base_type = BaseForceModelPMB<Elastic>;
     using base_temperature_type = ThermalFractureModel<TemperatureType>;
-    using base_type::base_model;
-    using base_type::fracture_type;
-    using mechanics_type = Elastic;
-    using thermal_type = TemperatureDependent;
-
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
-
-    // Does not use the base bond_break_coeff.
-    using base_temperature_type::G0;
-    using base_temperature_type::s0;
-
-    // Thermal parameters
-    using base_temperature_type::alpha;
-    using base_temperature_type::temp0;
-    using base_temperature_type::temperature;
 
     using base_type::operator();
     using base_temperature_type::operator();
@@ -415,11 +334,6 @@ struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, TemperatureDependent,
     using base_type = BaseForceModelPMB<ElasticPerfectlyPlastic,
                                         typename TemperatureType::memory_space>;
     using base_temperature_type = ThermalFractureModel<TemperatureType>;
-
-    using model_type = PMB;
-    using base_type::base_model;
-    using fracture_type = Fracture;
-    using thermal_type = TemperatureDependent;
 
     using base_type::operator();
     using base_temperature_type::operator();
@@ -450,6 +364,7 @@ ForceModel( ModelType, const double delta, const double K, const double _G0,
 template <typename TemperatureType>
 struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>
     : public BaseForceModelPMB<Elastic>,
+      BaseNoFractureModel,
       BaseTemperatureModel<TemperatureDependent, TemperatureType>,
       BaseDynamicTemperatureModel
 {
@@ -458,22 +373,8 @@ struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>
         BaseTemperatureModel<TemperatureDependent, TemperatureType>;
     using base_heat_transfer_type = BaseDynamicTemperatureModel;
 
-    using model_type = PMB;
-    using base_model = PMB;
-    using fracture_type = NoFracture;
+    // Necessary to distinguish between TemperatureDependent
     using thermal_type = DynamicTemperature;
-
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
-
-    // Thermal parameters
-    using base_heat_transfer_type::cp;
-    using base_heat_transfer_type::kappa;
-    using base_heat_transfer_type::thermal_coeff;
-    using base_temperature_type::alpha;
-    using base_temperature_type::temp0;
-    using base_temperature_type::temperature;
 
     using base_type::operator();
     using base_temperature_type::operator();
@@ -511,25 +412,8 @@ struct ForceModel<ModelType, Elastic, Fracture, DynamicTemperature,
     using base_temperature_type = ThermalFractureModel<TemperatureType>;
     using base_heat_transfer_type = BaseDynamicTemperatureModel;
 
-    using model_type = PMB;
-    using base_type::base_model;
-    using fracture_type = Fracture;
+    // Necessary to distinguish between TemperatureDependent
     using thermal_type = DynamicTemperature;
-
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
-
-    using base_temperature_type::G0;
-    using base_temperature_type::s0;
-
-    // Thermal parameters
-    using base_heat_transfer_type::cp;
-    using base_heat_transfer_type::kappa;
-    using base_heat_transfer_type::thermal_coeff;
-    using base_temperature_type::alpha;
-    using base_temperature_type::temp0;
-    using base_temperature_type::temperature;
 
     using base_type::operator();
     using base_temperature_type::operator();

--- a/src/force_models/CabanaPD_PMB.hpp
+++ b/src/force_models/CabanaPD_PMB.hpp
@@ -20,11 +20,15 @@
 
 namespace CabanaPD
 {
+
+template <typename MechanicsModelType, typename... DataTypes>
+struct BaseForceModelPMB;
+
 template <>
-struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
-    : public BaseForceModel
+struct BaseForceModelPMB<Elastic> : public BaseForceModel
 {
     using base_type = BaseForceModel;
+    using model_type = PMB;
     using base_model = PMB;
     using fracture_type = NoFracture;
     using thermal_type = TemperatureIndependent;
@@ -34,14 +38,15 @@ struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
     double c;
     double K;
 
-    ForceModel( PMB, NoFracture, const double delta, const double _K )
+    BaseForceModelPMB( PMB, NoFracture, const double delta, const double _K )
         : base_type( delta )
         , K( _K )
     {
         init();
     }
 
-    ForceModel( PMB, Elastic, NoFracture, const double delta, const double _K )
+    BaseForceModelPMB( PMB, Elastic, NoFracture, const double delta,
+                       const double _K )
         : base_type( delta )
         , K( _K )
     {
@@ -51,15 +56,15 @@ struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
     void init() { c = 18.0 * K / ( pi * delta * delta * delta * delta ); }
 
     KOKKOS_INLINE_FUNCTION
-    auto forceCoeff( const int, const int, const double s,
+    auto operator()( ForceCoeffTag, const int, const int, const double s,
                      const double vol ) const
     {
         return c * s * vol;
     }
 
     KOKKOS_INLINE_FUNCTION
-    auto energy( const int, const int, const double s, const double xi,
-                 const double vol ) const
+    auto operator()( EnergyTag, const int, const int, const double s,
+                     const double xi, const double vol ) const
     {
         // 0.25 factor is due to 1/2 from outside the integral and 1/2 from
         // the integrand (pairwise potential).
@@ -67,101 +72,34 @@ struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
     }
 };
 
-template <>
-struct ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
-    : public ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
-{
-    using base_type = ForceModel<PMB, Elastic, NoFracture>;
-    using base_model = typename base_type::base_model;
-    using fracture_type = Fracture;
-    using mechanics_type = Elastic;
-    using thermal_type = base_type::thermal_type;
-
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
-    double G0;
-    double s0;
-    double bond_break_coeff;
-
-    ForceModel( PMB model, const double delta, const double K,
-                const double _G0 )
-        : base_type( model, NoFracture{}, delta, K )
-        , G0( _G0 )
-    {
-        init();
-    }
-
-    ForceModel( PMB model, Elastic elastic, const double delta, const double K,
-                const double _G0 )
-        : base_type( model, elastic, NoFracture{}, delta, K )
-        , G0( _G0 )
-    {
-        init();
-    }
-
-    void init()
-    {
-        s0 = Kokkos::sqrt( 5.0 * G0 / 9.0 / K / delta );
-        bond_break_coeff = ( 1.0 + s0 ) * ( 1.0 + s0 );
-    }
-
-    // Constructor to work with plasticity.
-    ForceModel( PMB model, Elastic elastic, const double delta, const double K,
-                const double _G0, const double _s0 )
-        : base_type( model, elastic, NoFracture{}, delta, K )
-        , G0( _G0 )
-        , s0( _s0 )
-    {
-        bond_break_coeff = ( 1.0 + s0 ) * ( 1.0 + s0 );
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    bool criticalStretch( const int, const int, const double r,
-                          const double xi ) const
-    {
-        return r * r >= bond_break_coeff * xi * xi;
-    }
-};
-
 template <typename MemorySpace>
-struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
-                  TemperatureIndependent, MemorySpace>
-    : public ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>,
-      public BasePlasticity<MemorySpace>
+struct BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>
+    : public BaseForceModelPMB<Elastic>, public BasePlasticity<MemorySpace>
 {
-    using base_type = ForceModel<PMB, Elastic>;
+    using base_type = BaseForceModelPMB<Elastic>;
+    using base_fracture_type = BaseFractureModel;
     using base_plasticity_type = BasePlasticity<MemorySpace>;
-    using base_model = typename base_type::base_model;
+    using base_type::base_model;
     using fracture_type = Fracture;
     using mechanics_type = ElasticPerfectlyPlastic;
-    using thermal_type = base_type::thermal_type;
-
-    using base_type::bond_break_coeff;
-    using base_type::c;
-    using base_type::delta;
-    using base_type::G0;
-    using base_type::K;
-    using base_type::s0;
 
     using base_plasticity_type::_s_p;
+    using base_type::c;
     double s_Y;
 
     using base_plasticity_type::updateBonds;
 
-    ForceModel( PMB model, mechanics_type, MemorySpace, const double delta,
-                const double K, const double G0, const double sigma_y )
-        : base_type( model, Elastic{}, delta, K, G0,
-                     // s0
-                     ( 5.0 * G0 / sigma_y / delta + sigma_y / K ) / 6.0 )
+    BaseForceModelPMB( PMB model, mechanics_type, MemorySpace,
+                       const double delta, const double K,
+                       const double sigma_y )
+        : base_type( model, NoFracture{}, delta, K )
         , base_plasticity_type()
         , s_Y( sigma_y / 3.0 / K )
     {
     }
 
-    // FIXME: avoiding multiple inheritance.
     KOKKOS_INLINE_FUNCTION
-    auto forceCoeff( const int i, const int n, const double s,
+    auto operator()( ForceCoeffTag, const int i, const int n, const double s,
                      const double vol ) const
     {
         // Update bond plastic stretch.
@@ -182,8 +120,8 @@ struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
     // This energy calculation is only valid for pure tension or pure
     // compression.
     KOKKOS_INLINE_FUNCTION
-    auto energy( const int i, const int n, const double s, const double xi,
-                 const double vol ) const
+    auto operator()( EnergyTag, const int i, const int n, const double s,
+                     const double xi, const double vol ) const
     {
         auto s_p = _s_p( i, n );
         double stretch_term;
@@ -204,49 +142,170 @@ struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
 };
 
 template <>
+struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
+    : public BaseForceModelPMB<Elastic>,
+      BaseTemperatureModel<TemperatureIndependent>
+{
+    using base_type = BaseForceModelPMB<Elastic>;
+    using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
+
+    using base_type::base_model;
+    using fracture_type = NoFracture;
+    using mechanics_type = Elastic;
+    using thermal_type = base_type::thermal_type;
+
+    using base_type::base_type;
+    using base_type::delta;
+    using base_type::operator();
+    using base_temperature_type::operator();
+};
+
+template <>
+struct ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
+    : public BaseForceModelPMB<Elastic>,
+      BaseFractureModel,
+      BaseTemperatureModel<TemperatureIndependent>
+{
+    using base_type = BaseForceModelPMB<Elastic>;
+    using base_fracture_type = BaseFractureModel;
+    using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
+
+    using model_type = typename base_type::model_type;
+    using base_type::base_model;
+    using fracture_type = Fracture;
+    using thermal_type = base_temperature_type::thermal_type;
+
+    using base_fracture_type::bond_break_coeff;
+    using base_fracture_type::G0;
+    using base_fracture_type::s0;
+    using base_type::c;
+    using base_type::delta;
+    using base_type::K;
+
+    using base_type::operator();
+    using base_fracture_type::operator();
+    using base_temperature_type::operator();
+
+    ForceModel( PMB model, const double delta, const double K, const double G0,
+                const int influence_type = 1 )
+        : base_type( model, NoFracture{}, delta, K )
+        , base_fracture_type( delta, K, G0, influence_type )
+    {
+    }
+
+    ForceModel( PMB model, Elastic elastic, const double delta, const double K,
+                const double G0, const int influence_type = 1 )
+        : base_type( model, elastic, NoFracture{}, delta, K )
+        , base_fracture_type( delta, K, G0, influence_type )
+    {
+    }
+
+    // Constructor to work with plasticity.
+    ForceModel( PMB model, Elastic elastic, const double delta, const double K,
+                const double G0, const double s0 )
+        : base_type( model, elastic, NoFracture{}, delta, K )
+        , base_fracture_type( G0, s0 )
+    {
+    }
+};
+
+template <typename MemorySpace>
+struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
+                  TemperatureIndependent, MemorySpace>
+    : public BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>,
+      public BaseFractureModel,
+      public BaseTemperatureModel<TemperatureIndependent>
+{
+    using base_type = BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>;
+    using base_fracture_type = BaseFractureModel;
+    using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
+    using typename base_type::base_model;
+    using fracture_type = Fracture;
+    using mechanics_type = ElasticPerfectlyPlastic;
+    using typename base_type::thermal_type;
+
+    using base_fracture_type::bond_break_coeff;
+    using base_fracture_type::G0;
+    using base_fracture_type::s0;
+    using base_type::c;
+    using base_type::delta;
+    using base_type::K;
+
+    using base_type::_s_p;
+    double s_Y;
+
+    using base_type::operator();
+    using base_fracture_type::operator();
+    using base_temperature_type::operator();
+    using base_type::updateBonds;
+
+    ForceModel( PMB model, ElasticPerfectlyPlastic mechanics, MemorySpace space,
+                const double delta, const double K, const double G0,
+                const double sigma_y )
+        : base_type( model, mechanics, space, delta, K, sigma_y )
+        , base_fracture_type( G0,
+                              // s0
+                              ( 5.0 * G0 / sigma_y / delta + sigma_y / K ) /
+                                  6.0 )
+        , base_temperature_type()
+    {
+    }
+};
+
+template <>
 struct ForceModel<LinearPMB, Elastic, NoFracture, TemperatureIndependent>
     : public ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
 {
-    using base_type = ForceModel<PMB, Elastic, NoFracture>;
-    using base_model = typename base_type::base_model;
-    using fracture_type = typename base_type::fracture_type;
-    using mechanics_type = Elastic;
-    using thermal_type = base_type::thermal_type;
+    using base_type =
+        ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>;
+
+    using model_type = LinearPMB;
+    using base_type::base_model;
+    using base_type::fracture_type;
+    using thermal_type = typename base_temperature_type::thermal_type;
+
+    using base_type::base_type;
+    using base_type::operator();
+
+    using base_type::c;
+    using base_type::delta;
+    using base_type::K;
 
     template <typename... Args>
     ForceModel( LinearPMB, Args... args )
         : base_type( base_model{}, args... )
     {
     }
-
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
 };
 
 template <>
 struct ForceModel<LinearPMB, Elastic, Fracture, TemperatureIndependent>
     : public ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
 {
-    using base_type = ForceModel<PMB>;
-    using base_model = typename base_type::base_model;
-    using fracture_type = typename base_type::fracture_type;
+    using base_type =
+        ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>;
+
+    using model_type = LinearPMB;
+    using base_type::base_model;
+    using base_type::fracture_type;
     using mechanics_type = Elastic;
     using thermal_type = base_type::thermal_type;
+
+    using base_type::c;
+    using base_type::delta;
+    using base_type::K;
+
+    using base_type::base_type;
+    using base_type::bond_break_coeff;
+    using base_type::G0;
+    using base_type::s0;
+    using base_type::operator();
 
     template <typename... Args>
     ForceModel( LinearPMB, Args... args )
         : base_type( base_model{}, std::forward<Args>( args )... )
     {
     }
-
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
-
-    using base_type::bond_break_coeff;
-    using base_type::G0;
-    using base_type::s0;
 };
 
 template <typename ModelType>
@@ -276,12 +335,14 @@ ForceModel( ModelType, ElasticPerfectlyPlastic, MemorySpace, const double delta,
 template <typename TemperatureType>
 struct ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
                   TemperatureType>
-    : public BaseTemperatureModel<TemperatureType>,
-      public ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
+    : public BaseForceModelPMB<Elastic>,
+      BaseTemperatureModel<TemperatureDependent, TemperatureType>
 {
-    using base_type =
-        ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>;
-    using base_temperature_type = BaseTemperatureModel<TemperatureType>;
+    using base_type = BaseForceModelPMB<Elastic>;
+    using base_temperature_type =
+        BaseTemperatureModel<TemperatureDependent, TemperatureType>;
+
+    using model_type = PMB;
     using base_model = PMB;
     using fracture_type = NoFracture;
     using thermal_type = TemperatureDependent;
@@ -294,29 +355,27 @@ struct ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
     using base_temperature_type::alpha;
     using base_temperature_type::temp0;
 
-    // Explicitly use the temperature-dependent stretch.
-    using base_temperature_type::thermalStretch;
+    using base_type::operator();
+    using base_temperature_type::operator();
 
     ForceModel( PMB model, NoFracture fracture, const double _delta,
                 const double _K, const TemperatureType _temp,
                 const double _alpha, const double _temp0 = 0.0 )
-        : base_temperature_type( _temp, _alpha, _temp0 )
-        , base_type( model, fracture, _delta, _K )
+        : base_type( model, fracture, _delta, _K )
+        , base_temperature_type( _temp, _alpha, _temp0 )
+
     {
     }
 };
 
 template <typename TemperatureType>
 struct ForceModel<PMB, Elastic, Fracture, TemperatureDependent, TemperatureType>
-    : public BaseTemperatureModel<TemperatureType>,
-      public ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
-
+    : public BaseForceModelPMB<Elastic>, ThermalFractureModel<TemperatureType>
 {
-    using base_type =
-        ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>;
-    using base_temperature_type = BaseTemperatureModel<TemperatureType>;
-    using base_model = typename base_type::base_model;
-    using fracture_type = typename base_type::fracture_type;
+    using base_type = BaseForceModelPMB<Elastic>;
+    using base_temperature_type = ThermalFractureModel<TemperatureType>;
+    using base_type::base_model;
+    using base_type::fracture_type;
     using mechanics_type = Elastic;
     using thermal_type = TemperatureDependent;
 
@@ -325,86 +384,52 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureDependent, TemperatureType>
     using base_type::K;
 
     // Does not use the base bond_break_coeff.
-    using base_type::G0;
-    using base_type::s0;
+    using base_temperature_type::G0;
+    using base_temperature_type::s0;
 
     // Thermal parameters
     using base_temperature_type::alpha;
     using base_temperature_type::temp0;
     using base_temperature_type::temperature;
 
-    // Explicitly use the temperature-dependent stretch.
-    using base_temperature_type::thermalStretch;
+    using base_type::operator();
+    using base_temperature_type::operator();
 
     ForceModel( PMB model, const double _delta, const double _K,
                 const double _G0, const TemperatureType _temp,
                 const double _alpha, const double _temp0 = 0.0 )
-        : base_temperature_type( _temp, _alpha, _temp0 )
-        , base_type( model, _delta, _K, _G0 )
-    {
-    }
+        : base_type( model, NoFracture{}, _delta, _K )
+        , base_temperature_type( _delta, _K, _G0, _temp, _alpha, _temp0 )
 
-    KOKKOS_INLINE_FUNCTION
-    bool criticalStretch( const int i, const int j, const double r,
-                          const double xi ) const
     {
-        double temp_avg = 0.5 * ( temperature( i ) + temperature( j ) ) - temp0;
-        double bond_break_coeff =
-            ( 1.0 + s0 + alpha * temp_avg ) * ( 1.0 + s0 + alpha * temp_avg );
-        return r * r >= bond_break_coeff * xi * xi;
     }
 };
 
 template <typename TemperatureType>
 struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, TemperatureDependent,
                   TemperatureType>
-    : public ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
-                        TemperatureIndependent,
-                        typename TemperatureType::memory_space>,
-      BaseTemperatureModel<TemperatureType>
+    : public BaseForceModelPMB<ElasticPerfectlyPlastic,
+                               typename TemperatureType::memory_space>,
+      public ThermalFractureModel<TemperatureType>
 {
-    using base_type = ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
-                                 TemperatureIndependent,
-                                 typename TemperatureType::memory_space>;
-    using base_temperature_type = BaseTemperatureModel<TemperatureType>;
-    using base_model = typename base_type::base_model;
-    using fracture_type = typename base_type::fracture_type;
-    using mechanics_type = ElasticPerfectlyPlastic;
+    using base_type = BaseForceModelPMB<ElasticPerfectlyPlastic,
+                                        typename TemperatureType::memory_space>;
+    using base_temperature_type = ThermalFractureModel<TemperatureType>;
+
+    using model_type = PMB;
+    using base_type::base_model;
+    using fracture_type = Fracture;
     using thermal_type = TemperatureDependent;
 
-    using base_type::c;
-    using base_type::delta;
-    using base_type::K;
-
-    // Does not use the base bond_break_coeff.
-    using base_type::G0;
-    using base_type::s0;
-
-    // Thermal parameters
-    using base_temperature_type::alpha;
-    using base_temperature_type::temp0;
-    using base_temperature_type::temperature;
-
-    // Explicitly use the temperature-dependent stretch.
-    using base_temperature_type::thermalStretch;
+    using base_type::operator();
+    using base_temperature_type::operator();
 
     ForceModel( const double _delta, const double _K, const double _G0,
-                const double _sigma_y, const TemperatureType _temp,
+                const double sigma_y, const TemperatureType _temp,
                 const double _alpha, const double _temp0 = 0.0 )
-        : base_type( _delta, _K, _G0, _sigma_y )
-        , base_temperature_type( _temp, _alpha, _temp0 )
+        : base_type( _delta, _K, _G0, sigma_y )
+        , base_temperature_type( _delta, _K, _G0, _temp, _alpha, _temp0 )
     {
-    }
-
-    // This is copied from the base temperature.
-    KOKKOS_INLINE_FUNCTION
-    bool criticalStretch( const int i, const int j, const double r,
-                          const double xi ) const
-    {
-        double temp_avg = 0.5 * ( temperature( i ) + temperature( j ) ) - temp0;
-        double bond_break_coeff =
-            ( 1.0 + s0 + alpha * temp_avg ) * ( 1.0 + s0 + alpha * temp_avg );
-        return r * r >= bond_break_coeff * xi * xi;
     }
 };
 
@@ -424,13 +449,16 @@ ForceModel( ModelType, const double delta, const double K, const double _G0,
 
 template <typename TemperatureType>
 struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>
-    : public BaseDynamicTemperatureModel,
-      public ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
-                        TemperatureType>
+    : public BaseForceModelPMB<Elastic>,
+      BaseTemperatureModel<TemperatureDependent, TemperatureType>,
+      BaseDynamicTemperatureModel
 {
-    using base_type = ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
-                                 TemperatureType>;
-    using base_temperature_type = BaseDynamicTemperatureModel;
+    using base_type = BaseForceModelPMB<Elastic>;
+    using base_temperature_type =
+        BaseTemperatureModel<TemperatureDependent, TemperatureType>;
+    using base_heat_transfer_type = BaseDynamicTemperatureModel;
+
+    using model_type = PMB;
     using base_model = PMB;
     using fracture_type = NoFracture;
     using thermal_type = DynamicTemperature;
@@ -440,25 +468,25 @@ struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>
     using base_type::K;
 
     // Thermal parameters
-    using base_temperature_type::cp;
-    using base_temperature_type::kappa;
-    using base_temperature_type::thermal_coeff;
-    using base_type::alpha;
-    using base_type::temp0;
-    using base_type::temperature;
+    using base_heat_transfer_type::cp;
+    using base_heat_transfer_type::kappa;
+    using base_heat_transfer_type::thermal_coeff;
+    using base_temperature_type::alpha;
+    using base_temperature_type::temp0;
+    using base_temperature_type::temperature;
 
-    // Explicitly use the temperature-dependent stretch.
-    using base_type::thermalStretch;
+    using base_type::operator();
+    using base_temperature_type::operator();
 
     ForceModel( PMB model, NoFracture fracture, const double _delta,
                 const double _K, const TemperatureType& _temp,
                 const double _kappa, const double _cp, const double _alpha,
                 const double _temp0 = 0.0,
                 const bool _constant_microconductivity = true )
-        : base_temperature_type( _delta, _kappa, _cp,
-                                 _constant_microconductivity )
-        , base_type( model, fracture, _delta, _K, _temp, _alpha, _temp0 )
-
+        : base_type( model, fracture, _delta, _K )
+        , base_temperature_type( _temp, _alpha, _temp0 )
+        , base_heat_transfer_type( _delta, _kappa, _cp,
+                                   _constant_microconductivity )
     {
     }
 };
@@ -474,45 +502,47 @@ ForceModel( ModelType, NoFracture, const double delta, const double K,
 template <typename ModelType, typename TemperatureType>
 struct ForceModel<ModelType, Elastic, Fracture, DynamicTemperature,
                   TemperatureType>
-    : public BaseDynamicTemperatureModel,
-      public ForceModel<ModelType, Elastic, Fracture, TemperatureDependent,
-                        TemperatureType>
 
+    : public BaseForceModelPMB<Elastic>,
+      ThermalFractureModel<TemperatureType>,
+      BaseDynamicTemperatureModel
 {
-    using base_type = ForceModel<PMB, Elastic, Fracture, TemperatureDependent,
-                                 TemperatureType>;
-    using base_temperature_type = BaseDynamicTemperatureModel;
-    using base_model = typename base_type::base_model;
-    using fracture_type = typename base_type::fracture_type;
+    using base_type = BaseForceModelPMB<Elastic>;
+    using base_temperature_type = ThermalFractureModel<TemperatureType>;
+    using base_heat_transfer_type = BaseDynamicTemperatureModel;
+
+    using model_type = PMB;
+    using base_type::base_model;
+    using fracture_type = Fracture;
     using thermal_type = DynamicTemperature;
 
     using base_type::c;
     using base_type::delta;
     using base_type::K;
 
-    // Does not use the base bond_break_coeff.
-    using base_type::G0;
-    using base_type::s0;
+    using base_temperature_type::G0;
+    using base_temperature_type::s0;
 
     // Thermal parameters
-    using base_temperature_type::cp;
-    using base_temperature_type::kappa;
-    using base_temperature_type::thermal_coeff;
-    using base_type::alpha;
-    using base_type::temp0;
-    using base_type::temperature;
+    using base_heat_transfer_type::cp;
+    using base_heat_transfer_type::kappa;
+    using base_heat_transfer_type::thermal_coeff;
+    using base_temperature_type::alpha;
+    using base_temperature_type::temp0;
+    using base_temperature_type::temperature;
 
-    // Explicitly use the temperature-dependent stretch.
-    using base_type::thermalStretch;
+    using base_type::operator();
+    using base_temperature_type::operator();
 
     ForceModel( PMB model, const double _delta, const double _K,
                 const double _G0, const TemperatureType _temp,
                 const double _kappa, const double _cp, const double _alpha,
                 const double _temp0 = 0.0,
                 const bool _constant_microconductivity = true )
-        : base_temperature_type( _delta, _kappa, _cp,
-                                 _constant_microconductivity )
-        , base_type( model, _delta, _K, _G0, _temp, _alpha, _temp0 )
+        : base_type( model, NoFracture{}, _delta, _K )
+        , base_temperature_type( _delta, _K, _G0, _temp, _alpha, _temp0 )
+        , base_heat_transfer_type( _delta, _kappa, _cp,
+                                   _constant_microconductivity )
     {
     }
 };


### PR DESCRIPTION
Refactor extracted from multi-material; the functor interface will enable passing through the multi-material models.

Also:
1. Redefine model inheritance to avoid diamonds (separate base thermal, fracture, plasticity, etc.)
2. Remove unused child model typedefs