### PR TITLE
Increase region output precision

### DIFF
--- a/src/CabanaPD_OutputProfiles.hpp
+++ b/src/CabanaPD_OutputProfiles.hpp
@@ -156,7 +156,8 @@ class OutputTimeSeries
             fout.open( file_name, std::ios::app );
             for ( std::size_t t = 0; t < index; t++ )
             {
-                fout << profile_host( t ) << "  "
+                fout << std::fixed << std::setprecision( 15 )
+                     << profile_host( t ) << "  "
                      << profile_host( t ) / num_particles << std::endl;
             }
         }


### PR DESCRIPTION
The function OutputTimeSeries was only outputting single precision when using it for the dogbone tensile test example.