### PR TITLE
Simplify force bridge pattern and model templates

### DIFF
--- a/src/CabanaPD_Force.hpp
+++ b/src/CabanaPD_Force.hpp
@@ -137,11 +137,12 @@ getLinearizedDistance( const PosType& x, const PosType& u, const int i,
 }
 
 // Forward declaration.
-template <class MemorySpace, class ForceType>
+template <class MemorySpace, class ModelType, class ModelTag,
+          class FractureType>
 class Force;
 
 template <class MemorySpace>
-class Force<MemorySpace, BaseForceModel>
+class BaseForce
 {
   public:
     using neighbor_list_type =
@@ -159,8 +160,8 @@ class Force<MemorySpace, BaseForceModel>
   public:
     // Primary constructor: use positions and construct neighbors.
     template <class ParticleType>
-    Force( const bool half_neigh, const double delta,
-           const ParticleType& particles, const double tol = 1e-14 )
+    BaseForce( const bool half_neigh, const double delta,
+               const ParticleType& particles, const double tol = 1e-14 )
         : _half_neigh( half_neigh )
         , _neigh_list( neighbor_list_type(
               particles.sliceReferencePosition(), particles.frozenOffset(),
@@ -172,10 +173,10 @@ class Force<MemorySpace, BaseForceModel>
     // General constructor (necessary for contact, but could be used by any
     // force routine).
     template <class PositionType>
-    Force( const bool half_neigh, const double delta,
-           const PositionType& positions, const std::size_t frozen_offset,
-           const std::size_t local_offset, const double mesh_min[3],
-           const double mesh_max[3], const double tol = 1e-14 )
+    BaseForce( const bool half_neigh, const double delta,
+               const PositionType& positions, const std::size_t frozen_offset,
+               const std::size_t local_offset, const double mesh_min[3],
+               const double mesh_max[3], const double tol = 1e-14 )
         : _half_neigh( half_neigh )
         , _neigh_list( neighbor_list_type( positions, frozen_offset,
                                            local_offset, delta + tol, 1.0,
@@ -185,7 +186,7 @@ class Force<MemorySpace, BaseForceModel>
 
     // Constructor which stores existing neighbors.
     template <class NeighborListType>
-    Force( const bool half_neigh, const NeighborListType& neighbors )
+    BaseForce( const bool half_neigh, const NeighborListType& neighbors )
         : _half_neigh( half_neigh )
         , _neigh_list( neighbors )
     {

--- a/src/CabanaPD_HeatTransfer.hpp
+++ b/src/CabanaPD_HeatTransfer.hpp
@@ -27,14 +27,14 @@ class HeatTransfer;
 template <class MemorySpace, class MechanicsType, class... ModelParams>
 class HeatTransfer<MemorySpace, ForceModel<PMB, MechanicsType, NoFracture,
                                            DynamicTemperature, ModelParams...>>
-    : public Force<MemorySpace, BaseForceModel>
+    : public BaseForce<MemorySpace>
 {
   public:
     // Using the default exec_space.
     using exec_space = typename MemorySpace::execution_space;
     using model_type = ForceModel<PMB, MechanicsType, NoFracture,
                                   DynamicTemperature, ModelParams...>;
-    using base_type = Force<MemorySpace, BaseForceModel>;
+    using base_type = BaseForce<MemorySpace>;
     using neighbor_list_type = typename base_type::neighbor_list_type;
 
   protected:

--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -95,7 +95,10 @@ class Solver
 
     // Core module types - required for all problems.
     using force_model_type = ForceModelType;
-    using force_type = Force<memory_space, force_model_type>;
+    using force_model_tag = typename force_model_type::model_type;
+    using force_fracture_type = typename force_model_type::fracture_type;
+    using force_type = Force<memory_space, force_model_type, force_model_tag,
+                             force_fracture_type>;
     using comm_type =
         Comm<ParticleType, typename force_model_type::base_model::base_type,
              typename ParticleType::thermal_type>;
@@ -103,8 +106,12 @@ class Solver
 
     // Optional module types.
     using heat_transfer_type = HeatTransfer<memory_space, force_model_type>;
-    using contact_type = Force<memory_space, ContactModelType>;
     using contact_model_type = ContactModelType;
+    using contact_model_tag = typename contact_model_type::model_type;
+    using contact_base_model_type = typename contact_model_type::base_model;
+    using contact_fracture_type = typename contact_model_type::fracture_type;
+    using contact_type = Force<memory_space, contact_model_type,
+                               contact_model_tag, contact_fracture_type>;
 
     // Flexible module types.
     // Integration should include max displacement tracking if either model
@@ -305,7 +312,7 @@ class Solver
         // FIXME: Will need to rebuild ghosts.
     }
 
-    void updateNeighbors() { force->update( *particles, 0.0, true ); }
+    void updateNeighbors() { force->update( particles, 0.0, true ); }
 
     template <typename BoundaryType>
     void runStep( const int step, BoundaryType boundary_condition )

--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -48,42 +48,6 @@ struct State
 {
 };
 
-// Contact and DEM (contact without PD) tags.
-struct Contact
-{
-    using base_type = Pair;
-};
-struct NoContact
-{
-    using base_type = std::false_type;
-};
-template <class, class SFINAE = void>
-struct is_contact : public std::false_type
-{
-};
-template <typename ModelType>
-struct is_contact<
-    ModelType,
-    typename std::enable_if<(
-        std::is_same<typename ModelType::base_model, Contact>::value )>::type>
-    : public std::true_type
-{
-};
-
-template <class, class, class SFINAE = void>
-struct either_contact
-{
-    using base_type = NoContact;
-};
-template <class Model1, class Model2>
-struct either_contact<
-    Model1, Model2,
-    typename std::enable_if<( is_contact<Model1>::value ||
-                              is_contact<Model2>::value )>::type>
-{
-    using base_type = Contact;
-};
-
 // Thermal tags.
 struct TemperatureIndependent
 {
@@ -158,6 +122,46 @@ struct LinearLPS
     using base_model = LPS;
 };
 
+// Contact and DEM (contact without PD) tags.
+struct Contact
+{
+    using base_type = Pair;
+};
+struct NoContact
+{
+    using base_model = std::false_type;
+    using model_type = std::false_type;
+    using thermal_type = TemperatureIndependent;
+    using fracture_type = NoFracture;
+};
+template <class, class SFINAE = void>
+struct is_contact : public std::false_type
+{
+};
+template <typename ModelType>
+struct is_contact<
+    ModelType,
+    typename std::enable_if<(
+        std::is_same<typename ModelType::base_model, Contact>::value )>::type>
+    : public std::true_type
+{
+};
+
+template <class, class, class SFINAE = void>
+struct either_contact
+{
+    using base_type = NoContact;
+};
+template <class Model1, class Model2>
+struct either_contact<
+    Model1, Model2,
+    typename std::enable_if<( is_contact<Model1>::value ||
+                              is_contact<Model2>::value )>::type>
+{
+    using base_type = Contact;
+};
+
+// Output tags.
 struct BaseOutput
 {
 };

--- a/src/force/CabanaPD_Contact.hpp
+++ b/src/force/CabanaPD_Contact.hpp
@@ -40,10 +40,10 @@ KOKKOS_INLINE_FUNCTION void getRelativeNormalVelocityComponents(
 
 // Contact forces base class.
 template <class MemorySpace>
-class BaseForceContact : public Force<MemorySpace, BaseForceModel>
+class BaseForceContact : public BaseForce<MemorySpace>
 {
   public:
-    using base_type = Force<MemorySpace, BaseForceModel>;
+    using base_type = BaseForce<MemorySpace>;
     using neighbor_list_type = typename base_type::neighbor_list_type;
 
     // NOTE: using 2x radius to find neighbors when particles first touch.
@@ -101,8 +101,8 @@ class BaseForceContact : public Force<MemorySpace, BaseForceModel>
 /******************************************************************************
   Normal repulsion forces
 ******************************************************************************/
-template <class MemorySpace>
-class Force<MemorySpace, NormalRepulsionModel>
+template <class MemorySpace, class ModelType>
+class Force<MemorySpace, ModelType, NormalRepulsionModel, NoFracture>
     : public BaseForceContact<MemorySpace>
 {
   public:
@@ -111,7 +111,7 @@ class Force<MemorySpace, NormalRepulsionModel>
 
     template <class ParticleType>
     Force( const bool half_neigh, const ParticleType& particles,
-           const NormalRepulsionModel model )
+           const ModelType model )
         : base_type( half_neigh, particles, model )
         , _model( model )
     {
@@ -175,7 +175,7 @@ class Force<MemorySpace, NormalRepulsionModel>
     }
 
   protected:
-    NormalRepulsionModel _model;
+    ModelType _model;
     using base_type::_half_neigh;
     using base_type::_neigh_list;
     using base_type::_neigh_timer;

--- a/src/force/CabanaPD_Hertzian.hpp
+++ b/src/force/CabanaPD_Hertzian.hpp
@@ -24,8 +24,9 @@ namespace CabanaPD
 /******************************************************************************
   Normal repulsion forces
 ******************************************************************************/
-template <class MemorySpace>
-class Force<MemorySpace, HertzianModel> : public BaseForceContact<MemorySpace>
+template <class MemorySpace, class ModelType>
+class Force<MemorySpace, ModelType, HertzianModel, NoFracture>
+    : public BaseForceContact<MemorySpace>
 {
   public:
     using base_type = BaseForceContact<MemorySpace>;
@@ -33,7 +34,7 @@ class Force<MemorySpace, HertzianModel> : public BaseForceContact<MemorySpace>
 
     template <class ParticleType>
     Force( const bool half_neigh, const ParticleType& particles,
-           const HertzianModel model )
+           const ModelType model )
         : base_type( half_neigh, particles, model )
         , _model( model )
     {
@@ -94,7 +95,7 @@ class Force<MemorySpace, HertzianModel> : public BaseForceContact<MemorySpace>
     }
 
   protected:
-    HertzianModel _model;
+    ModelType _model;
     using base_type::_half_neigh;
     using base_type::_neigh_list;
     using base_type::_neigh_timer;

--- a/src/force/CabanaPD_LPS.hpp
+++ b/src/force/CabanaPD_LPS.hpp
@@ -69,14 +69,14 @@
 
 namespace CabanaPD
 {
-template <class MemorySpace>
-class Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>
-    : public Force<MemorySpace, BaseForceModel>
+template <class MemorySpace, class ModelType>
+class Force<MemorySpace, ModelType, LPS, NoFracture>
+    : public BaseForce<MemorySpace>
 {
   protected:
-    using base_type = Force<MemorySpace, BaseForceModel>;
+    using base_type = BaseForce<MemorySpace>;
     using base_type::_half_neigh;
-    using model_type = ForceModel<LPS, Elastic, NoFracture>;
+    using model_type = ModelType;
     model_type _model;
 
     using base_type::_energy_timer;
@@ -245,9 +245,6 @@ class Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>
         return strain_energy;
     }
 
-    auto time() { return _timer.time(); };
-    auto timeEnergy() { return _energy_timer.time(); };
-
     template <class ParticleType, class ParallelType>
     void computeStressFull( ParticleType& particles,
                             ParallelType& neigh_op_tag )
@@ -302,18 +299,17 @@ class Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>
     }
 };
 
-template <class MemorySpace>
-class Force<MemorySpace, ForceModel<LPS, Elastic, Fracture>>
-    : public Force<MemorySpace, BaseForceModel>,
-      public BaseFracture<MemorySpace>
+template <class MemorySpace, class ModelType>
+class Force<MemorySpace, ModelType, LPS, Fracture>
+    : public BaseForce<MemorySpace>, public BaseFracture<MemorySpace>
 {
   protected:
+    using base_type = BaseForce<MemorySpace>;
+    using base_type::_half_neigh;
     using fracture_type = BaseFracture<MemorySpace>;
     using fracture_type::_mu;
 
-    using base_type = Force<MemorySpace, BaseForceModel>;
-    using base_type::_half_neigh;
-    using model_type = ForceModel<LPS, Elastic, Fracture>;
+    using model_type = ModelType;
     model_type _model;
 
     using base_type::_energy_timer;
@@ -628,13 +624,13 @@ class Force<MemorySpace, ForceModel<LPS, Elastic, Fracture>>
     }
 };
 
-template <class MemorySpace>
-class Force<MemorySpace, ForceModel<LinearLPS, Elastic, NoFracture>>
-    : public Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>
+template <class MemorySpace, class ModelType>
+class Force<MemorySpace, ModelType, LinearLPS, NoFracture>
+    : public Force<MemorySpace, ModelType, LPS, NoFracture>
 {
   protected:
-    using base_type = Force<MemorySpace, ForceModel<LPS, Elastic, NoFracture>>;
-    using model_type = ForceModel<LinearLPS, Elastic, NoFracture>;
+    using base_type = Force<MemorySpace, ModelType, LPS, NoFracture>;
+    using model_type = ModelType;
     model_type _model;
 
     using base_type::_energy_timer;

--- a/src/force/CabanaPD_PMB.hpp
+++ b/src/force/CabanaPD_PMB.hpp
@@ -70,17 +70,15 @@
 
 namespace CabanaPD
 {
-template <class MemorySpace, class MechanicsType, class... ModelParams>
-class Force<MemorySpace,
-            ForceModel<PMB, MechanicsType, NoFracture, ModelParams...>>
-    : public Force<MemorySpace, BaseForceModel>
+template <class MemorySpace, class ModelType>
+class Force<MemorySpace, ModelType, PMB, NoFracture>
+    : public BaseForce<MemorySpace>
 {
   public:
     // Using the default exec_space.
     using exec_space = typename MemorySpace::execution_space;
-    using model_type =
-        ForceModel<PMB, MechanicsType, NoFracture, ModelParams...>;
-    using base_type = Force<MemorySpace, BaseForceModel>;
+    using model_type = ModelType;
+    using base_type = BaseForce<MemorySpace>;
     using neighbor_list_type = typename base_type::neighbor_list_type;
     using base_type::_neigh_list;
 
@@ -233,26 +231,22 @@ class Force<MemorySpace,
     }
 };
 
-template <class MemorySpace, class MechanicsType, class... ModelParams>
-class Force<MemorySpace,
-            ForceModel<PMB, MechanicsType, Fracture, ModelParams...>>
-    : public Force<MemorySpace, BaseForceModel>,
-      public BaseFracture<MemorySpace>
+template <class MemorySpace, class ModelType>
+class Force<MemorySpace, ModelType, PMB, Fracture>
+    : public BaseForce<MemorySpace>, public BaseFracture<MemorySpace>
 {
   public:
     // Using the default exec_space.
     using exec_space = typename MemorySpace::execution_space;
-    using model_type = ForceModel<PMB, MechanicsType, Fracture, ModelParams...>;
-    using base_type = Force<MemorySpace, BaseForceModel>;
+    using model_type = ModelType;
+    using base_type = BaseForce<MemorySpace>;
     using neighbor_list_type = typename base_type::neighbor_list_type;
     using base_type::_neigh_list;
 
   protected:
+    using base_type::_half_neigh;
     using fracture_type = BaseFracture<MemorySpace>;
     using fracture_type::_mu;
-
-    using base_model_type = typename model_type::base_type;
-    using base_type::_half_neigh;
     model_type _model;
 
     using base_type::_energy_timer;
@@ -463,17 +457,15 @@ class Force<MemorySpace,
     }
 };
 
-template <class MemorySpace, class... ModelParams>
-class Force<MemorySpace,
-            ForceModel<LinearPMB, Elastic, NoFracture, ModelParams...>>
-    : public Force<MemorySpace, BaseForceModel>
+template <class MemorySpace, class ModelType>
+class Force<MemorySpace, ModelType, LinearPMB, NoFracture>
+    : public BaseForce<MemorySpace>
 {
   public:
     // Using the default exec_space.
     using exec_space = typename MemorySpace::execution_space;
-    using model_type =
-        ForceModel<LinearPMB, Elastic, NoFracture, TemperatureIndependent>;
-    using base_type = Force<MemorySpace, BaseForceModel>;
+    using model_type = ModelType;
+    using base_type = BaseForce<MemorySpace>;
     using neighbor_list_type = typename base_type::neighbor_list_type;
     using base_type::_neigh_list;
 

--- a/src/force_models/CabanaPD_Contact.hpp
+++ b/src/force_models/CabanaPD_Contact.hpp
@@ -46,6 +46,7 @@ struct NormalRepulsionModel : public ContactModel
 {
     using base_type = ContactModel;
     using base_model = base_type::base_model;
+    using model_type = NormalRepulsionModel;
     using fracture_type = NoFracture;
     using thermal_type = TemperatureIndependent;
 

--- a/src/force_models/CabanaPD_Hertzian.hpp
+++ b/src/force_models/CabanaPD_Hertzian.hpp
@@ -24,6 +24,7 @@ struct HertzianModel : public ContactModel
 {
     using base_type = ContactModel;
     using base_model = base_type::base_model;
+    using model_type = HertzianModel;
     using fracture_type = NoFracture;
     using thermal_type = TemperatureIndependent;
 

--- a/src/force_models/CabanaPD_LPS.hpp
+++ b/src/force_models/CabanaPD_LPS.hpp
@@ -26,6 +26,7 @@ template <>
 struct BaseForceModelLPS<Elastic> : public BaseForceModel
 {
     using base_type = BaseForceModel;
+    using model_type = LPS;
     using base_model = LPS;
 
     using base_type::delta;
@@ -136,8 +137,6 @@ struct ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>
     using base_fracture_type = BaseFractureModel;
     using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
 
-    using model_type = LPS;
-    using base_model = typename base_type::base_model;
     using fracture_type = Fracture;
     using thermal_type = base_temperature_type::thermal_type;
 
@@ -198,9 +197,7 @@ struct ForceModel<LinearLPS, Elastic, NoFracture, TemperatureIndependent>
 {
     using base_type =
         ForceModel<LPS, Elastic, NoFracture, TemperatureIndependent>;
-    using base_temperature_type = typename base_type::base_temperature_type;
-    using base_model = typename base_type::base_model;
-    using fracture_type = typename base_type::fracture_type;
+    using model_type = LinearLPS;
 
     template <typename... Args>
     ForceModel( LinearLPS, Args&&... args )
@@ -220,9 +217,6 @@ struct ForceModel<LinearLPS, Elastic, Fracture, TemperatureIndependent>
         ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>;
 
     using model_type = LinearLPS;
-    using base_model = typename base_type::base_model;
-    using fracture_type = typename base_type::fracture_type;
-    using thermal_type = base_type::thermal_type;
 
     template <typename... Args>
     ForceModel( LinearLPS, Args&&... args )

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -808,7 +808,9 @@ void testForce( ModelType model, const double dx, const double m,
 
     // This needs to exactly match the mesh spacing to compare with the single
     // particle calculation.
-    CabanaPD::Force<TEST_MEMSPACE, ModelType> force( true, particles, model );
+    CabanaPD::Force<TEST_MEMSPACE, ModelType, typename ModelType::base_model,
+                    typename ModelType::fracture_type>
+        force( true, particles, model );
 
     auto x = particles.sliceReferencePosition();
     auto f = particles.sliceForce();


### PR DESCRIPTION
Currently only the exact model form is usable by the force class. Multi-material models and more general flexibility (e.g. combining with linearized models) require a separation of the specialization tags for force classes 