### PR TITLE
Differentiate timing per run type

### DIFF
--- a/examples/mechanics/inputs/fragmenting_cylinder.json
+++ b/examples/mechanics/inputs/fragmenting_cylinder.json
@@ -15,7 +15,7 @@
     "max_radial_velocity"      : {"value": 200, "unit": "m/s"}, 
     "min_radial_velocity"      : {"value": 50, "unit": "m/s"},
     "max_vertical_velocity"    : {"value": 100, "unit": "m/s"}, 
-    "final_time"               : {"value": 2.5e-4, "unit": "s"},
+    "final_time"               : {"value": 2.4e-4, "unit": "s"},
     "timestep"                 : {"value": 1.7e-07, "unit": "s"},
     "timestep_safety_factor"   : {"value": 0.70},
     "output_frequency"         : {"value": 50},

--- a/src/CabanaPD_Output.hpp
+++ b/src/CabanaPD_Output.hpp
@@ -24,12 +24,15 @@
 #define OUTPUT_H
 
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <utility>
 
 #include <mpi.h>
+
+#include <CabanaPD_Types.hpp>
 
 namespace CabanaPD
 {
@@ -83,6 +86,229 @@ void checkParticleCount( std::size_t initial, std::size_t current,
                  ").\n Likely a slice() call is missing." );
 }
 
+/******************************************************************************
+ Timing output
+******************************************************************************/
+
+template <typename ForceType, typename ContactType, typename SFINAE = void>
+struct TimingOutput;
+
+template <typename ForceType>
+struct TimingOutput<
+    ForceType, NoContact,
+    typename std::enable_if<( !is_contact<ForceType>::value )>::type>
+{
+    void header( const std::string output_file, const double init )
+    {
+        std::ofstream out( output_file, std::ofstream::app );
+        log( out, "Running PD only.\n" );
+        log( out, "Init-Time(s): ", init );
+        if constexpr ( is_fracture<ForceType>::value )
+            log( out,
+                 "#Timestep/Total-steps Simulation-time Total-strain-energy "
+                 "Total-Damage Cumulative-Time(s) Force-Time(s) Comm-Time(s) "
+                 "Integrate-Time(s) Energy-Time(s) Output-Time(s) "
+                 "Particle*steps/s" );
+        else
+            log( out,
+                 "#Timestep/Total-steps Simulation-time Total-strain-energy "
+                 "Cumulative-Time(s) Force-Time(s) Comm-Time(s) "
+                 "Integrate-Time(s) Energy-Time(s) Output-Time(s) "
+                 "Particle*steps/s" );
+        out.close();
+    }
+
+    void step( const std::string output_file, const int step,
+               const int num_steps, const double dt, const double W,
+               [[maybe_unused]] const double relative_damage,
+               const double total, const double force, const double,
+               const double, const double comm, const double integrate,
+               const double energy, const double output,
+               const double p_steps_per_sec )
+    {
+        std::ofstream out( output_file, std::ofstream::app );
+        log( std::cout, step, "/", num_steps, " ", std::scientific,
+             std::setprecision( 2 ), step * dt );
+
+        if constexpr ( is_fracture<ForceType>::value )
+            log( out, std::fixed, std::setprecision( 6 ), step, "/", num_steps,
+                 " ", std::scientific, std::setprecision( 2 ), step * dt, " ",
+                 W, " ", relative_damage, " ", std::fixed, total, " ", force,
+                 " ", comm, " ", integrate, " ", energy, " ", output, " ",
+                 std::scientific, p_steps_per_sec );
+        else
+            log( out, std::fixed, std::setprecision( 6 ), step, "/", num_steps,
+                 " ", std::scientific, std::setprecision( 2 ), step * dt, " ",
+                 W, " ", std::fixed, total, " ", force, " ", comm, " ",
+                 integrate, " ", energy, " ", output, " ", std::scientific,
+                 p_steps_per_sec );
+        out.close();
+    }
+
+    void final( const std::string output_file, const int size,
+                const int global_particles, const double total,
+                const double force, const double, const double neigh,
+                const double, const double comm, const double integrate,
+                const double energy, const double output, const double other,
+                const double steps_per_sec, const double p_steps_per_sec )
+    {
+        std::ofstream out( output_file, std::ofstream::app );
+        log( out, std::fixed, std::setprecision( 2 ),
+             "\n#Procs Particles | Total Force Neighbor Comm Integrate Energy "
+             "Output Other |\n",
+             size, " ", global_particles, " | \t", total, " ", force, " ",
+             neigh, " ", comm, " ", integrate, " ", energy, " ", output, " ",
+             other, " | PERFORMANCE\n", std::fixed, size, " ", global_particles,
+             " | \t", 1.0, " ", force / total, " ", neigh / total, " ",
+             comm / total, " ", integrate / total, " ", energy / total, " ",
+             output / total, " ", other / total, " | FRACTION\n\n",
+             "#Steps/s Particle-steps/s Particle-steps/proc/s\n",
+             std::scientific, steps_per_sec, " ", p_steps_per_sec, " ",
+             p_steps_per_sec / size );
+        out.close();
+    }
+};
+
+template <typename ContactType>
+struct TimingOutput<
+    ContactType, NoContact,
+    typename std::enable_if<( is_contact<ContactType>::value )>::type>
+{
+    void header( const std::string output_file, const double init )
+    {
+        std::ofstream out( output_file, std::ofstream::app );
+        log( out, "Running DEM only.\n" );
+        log( out, "Init-Time(s): ", init );
+        log( out, "#Timestep/Total-steps Simulation-time Cumulative-Time(s) "
+                  "Force-Time(s) Neighbor-Time(s) Comm-Time(s) "
+                  "Integrate-Time(s) Energy-Time(s) Output-Time(s) "
+                  "Particle*steps/s" );
+        out.close();
+    }
+
+    void step( const std::string output_file, const int step,
+               const int num_steps, const double dt, const double, const double,
+               const double total, const double force, const double,
+               const double neigh, const double comm, const double integrate,
+               const double energy, const double output,
+               const double p_steps_per_sec )
+    {
+        std::ofstream out( output_file, std::ofstream::app );
+        log( std::cout, step, "/", num_steps, " ", std::scientific,
+             std::setprecision( 2 ), step * dt );
+
+        log( out, std::fixed, std::setprecision( 6 ), step, "/", num_steps, " ",
+             std::scientific, std::setprecision( 2 ), step * dt, " ",
+             std::fixed, total, " ", force, " ", neigh, " ", comm, " ",
+             integrate, " ", energy, " ", output, " ", std::scientific,
+             p_steps_per_sec );
+        out.close();
+    }
+
+    void final( const std::string output_file, const int size,
+                const int global_particles, const double total,
+                const double force, const double, const double,
+                const double neigh, const double comm, const double integrate,
+                const double, const double output, const double other,
+                const double steps_per_sec, const double p_steps_per_sec )
+    {
+        std::ofstream out( output_file, std::ofstream::app );
+        log( out, std::fixed, std::setprecision( 2 ),
+             "\n#Procs Particles | Total Force Neighbor Comm Integrate Output "
+             "Other |\n",
+             size, " ", global_particles, " | \t", total, " ", force, " ",
+             neigh, " ", comm, " ", integrate, " ", output, " ", other,
+             " | PERFORMANCE\n", std::fixed, size, " ", global_particles,
+             " | \t", 1.0, " ", force / total, " ", neigh / total, " ",
+             comm / total, " ", integrate / total, " ", output / total, " ",
+             other / total, " | FRACTION\n\n",
+             "#Steps/s Particle-steps/s Particle-steps/proc/s\n",
+             std::scientific, steps_per_sec, " ", p_steps_per_sec, " ",
+             p_steps_per_sec / size );
+        out.close();
+    }
+};
+
+template <typename ForceType, typename ContactType>
+struct TimingOutput<
+    ForceType, ContactType,
+    typename std::enable_if<( is_contact<ContactType>::value )>::type>
+{
+    void header( const std::string output_file, const double init )
+    {
+        std::ofstream out( output_file, std::ofstream::app );
+        log( out, "Running hybrid DEM-PD.\n" );
+        log( out, "Init-Time(s): ", init );
+        if constexpr ( is_fracture<ForceType>::value )
+            log( out,
+                 "#Timestep/Total-steps Simulation-time Total-strain-energy "
+                 "Total-Damage Cumulative-Time(s) Force-Time(s) "
+                 "Force-Contact-Time(s) Neighbor-Contact-Time(s) Comm-Time(s) "
+                 "Integrate-Time(s) Energy-Time(s) Output-Time(s) "
+                 "Particle*steps/s" );
+        else
+            log( out,
+                 "#Timestep/Total-steps Simulation-time Total-strain-energy "
+                 "Cumulative-Time(s) Force-Time(s) Force-Contact-Time(s) "
+                 "Neighbor-Contact-Time(s) Comm-Time(s) "
+                 "Integrate-Time(s) Energy-Time(s) Output-Time(s) "
+                 "Particle*steps/s" );
+        out.close();
+    }
+
+    void step( const std::string output_file, const int step,
+               const int num_steps, const double dt, const double W,
+               [[maybe_unused]] const double relative_damage,
+               const double total, const double force, const double contact,
+               const double neigh, const double comm, const double integrate,
+               const double energy, const double output,
+               const double p_steps_per_sec )
+    {
+        std::ofstream out( output_file, std::ofstream::app );
+        log( std::cout, step, "/", num_steps, " ", std::scientific,
+             std::setprecision( 2 ), step * dt );
+
+        if constexpr ( is_fracture<ForceType>::value )
+            log( out, std::fixed, std::setprecision( 6 ), step, "/", num_steps,
+                 " ", std::scientific, std::setprecision( 2 ), step * dt, " ",
+                 W, " ", relative_damage, " ", std::fixed, total, " ", force,
+                 " ", contact, " ", neigh, " ", comm, " ", integrate, " ",
+                 energy, " ", output, " ", std::scientific, p_steps_per_sec );
+        else
+            log( out, std::fixed, std::setprecision( 6 ), step, "/", num_steps,
+                 " ", std::scientific, std::setprecision( 2 ), step * dt, " ",
+                 W, " ", std::fixed, total, " ", force, " ", contact, " ",
+                 neigh, " ", comm, " ", integrate, " ", energy, " ", output,
+                 " ", std::scientific, p_steps_per_sec );
+        out.close();
+    }
+
+    void final( const std::string output_file, const int size,
+                const int global_particles, const double total,
+                const double force, const double contact_force,
+                const double neigh, const double contact_neigh,
+                const double comm, const double integrate, const double energy,
+                const double output, const double other,
+                const double steps_per_sec, const double p_steps_per_sec )
+    {
+        std::ofstream out( output_file, std::ofstream::app );
+        log( out, std::fixed, std::setprecision( 2 ),
+             "\n#Procs Particles | Total Force Contact-Force Neighbor "
+             "Contact-Neighbor Comm Integrate Energy Output Other |\n",
+             size, " ", global_particles, " | \t", total, " ", force, " ",
+             contact_force, " ", neigh, " ", contact_neigh, " ", comm, " ",
+             integrate, " ", energy, " ", output, " ", other,
+             " | PERFORMANCE\n", std::fixed, size, " ", global_particles,
+             " | \t", 1.0, " ", force / total, " ", contact_force / total, " ",
+             neigh / total, " ", contact_neigh / total, " ", comm / total, " ",
+             integrate / total, " ", energy / total, " ", output / total, " ",
+             other / total, " | FRACTION\n\n",
+             "#Steps/s Particle-steps/s Particle-steps/proc/s\n",
+             std::scientific, steps_per_sec, " ", p_steps_per_sec, " ",
+             p_steps_per_sec / size );
+        out.close();
+    }
+};
 } // namespace CabanaPD
 
 #endif

--- a/src/CabanaPD_Particles.hpp
+++ b/src/CabanaPD_Particles.hpp
@@ -546,7 +546,7 @@ class Particles<MemorySpace, PMB, TemperatureIndependent, BaseOutput, Dimension>
     void updateParticles( const ExecSpace, const FunctorType init_functor,
                           const bool update_frozen = false )
     {
-        _timer.start();
+        _init_timer.start();
         std::size_t start = frozen_offset;
         if ( update_frozen )
             start = 0;
@@ -555,7 +555,7 @@ class Particles<MemorySpace, PMB, TemperatureIndependent, BaseOutput, Dimension>
             "CabanaPD::Particles::update_particles", policy,
             KOKKOS_LAMBDA( const int pid ) { init_functor( pid ); } );
         Kokkos::fence();
-        _timer.stop();
+        _init_timer.stop();
     }
 
     // Particles are always in order frozen, local, ghost.

--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -63,7 +63,6 @@
 #include <chrono>
 #include <ctime>
 #include <fstream>
-#include <iomanip>
 #include <iostream>
 
 #include <CabanaPD_config.hpp>
@@ -110,7 +109,6 @@ class Solver
     using heat_transfer_type = HeatTransfer<memory_space, force_model_type>;
     using contact_model_type = ContactModelType;
     using contact_model_tag = typename contact_model_type::model_type;
-    using contact_base_model_type = typename contact_model_type::base_model;
     using contact_fracture_type = typename contact_model_type::fracture_type;
     using contact_type = Force<memory_space, contact_model_type,
                                contact_model_tag, contact_fracture_type>;
@@ -121,28 +119,34 @@ class Solver
     using integrator_type =
         VelocityVerlet<typename either_contact<force_model_type,
                                                contact_model_type>::base_type>;
+    // Different timings are output based on models.
+    using output_type = TimingOutput<force_model_type, contact_model_type>;
 
     Solver( Inputs _inputs, ParticleType _particles,
             force_model_type force_model )
         : particles( _particles )
         , inputs( _inputs )
-        , _init_time( 0.0 )
+        , _other_time( 0.0 )
+        , _total_time( 0.0 )
     {
+        _total_timer.start();
         setup( force_model );
+        _total_timer.stop();
     }
 
     Solver( Inputs _inputs, ParticleType _particles,
             force_model_type force_model, contact_model_type contact_model )
         : particles( _particles )
         , inputs( _inputs )
-        , _init_time( 0.0 )
+        , _other_time( 0.0 )
+        , _total_time( 0.0 )
     {
+        _total_timer.start();
         setup( force_model );
 
-        _neighbor_timer.start();
         contact = std::make_shared<contact_type>( inputs["half_neigh"],
                                                   particles, contact_model );
-        _neighbor_timer.stop();
+        _total_timer.stop();
     }
 
     void setup( force_model_type force_model )
@@ -184,7 +188,6 @@ class Solver
                                               force_model );
         _neighbor_timer.stop();
 
-        _init_timer.start();
         unsigned max_neighbors;
         unsigned long long total_neighbors;
         force->getNeighborStatistics( max_neighbors, total_neighbors );
@@ -223,11 +226,11 @@ class Solver
                  ", Total neighbors: ", total_neighbors, "\n" );
             out.close();
         }
-        _init_timer.stop();
     }
 
     void init( const bool initial_output = true )
     {
+        _total_timer.start();
         // Compute and communicate weighted volume for LPS (does nothing for
         // PMB). Only computed once without fracture (and inside updateForce for
         // fracture).
@@ -244,12 +247,14 @@ class Solver
 
         if ( initial_output )
             particles.output( 0, 0.0, output_reference );
+        _total_timer.stop();
     }
 
     template <typename BoundaryType>
     void init( BoundaryType boundary_condition,
                const bool initial_output = true )
     {
+        _total_timer.start();
         // Add non-force boundary condition.
         if ( !boundary_condition.forceUpdate() )
             boundary_condition.apply( exec_space(), particles, 0.0 );
@@ -261,16 +266,19 @@ class Solver
         if constexpr ( is_temperature_dependent<
                            typename force_model_type::thermal_type>::value )
             comm->gatherTemperature();
+        _total_timer.stop();
 
         // Force init without particle output.
         init( false );
 
+        _total_timer.start();
         // Add force boundary condition.
         if ( boundary_condition.forceUpdate() )
             boundary_condition.apply( exec_space(), particles, 0.0 );
 
         if ( initial_output )
             particles.output( 0, 0.0, output_reference );
+        _total_timer.stop();
     }
 
     // Initialize with prenotch, but no BC.
@@ -294,6 +302,7 @@ class Solver
     // Given a user functor, remove certain particles.
     void remove( const double threshold, const bool use_frozen = false )
     {
+        _total_timer.start();
         // Remove any points that are too close.
         Kokkos::View<int*, memory_space> keep( "keep_points",
                                                particles.numLocal() );
@@ -319,6 +328,8 @@ class Solver
         Kokkos::fence();
         particles.remove( num_keep, keep );
         // FIXME: Will need to rebuild ghosts.
+        _total_timer.stop();
+        _other_time += _total_timer.lastTime();
     }
 
     void updateNeighbors() { force->update( particles, 0.0, true ); }
@@ -400,6 +411,7 @@ class Solver
     void run( OutputType&... region_output )
     {
         init_output();
+        _total_timer.start();
 
         // Main timestep loop.
         for ( int step = 1; step <= num_steps; step++ )
@@ -411,13 +423,16 @@ class Solver
         }
 
         // Final output and timings.
+        _total_timer.stop();
         final_output( region_output... );
     }
 
     template <typename BoundaryType, typename... OutputType>
     void run( BoundaryType& boundary_condition, OutputType&... region_output )
     {
-        init_output( boundary_condition.timeInit() );
+        init_output();
+        _total_timer.start();
+        _other_time += boundary_condition.timeInit();
 
         // Main timestep loop.
         for ( int step = 1; step <= num_steps; step++ )
@@ -429,6 +444,7 @@ class Solver
         }
 
         // Final output and timings.
+        _total_timer.stop();
         final_output( region_output... );
     }
 
@@ -482,20 +498,17 @@ class Solver
         }
     }
 
-    void init_output( double boundary_init_time = 0.0 )
+    void init_output()
     {
-        // Output after construction and initial forces.
-        std::ofstream out( output_file, std::ofstream::app );
-        _init_time += _init_timer.time() + particles.timeInit() +
-                      comm->timeInit() + integrator->timeInit() +
-                      boundary_init_time;
-        log( out, "Init-Time(s): ", _init_time );
-        log( out, "Init-Neighbor-Time(s): ", _neighbor_timer.time(), "\n" );
-        log( out, "#Timestep/Total-steps Simulation-time Total-strain-energy "
-                  "Total-Damage "
-                  "Step-Time(s) Force-Time(s) Neighbor-Time(s) Comm-Time(s) "
-                  "Integrate-Time(s) Energy-Time(s) Output-Time(s) "
-                  "Particle*steps/s" );
+        // Add timings that aren't included elsewhere (particles are created
+        // prior to the solver and therefore not included in any other timers).
+        double particle_time = particles.timeInit() + particles.time();
+        // All time up to now is init.
+        double total_init_time = _total_timer.time() + particle_time;
+        _step_timer.set( total_init_time );
+
+        // Use total init time here.
+        timing_output.header( output_file, total_init_time );
     }
 
     void step_output( const int step )
@@ -513,32 +526,26 @@ class Solver
 
         if ( print )
         {
-            std::ofstream out( output_file, std::ofstream::app );
-            log( std::cout, step, "/", num_steps, " ", std::scientific,
-                 std::setprecision( 2 ), step * dt );
-
             double step_time = _step_timer.time();
-            double comm_time = comm->time();
-            double integrate_time = integrator->time();
-            double force_time = force->time();
-            double energy_time = force->timeEnergy();
-            // Init neighbor build and later (contact) rebuilds.
-            double neigh_time = _neighbor_timer.time() + force->timeNeighbor();
-            double output_time = particles.timeOutput();
-            _total_time += step_time;
+
             // Instantaneous rate.
             double p_steps_per_sec =
                 static_cast<double>( particles.numGlobal() ) *
                 output_frequency / step_time;
 
-            _step_timer.reset();
-            log( out, std::fixed, std::setprecision( 6 ), step, "/", num_steps,
-                 " ", std::scientific, std::setprecision( 2 ), step * dt, " ",
-                 total_strain_energy, " ", relative_damage, " ", std::fixed,
-                 _total_time, " ", force_time, " ", neigh_time, " ", comm_time,
-                 " ", integrate_time, " ", energy_time, " ", output_time, " ",
-                 std::scientific, p_steps_per_sec );
-            out.close();
+            double contact_time = 0.0;
+            double neigh_time = force->timeNeighbor() + _neighbor_timer.time();
+            if constexpr ( is_contact<contact_model_type>::value )
+            {
+                contact_time = contact->time();
+                neigh_time += contact->timeNeighbor();
+            }
+
+            timing_output.step(
+                output_file, step, num_steps, dt, total_strain_energy,
+                relative_damage, step_time, force->time(), contact_time,
+                neigh_time, comm->time(), integrator->time(),
+                force->timeEnergy(), particles.timeOutput(), p_steps_per_sec );
         }
     }
 
@@ -546,40 +553,36 @@ class Solver
     {
         if ( print )
         {
-            // Add the last steps and initialization to total.
-            _total_time += _step_timer.time() + _init_time;
-
-            std::ofstream out( output_file, std::ofstream::app );
-            double comm_time = comm->time();
-            double integrate_time = integrator->time();
-            double force_time = force->time();
-            double energy_time = force->timeEnergy();
-            double output_time = particles.timeOutput();
-            // Init neighbor build and later (contact) rebuilds.
-            double neigh_time = _neighbor_timer.time() + force->timeNeighbor();
+            // Add timings that aren't included elsewhere (particles are created
+            // prior to the solver and therefore not included in any other
+            // timers).
+            double particle_time = particles.timeInit() + particles.time();
+            double total_time = _total_timer.time() + particle_time;
+            // Already included in total, but not in other.
+            _other_time +=
+                comm->timeInit() + integrator->timeInit() + particle_time;
 
             // Rates over the whole simulation.
             double steps_per_sec =
-                static_cast<double>( num_steps ) / _total_time;
+                static_cast<double>( num_steps ) / total_time;
             double p_steps_per_sec =
                 static_cast<double>( particles.numGlobal() ) * steps_per_sec;
-            log( out, std::fixed, std::setprecision( 2 ),
-                 "\n#Procs Particles | Total Force Neighbor Comm Integrate "
-                 "Energy "
-                 "Output Init |\n",
-                 comm->mpi_size, " ", particles.numGlobal(), " | \t",
-                 _total_time, " ", force_time, " ", neigh_time, " ", comm_time,
-                 " ", integrate_time, " ", energy_time, " ", output_time, " ",
-                 _init_time, " | PERFORMANCE\n", std::fixed, comm->mpi_size,
-                 " ", particles.numGlobal(), " | \t", 1.0, " ",
-                 force_time / _total_time, " ", neigh_time / _total_time, " ",
-                 comm_time / _total_time, " ", integrate_time / _total_time,
-                 " ", energy_time / _total_time, " ", output_time / _total_time,
-                 " ", _init_time / _total_time, " | FRACTION\n\n",
-                 "#Steps/s Particle-steps/s Particle-steps/proc/s\n",
-                 std::scientific, steps_per_sec, " ", p_steps_per_sec, " ",
-                 p_steps_per_sec / comm->mpi_size );
-            out.close();
+
+            double neigh_time = _neighbor_timer.time();
+            double contact_time = 0.0;
+            double contact_neigh_time = force->timeNeighbor();
+            if constexpr ( is_contact<contact_model_type>::value )
+            {
+                contact_time = contact->time();
+                contact_neigh_time += contact->timeNeighbor();
+            }
+
+            timing_output.final(
+                output_file, comm->mpi_size, particles.numGlobal(), total_time,
+                force->time(), contact_time, neigh_time, contact_neigh_time,
+                comm->time(), integrator->time(), force->timeEnergy(),
+                particles.timeOutput(), _other_time, steps_per_sec,
+                p_steps_per_sec );
         }
     }
 
@@ -623,13 +626,15 @@ class Solver
     template <std::size_t NumPrenotch>
     void init_prenotch( Prenotch<NumPrenotch> prenotch )
     {
+        _total_timer.start();
         static_assert(
             is_fracture<typename force_model_type::fracture_type>::value,
             "Cannot create prenotch in system without fracture." );
 
         // Create prenotch.
         force->prenotch( exec_space{}, particles, prenotch );
-        _init_time += prenotch.time();
+        _other_time += prenotch.time();
+        _total_timer.stop();
     }
 
     // Core modules.
@@ -645,13 +650,14 @@ class Solver
     std::string output_file;
     std::string error_file;
 
-    // Note: init_time is combined from many class timers.
-    double _init_time;
-    Timer _init_timer;
+    // Note: _other_time is combined from many class timers.
+    double _other_time;
+    double _total_time;
     Timer _neighbor_timer;
     Timer _step_timer;
-    double _total_time;
+    Timer _total_timer;
     bool print;
+    output_type timing_output;
 };
 
 } // namespace CabanaPD

--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -234,8 +234,7 @@ class Solver
         // Compute and communicate weighted volume for LPS (does nothing for
         // PMB). Only computed once without fracture (and inside updateForce for
         // fracture).
-        if constexpr ( !is_fracture<
-                           typename force_model_type::fracture_type>::value )
+        if constexpr ( !is_fracture<force_model_type>::value )
         {
             force->computeWeightedVolume( particles, neigh_iter_tag{} );
             comm->gatherWeightedVolume();
@@ -466,8 +465,7 @@ class Solver
     {
         // Compute and communicate weighted volume for LPS (does nothing for
         // PMB). Only computed once without fracture.
-        if constexpr ( is_fracture<
-                           typename force_model_type::fracture_type>::value )
+        if constexpr ( is_fracture<force_model_type>::value )
         {
             force->computeWeightedVolume( particles, neigh_iter_tag{} );
             comm->gatherWeightedVolume();
@@ -516,8 +514,7 @@ class Solver
         // All ranks must reduce - do this outside the if block since only rank
         // 0 will print below.
         double global_damage = 0.0;
-        if constexpr ( is_fracture<
-                           typename force_model_type::fracture_type>::value )
+        if constexpr ( is_fracture<force_model_type>::value )
         {
             global_damage = updateGlobal( force->totalDamage() );
         }
@@ -627,9 +624,8 @@ class Solver
     void init_prenotch( Prenotch<NumPrenotch> prenotch )
     {
         _total_timer.start();
-        static_assert(
-            is_fracture<typename force_model_type::fracture_type>::value,
-            "Cannot create prenotch in system without fracture." );
+        static_assert( is_fracture<force_model_type>::value,
+                       "Cannot create prenotch in system without fracture." );
 
         // Create prenotch.
         force->prenotch( exec_space{}, particles, prenotch );

--- a/src/CabanaPD_Timer.hpp
+++ b/src/CabanaPD_Timer.hpp
@@ -48,6 +48,11 @@ class Timer
         _running = false;
     }
     void reset() { _time = 0.0; }
+    void set( const double val )
+    {
+        _time = val;
+        _last_time = val;
+    }
     bool running() { return _running; }
     auto time() { return _time; }
     auto minTime() { return _min_time; }

--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -23,12 +23,20 @@ struct NoFracture
 struct Fracture
 {
 };
-template <class>
+template <class, class SFINAE = void>
 struct is_fracture : public std::false_type
 {
 };
 template <>
 struct is_fracture<Fracture> : public std::true_type
+{
+};
+template <typename ModelType>
+struct is_fracture<
+    ModelType,
+    typename std::enable_if<( std::is_same<typename ModelType::fracture_type,
+                                           Fracture>::value )>::type>
+    : public std::true_type
 {
 };
 


### PR DESCRIPTION
Timings differ for:

- PD only (only output final neighbor time)
- DEM only (output neighbor time per step)
- Hybrid (output both PD and DEM force time and neighbor time)

Simplify internal solver timers as well 