### PR TITLE
Use Kokkos legacy Views for nightly builds

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -26,7 +26,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DCMAKE_INSTALL_PREFIX=$HOME/kokkos \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \
-            -DKokkos_ENABLE_DEPRECATED_CODE_3=OFF
+            -DKokkos_ENABLE_DEPRECATED_CODE_3=OFF \
+            -DKokkos_ENABLE_IMPL_VIEW_LEGACY=ON
           cmake --build build --parallel 2
           cmake --install build
       - name: Checkout Cabana


### PR DESCRIPTION
Incompatibility with Kokkos `develop` breaks Cabana without this flag 