### PR TITLE
Test model construction and fix thermal plasticity model

### DIFF
--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -55,6 +55,22 @@ struct Pair
 struct State
 {
 };
+template <class, class SFINAE = void>
+struct is_state_based : public std::false_type
+{
+};
+template <>
+struct is_state_based<State> : public std::true_type
+{
+};
+template <typename ModelType>
+struct is_state_based<
+    ModelType,
+    typename std::enable_if<(
+        std::is_same<typename ModelType::base_type, State>::value )>::type>
+    : public std::true_type
+{
+};
 
 // Material option tags.
 struct SingleMaterial

--- a/src/force_models/CabanaPD_LPS.hpp
+++ b/src/force_models/CabanaPD_LPS.hpp
@@ -262,6 +262,14 @@ struct ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>
         init();
     }
 
+    ForceModel( LPS model, Elastic, const double _delta, const double _K,
+                const double _G, const double _G0, const int _influence = 0 )
+        : base_type( model, NoFracture{}, _delta, _K, _G, _influence )
+        , base_fracture_type( _delta, _K, _G0, _influence )
+    {
+        init();
+    }
+
     ForceModel( LPS model, Elastic elastic, Fracture, const double _delta,
                 const double _K, const double _G, const double _G0,
                 const int _influence = 0 )
@@ -342,13 +350,23 @@ ForceModel( ModelType, NoFracture, const double delta, const double K,
 
 template <typename ModelType>
 ForceModel( ModelType, Elastic, const double delta, const double K,
-            const double G, const int influence = 0 )
+            const double G, const double _G0, const int influence = 0,
+            typename std::enable_if<( is_state_based<ModelType>::value ),
+                                    int>::type* = 0 )
+    -> ForceModel<ModelType, Elastic>;
+
+template <typename ModelType>
+ForceModel( ModelType, Elastic, Fracture, const double delta, const double K,
+            const double G, const double _G0, const int influence = 0,
+            typename std::enable_if<( is_state_based<ModelType>::value ),
+                                    int>::type* = 0 )
     -> ForceModel<ModelType, Elastic>;
 
 template <typename ModelType>
 ForceModel( ModelType, const double _delta, const double _K, const double _G,
-            const double _G0, const int _influence = 0 )
-    -> ForceModel<ModelType>;
+            const double _G0, const int _influence = 0,
+            typename std::enable_if<( is_state_based<ModelType>::value ),
+                                    int>::type* = 0 ) -> ForceModel<ModelType>;
 
 } // namespace CabanaPD
 

--- a/src/force_models/CabanaPD_PMB.hpp
+++ b/src/force_models/CabanaPD_PMB.hpp
@@ -197,6 +197,20 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
     {
     }
 
+    ForceModel( PMB model, Fracture, const double delta, const double K,
+                const double G0, const int influence_type = 1 )
+        : base_type( model, Elastic{}, NoFracture{}, delta, K )
+        , base_fracture_type( delta, K, G0, influence_type )
+    {
+    }
+
+    ForceModel( PMB model, Elastic, Fracture, const double delta,
+                const double K, const double G0, const int influence_type = 1 )
+        : base_type( model, NoFracture{}, delta, K )
+        , base_fracture_type( delta, K, G0, influence_type )
+    {
+    }
+
     // Constructor to work with plasticity.
     ForceModel( PMB model, Elastic elastic, const double delta, const double K,
                 const double G0, const double s0 )
@@ -290,6 +304,10 @@ struct ForceModel<LinearPMB, Elastic, Fracture, TemperatureIndependent>
 template <typename ModelType>
 ForceModel( ModelType, Elastic, NoFracture, const double delta, const double K )
     -> ForceModel<ModelType, Elastic, NoFracture>;
+
+template <typename ModelType>
+ForceModel( ModelType, Elastic, Fracture, const double delta, const double K,
+            const double G0 ) -> ForceModel<ModelType, Elastic>;
 
 // Default to fracture.
 template <typename ModelType>

--- a/src/force_models/CabanaPD_PMB.hpp
+++ b/src/force_models/CabanaPD_PMB.hpp
@@ -375,10 +375,12 @@ struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, TemperatureDependent,
     using base_type::operator();
     using base_temperature_type::operator();
 
-    ForceModel( const double _delta, const double _K, const double _G0,
+    ForceModel( PMB model, ElasticPerfectlyPlastic mechanics,
+                const double _delta, const double _K, const double _G0,
                 const double sigma_y, const TemperatureType _temp,
                 const double _alpha, const double _temp0 = 0.0 )
-        : base_type( _delta, _K, _G0, sigma_y )
+        : base_type( model, mechanics, typename TemperatureType::memory_space{},
+                     _delta, _K, sigma_y )
         , base_temperature_type( _delta, _K, _G0, _temp, _alpha, _temp0 )
     {
     }
@@ -397,6 +399,14 @@ ForceModel( ModelType, const double delta, const double K, const double _G0,
             const double temp0 = 0.0 )
     -> ForceModel<ModelType, Elastic, Fracture, TemperatureDependent,
                   TemperatureType>;
+
+template <typename ModelType, typename TemperatureType>
+ForceModel( ModelType, ElasticPerfectlyPlastic, const double delta,
+            const double K, const double _G0, const double sigma_y,
+            const TemperatureType& temp, const double alpha,
+            const double temp0 = 0.0 )
+    -> ForceModel<ModelType, ElasticPerfectlyPlastic, Fracture,
+                  TemperatureDependent, TemperatureType>;
 
 template <typename TemperatureType>
 struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>

--- a/src/force_models/CabanaPD_PMB.hpp
+++ b/src/force_models/CabanaPD_PMB.hpp
@@ -502,6 +502,48 @@ ForceModel( ModelType, const double delta, const double K, const double G0,
     -> ForceModel<ModelType, Elastic, Fracture, DynamicTemperature,
                   TemperatureType>;
 
+template <typename TemperatureType>
+struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, DynamicTemperature,
+                  TemperatureType>
+    : public BaseForceModelPMB<ElasticPerfectlyPlastic,
+                               typename TemperatureType::memory_space>,
+      public ThermalFractureModel<TemperatureType>,
+      BaseDynamicTemperatureModel
+{
+    using base_type = BaseForceModelPMB<ElasticPerfectlyPlastic,
+                                        typename TemperatureType::memory_space>;
+    using base_temperature_type = ThermalFractureModel<TemperatureType>;
+    using base_heat_transfer_type = BaseDynamicTemperatureModel;
+
+    // Necessary to distinguish between TemperatureDependent
+    using thermal_type = DynamicTemperature;
+
+    using base_type::operator();
+    using base_temperature_type::operator();
+
+    ForceModel( PMB model, ElasticPerfectlyPlastic mechanics,
+                const double _delta, const double _K, const double _G0,
+                const double sigma_y, const TemperatureType _temp,
+                const double _kappa, const double _cp, const double _alpha,
+                const double _temp0 = 0.0,
+                const bool _constant_microconductivity = true )
+        : base_type( model, mechanics, typename TemperatureType::memory_space{},
+                     _delta, _K, sigma_y )
+        , base_temperature_type( _delta, _K, _G0, _temp, _alpha, _temp0 )
+        , base_heat_transfer_type( _delta, _kappa, _cp,
+                                   _constant_microconductivity )
+    {
+    }
+};
+
+template <typename ModelType, typename TemperatureType>
+ForceModel( ModelType, ElasticPerfectlyPlastic, const double delta,
+            const double K, const double G0, const double sigma_y,
+            const TemperatureType& temp, const double kappa, const double cp,
+            const double alpha, const double temp0 = 0.0,
+            const bool constant_microconductivity = true )
+    -> ForceModel<ModelType, ElasticPerfectlyPlastic, Fracture,
+                  DynamicTemperature, TemperatureType>;
 } // namespace CabanaPD
 
 #endif

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -58,6 +58,6 @@ macro(CabanaPD_add_tests)
   endforeach()
 endmacro()
 
-CabanaPD_add_tests(NAMES Particles Force Integrator Hertz HertzJKR)
+CabanaPD_add_tests(NAMES Particles Force Integrator NormalRepulsion Hertz HertzJKR)
 
 CabanaPD_add_tests(MPI NAMES Comm)

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -989,6 +989,12 @@ TEST( TEST_CATEGORY, test_force_pmb_construct )
         CabanaPD::ForceModel force_model( CabanaPD::PMB{}, delta, K, G0, temp,
                                           kappa, cp, alpha, temp0 );
     }
+    {
+        //  With EPP.
+        CabanaPD::ForceModel force_model(
+            CabanaPD::PMB{}, CabanaPD::ElasticPerfectlyPlastic{}, delta, K, G0,
+            sigma_y, temp, kappa, cp, alpha, temp0 );
+    }
 }
 
 // Test construction of all LPS models.

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -910,6 +910,120 @@ void testForce( ModelType model, const double dx, const double m,
 //---------------------------------------------------------------------------//
 // GTest tests.
 //---------------------------------------------------------------------------//
+
+// Test construction of all PMB models.
+TEST( TEST_CATEGORY, test_force_pmb_construct )
+{
+    double delta = 5.0;
+    double K = 1.0;
+    double G0 = 100.0;
+
+    {
+        // With defaults.
+        CabanaPD::ForceModel model( CabanaPD::PMB{}, delta, K, G0 );
+    }
+    {
+        // With mechanics input.
+        CabanaPD::ForceModel model( CabanaPD::PMB{}, CabanaPD::Elastic{}, delta,
+                                    K, G0 );
+    }
+    {
+        // With all inputs.
+        CabanaPD::ForceModel model( CabanaPD::PMB{}, CabanaPD::Elastic{},
+                                    CabanaPD::Fracture{}, delta, K, G0 );
+    }
+    // Without fracture.
+    {
+        CabanaPD::ForceModel model( CabanaPD::PMB{}, CabanaPD::Elastic{},
+                                    CabanaPD::NoFracture{}, delta, K );
+    }
+    {
+        CabanaPD::ForceModel model( CabanaPD::PMB{}, CabanaPD::NoFracture{},
+                                    delta, K );
+    }
+    // With EPP (cannot be run without fracture).
+    double sigma_y = 10.0;
+    {
+        CabanaPD::ForceModel force_model(
+            CabanaPD::PMB{}, CabanaPD::ElasticPerfectlyPlastic{},
+            TEST_MEMSPACE{}, delta, K, G0, sigma_y );
+    }
+
+    // With thermomechanics.
+    double alpha = 1.0;
+    double temp0 = 0.0;
+    std::array<double, 3> box_min = { -1.0, -1.0, -1.0 };
+    std::array<double, 3> box_max = { 1.0, 1.0, 1.0 };
+    std::array<int, 3> num_cells = { 10, 10, 10 };
+    CabanaPD::Particles particles( TEST_MEMSPACE{}, CabanaPD::PMB{},
+                                   CabanaPD::TemperatureDependent{}, box_min,
+                                   box_max, num_cells, 0, TEST_EXECSPACE{} );
+    auto temp = particles.sliceTemperature();
+    {
+        //  With elastic, without fracture.
+        CabanaPD::ForceModel force_model( CabanaPD::PMB{},
+                                          CabanaPD::NoFracture{}, delta, K,
+                                          temp, alpha, temp0 );
+    }
+    {
+        //  With elastic.
+        CabanaPD::ForceModel force_model( CabanaPD::PMB{}, delta, K, G0, temp,
+                                          alpha, temp0 );
+    }
+    {
+        //  With EPP.
+        CabanaPD::ForceModel force_model(
+            CabanaPD::PMB{}, CabanaPD::ElasticPerfectlyPlastic{}, delta, K, G0,
+            sigma_y, temp, alpha, temp0 );
+    }
+
+    // With heat transfer.
+    double kappa = 1.0;
+    double cp = 1.0;
+    {
+        CabanaPD::ForceModel force_model( CabanaPD::PMB{},
+                                          CabanaPD::NoFracture{}, delta, K,
+                                          temp, kappa, cp, alpha, temp0 );
+    }
+    {
+        CabanaPD::ForceModel force_model( CabanaPD::PMB{}, delta, K, G0, temp,
+                                          kappa, cp, alpha, temp0 );
+    }
+}
+
+// Test construction of all LPS models.
+TEST( TEST_CATEGORY, test_force_lps_construct )
+{
+    double delta = 5.0;
+    double K = 1.0;
+    double G = 2.0;
+    double G0 = 100.0;
+
+    {
+        // LPS with defaults.
+        CabanaPD::ForceModel model( CabanaPD::LPS{}, delta, K, G, G0, 1 );
+    }
+    {
+        // LPS with mechanics input.
+        CabanaPD::ForceModel model( CabanaPD::LPS{}, CabanaPD::Elastic{}, delta,
+                                    K, G, G0, 1 );
+    }
+    {
+        // LPS with all inputs.
+        CabanaPD::ForceModel model( CabanaPD::LPS{}, CabanaPD::Elastic{},
+                                    CabanaPD::Fracture{}, delta, K, G, G0, 1 );
+    }
+    // LPS without fracture.
+    {
+        CabanaPD::ForceModel model( CabanaPD::LPS{}, CabanaPD::Elastic{},
+                                    CabanaPD::NoFracture{}, delta, K, G, 1 );
+    }
+    {
+        CabanaPD::ForceModel model( CabanaPD::LPS{}, CabanaPD::NoFracture{},
+                                    delta, K, G, 1 );
+    }
+}
+
 TEST( TEST_CATEGORY, test_force_pmb )
 {
     // dx needs to be decreased for increased m: boundary particles are ignored.

--- a/unit_test/tstHertz.hpp
+++ b/unit_test/tstHertz.hpp
@@ -135,6 +135,17 @@ void testHertzianContact( const std::string filename )
     EXPECT_NEAR( std::sqrt( ke_f / ke_i ), e, 1e-3 );
 }
 
+// Test construction.
+TEST( TEST_CATEGORY, test_force_lps_construct )
+{
+    double radius = 5.0;
+    double extend = 1.0;
+    double nu = 2.0;
+    double E = 100.0;
+    double e = 1.0;
+    CabanaPD::HertzianModel contact_model( radius, extend, nu, E, e );
+}
+
 TEST( TEST_CATEGORY, test_hertzian_contact )
 {
     std::string input = "hertzian_contact.json";

--- a/unit_test/tstHertz.hpp
+++ b/unit_test/tstHertz.hpp
@@ -136,7 +136,7 @@ void testHertzianContact( const std::string filename )
 }
 
 // Test construction.
-TEST( TEST_CATEGORY, test_force_lps_construct )
+TEST( TEST_CATEGORY, test_force_hertz_construct )
 {
     double radius = 5.0;
     double extend = 1.0;

--- a/unit_test/tstHertzJKR.hpp
+++ b/unit_test/tstHertzJKR.hpp
@@ -148,7 +148,7 @@ void testHertzianJKRContact( const std::string filename )
 }
 
 // Test construction.
-TEST( TEST_CATEGORY, test_force_lps_construct )
+TEST( TEST_CATEGORY, test_force_jkr_construct )
 {
     double radius = 5.0;
     double extend = 1.0;

--- a/unit_test/tstHertzJKR.hpp
+++ b/unit_test/tstHertzJKR.hpp
@@ -147,6 +147,18 @@ void testHertzianJKRContact( const std::string filename )
     // the plain Hertz unit test.
 }
 
+// Test construction.
+TEST( TEST_CATEGORY, test_force_lps_construct )
+{
+    double radius = 5.0;
+    double extend = 1.0;
+    double nu = 2.0;
+    double E = 100.0;
+    double e = 1.0;
+    double gamma = 1.0;
+    CabanaPD::HertzianJKRModel contact_model( radius, extend, nu, E, e, gamma );
+}
+
 TEST( TEST_CATEGORY, test_hertzian_jkr_contact )
 {
     std::string input = "hertzian_jkr_contact.json";

--- a/unit_test/tstNormalRepulsion.hpp
+++ b/unit_test/tstNormalRepulsion.hpp
@@ -1,0 +1,30 @@
+/****************************************************************************
+ * Copyright (c) 2022 by Oak Ridge National Laboratory                      *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of CabanaPD. CabanaPD is distributed under a           *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <CabanaPD.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+namespace Test
+{
+
+// Test construction.
+TEST( TEST_CATEGORY, test_force_normal_construct )
+{
+    double delta = 10.0;
+    double radius = 5.0;
+    double extend = 1.0;
+    double K = 2.0;
+    CabanaPD::NormalRepulsionModel contact_model( delta, radius, extend, K );
+}
+
+} // end namespace Test


### PR DESCRIPTION
Construction of temperature dependent plasticity did not work. It is now

`CabanaPD::ForceModel force_model( model_type{}, ElasticPerfectlyPlastic{}, delta, K, G0, sigma_y, temp, alpha, temp0 );`

- New tests for all PMB/LPS/contact models were added.
- New heat transfer + plasticity model was added.