### PR TITLE
FIx heat transfer with plasticity

### DIFF
--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -106,7 +106,8 @@ class Solver
     using neigh_iter_tag = Cabana::SerialOpTag;
 
     // Optional module types.
-    using heat_transfer_type = HeatTransfer<memory_space, force_model_type>;
+    using heat_transfer_type =
+        HeatTransfer<memory_space, force_model_type, force_fracture_type>;
     using contact_model_type = ContactModelType;
     using contact_model_tag = typename contact_model_type::model_type;
     using contact_fracture_type = typename contact_model_type::fracture_type;


### PR DESCRIPTION
Remove explicit model requirements for heat transfer following #218

This adds the same model generality for heat transfer as in the force update; the plastic model not defining a non-fracture variant, but previously expecting one for inheritance in heat transfer, exemplifies the issue. 