### PR TITLE
Allow `ForceModels` to accept any number of models

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ECP-CoPA/Cabana
-          ref: 0.7.0
+          ref: edb0c7cd2ca32baecf09151ded2ed1ba6070c6fe
           path: cabana
       - name: Build Cabana
         working-directory: cabana
@@ -159,7 +159,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ECP-CoPA/Cabana
-          ref: 0.7.0
+          ref: edb0c7cd2ca32baecf09151ded2ed1ba6070c6fe
           path: cabana
       - name: Build Cabana
         working-directory: cabana
@@ -241,7 +241,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ECP-CoPA/Cabana
-          ref: 0.7.0
+          ref: edb0c7cd2ca32baecf09151ded2ed1ba6070c6fe
           path: cabana
       - name: Build Cabana
         working-directory: cabana

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ CabanaPD has the following dependencies:
 |Dependency | Version  | Required | Details|
 |---------- | -------  |--------  |------- |
 |CMake      | 3.11+    | Yes      | Build system
-|Cabana     | f99c7db9 | Yes      | Performance portable particle algorithms
+|Cabana     | edb0c7cd | Yes      | Performance portable particle algorithms
 |GTest      | 1.10+    | No       | Unit test framework
 
 Cabana must be built with the following in order to work with CabanaPD:
@@ -67,7 +67,7 @@ Cabana must be built with the following in order to work with CabanaPD:
 |---------- | ------- |--------  |------- |
 |CMake      | 3.16+   | Yes      | Build system
 |MPI        | GPU-Aware if CUDA/HIP enabled | Yes | Message Passing Interface
-|Kokkos     | 3.7.0+  | Yes      | Performance portable on-node parallelism
+|Kokkos     | 4.1.0+  | Yes      | Performance portable on-node parallelism
 |HDF5       | master  | No       | Particle output
 |SILO       | master  | No       | Particle output
 

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -268,33 +268,6 @@ struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
                 tag, i, j, args... );
     }
 
-    // This is only for LPS force/energy, currently the only cases that require
-    // type information. When running models individually, the SingleMaterial
-    // tag is used in the model directly;
-    // TODO retire this tag dispatch completely
-    template <typename Tag, typename... Args>
-    KOKKOS_INLINE_FUNCTION auto operator()( Tag tag, SingleMaterial,
-                                            const int i, const int j,
-                                            Args... args ) const
-    {
-        using commonReturnType = typename std::invoke_result_t<
-            typename ParameterPackType::template value_type<0>, Tag,
-            SingleMaterial, const int, const int, Args...>;
-
-        const int type_i = type( i );
-        const int type_j = type( j );
-
-        auto t = getIndex( i, j );
-        // Call individual model.
-        if ( static_cast<unsigned>( t ) < ParameterPackType::size )
-            return run_functor_for_index_in_pack_with_args(
-                IdentityFunctor{}, t, models, tag, SingleMaterial{}, type_i,
-                type_j, args... );
-        else
-            return outsideRangeFunctor.template operator()<commonReturnType>(
-                tag, i, j, args... );
-    }
-
     template <typename ParticleType>
     void update( const ParticleType& particles )
     {

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -195,6 +195,15 @@ struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
                          typename ParameterPackType::template value_type<
                              0>::model_tag>...>),
         "All models need the same base model" );
+
+    // TODO this might be softened in the future
+    static_assert(
+        (std::conjunction_v<
+            std::is_same<typename ParameterPackType::template value_type<
+                             Indices>::force_tag,
+                         typename ParameterPackType::template value_type<
+                             0>::force_tag>...>),
+        "All forces need the same base type" );
     using model_tag =
         typename ParameterPackType::template value_type<0>::model_tag;
 

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -400,7 +400,8 @@ auto createMultiForceModel( ParticleType particles, AverageTag, ModelType1 m1,
     // multiforce model, as the return index of indexing is used to select the
     // model from the model list.
     DiagonalIndexing<3> indexing;
-    return createMultiForceModel( particles, indexing, m1, m2, m12, m23, m13 );
+    return createMultiForceModel( particles, indexing, m1, m2, m3, m12, m23,
+                                  m13 );
 }
 
 template <typename ParticleType, typename ModelType1, typename ModelType2,

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -12,39 +12,210 @@
 #ifndef FORCE_MODELS_MULTI_H
 #define FORCE_MODELS_MULTI_H
 
+#include <CabanaPD_Indexing.hpp>
 #include <CabanaPD_Output.hpp>
 
 namespace CabanaPD
 {
 
-/******************************************************************************
-  Multi-material models
-******************************************************************************/
-struct AverageTag
+namespace Impl
 {
+template <std::size_t current, typename FunctorType, typename ParameterPackType,
+          typename... ARGS,
+          std::enable_if_t<current<ParameterPackType::size - 1, int> = 0>
+              KOKKOS_INLINE_FUNCTION auto
+                  recursion_functor_for_index_in_pack_with_args(
+                      FunctorType const& functor, std::size_t index,
+                      ParameterPackType& parameterPack, ARGS... args )
+{
+    if ( index == current )
+    {
+        return functor( Cabana::get<current>( parameterPack ), args... );
+    }
+    else
+    {
+        return recursion_functor_for_index_in_pack_with_args<current + 1>(
+            functor, index, parameterPack, args... );
+    }
+}
+
+template <std::size_t current, typename FunctorType, typename ParameterPackType,
+          typename... ARGS,
+          std::enable_if_t<current == ParameterPackType::size - 1, int> = 0>
+KOKKOS_INLINE_FUNCTION auto recursion_functor_for_index_in_pack_with_args(
+    FunctorType const& functor, std::size_t index,
+    ParameterPackType& parameterPack, ARGS... args )
+{
+    if ( index == current )
+    {
+        return functor( Cabana::get<current>( parameterPack ), args... );
+    }
+    else
+    {
+        Kokkos::abort( "Requested index not contained in ParameterPack" );
+        return functor( Cabana::get<current>( parameterPack ), args... );
+    }
+}
+
+template <typename FunctorType, typename ParameterPackType, typename... ARGS>
+KOKKOS_INLINE_FUNCTION auto run_functor_for_index_in_pack_with_args(
+    FunctorType const& functor, std::size_t index,
+    ParameterPackType& parameterPack, ARGS... args )
+{
+    return recursion_functor_for_index_in_pack_with_args<0>(
+        functor, index, parameterPack, args... );
+}
+
+struct IdentityFunctor
+{
+    template <typename Model, typename... ARGS>
+    KOKKOS_FUNCTION auto operator()( Model& model, ARGS... args ) const
+    {
+        return model( args... );
+    }
+};
+
+template <typename IfType, typename ElseType, bool Condition>
+struct IfElseType
+{
+    static_assert( !Condition, "IfElseType: We should never end up here" );
+    static_assert( Condition, "IfElseType: We should never end up here" );
+};
+
+template <typename IfType, typename ElseType>
+struct IfElseType<IfType, ElseType, true>
+{
+    using type = IfType;
+};
+
+template <typename IfType, typename ElseType>
+struct IfElseType<IfType, ElseType, false>
+{
+    using type = ElseType;
+};
+
+template <typename ParameterPackType, typename Sequence>
+struct CheckTemperatureDependence
+{
+    static_assert( !std::is_same_v<Sequence, Sequence>,
+                   "CheckTemperatureDependence: We should never end up here" );
+};
+
+template <typename ParameterPackType, std::size_t... Indices>
+struct CheckTemperatureDependence<ParameterPackType,
+                                  std::index_sequence<Indices...>>
+{
+    using type =
+        typename IfElseType<TemperatureDependent, TemperatureIndependent,
+                            std::disjunction_v<std::is_same<
+                                typename ParameterPackType::template value_type<
+                                    Indices>::thermal_type,
+                                TemperatureDependent>...>>::type;
+};
+
+template <typename ParameterPackType, typename Sequence>
+struct CheckFractureModel
+{
+    static_assert( !std::is_same_v<Sequence, Sequence>,
+                   "CheckFractureModel: We should never end up here" );
+};
+
+template <typename ParameterPackType, std::size_t... Indices>
+struct CheckFractureModel<ParameterPackType, std::index_sequence<Indices...>>
+{
+    using type =
+        typename IfElseType<Fracture, NoFracture,
+                            std::disjunction_v<std::is_same<
+                                typename ParameterPackType::template value_type<
+                                    Indices>::fracture_type,
+                                Fracture>...>>::type;
+};
+
+template <typename FractureType, typename ParameterPackType, unsigned Index,
+          bool Condition>
+struct FirstModelWithFractureTypeImpl
+{
+    static_assert(
+        !Condition,
+        "FirstModelWithFractureTypeImpl: We should never end up here" );
+    static_assert(
+        Condition,
+        "FirstModelWithFractureTypeImpl: We should never end up here" );
+};
+
+template <typename FractureType, typename ParameterPackType, unsigned Index>
+struct FirstModelWithFractureTypeImpl<FractureType, ParameterPackType, Index,
+                                      true>
+{
+    using type = typename ParameterPackType::template value_type<Index>;
+};
+
+template <typename FractureType, typename ParameterPackType, unsigned Index>
+struct FirstModelWithFractureTypeImpl<FractureType, ParameterPackType, Index,
+                                      false>
+{
+    using type = typename FirstModelWithFractureTypeImpl<
+        FractureType, ParameterPackType, Index + 1,
+        std::is_same_v<typename ParameterPackType::template value_type<
+                           Index + 1>::fracture_type,
+                       FractureType>>::type;
+};
+
+template <typename FractureType, typename ParameterPackType>
+struct FirstModelWithFractureType
+{
+    using type = typename FirstModelWithFractureTypeImpl<
+        FractureType, ParameterPackType, 0,
+        std::is_same_v<
+            typename ParameterPackType::template value_type<0>::fracture_type,
+            FractureType>>::type;
 };
 
 // Wrap multiple models in a single object.
-// TODO: this currently only supports bi-material systems.
-template <typename MaterialType, typename ModelType1, typename ModelType2,
-          typename ModelType12>
-struct ForceModels
+template <typename MaterialType, typename Indexing, typename ParameterPackType,
+          typename OutsideRangeFunctorType, typename Sequence>
+struct ForceModelsImpl
+{
+    static_assert( !std::is_same_v<Sequence, Sequence>,
+                   "ForceModelsImpl: We should never end up here" );
+};
+
+template <typename MaterialType, typename Indexing, typename ParameterPackType,
+          typename OutsideRangeFunctorType, std::size_t... Indices>
+struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
+                       OutsideRangeFunctorType, std::index_sequence<Indices...>>
 {
     using material_type = MultiMaterial;
-
-    using first_model = ModelType1;
-    using force_tag = typename first_model::force_tag;
-    using model_tag = typename first_model::model_tag;
-    using thermal_type = typename first_model::thermal_type;
-    using fracture_type = typename first_model::fracture_type;
     using needs_update = std::true_type;
 
-    ForceModels( MaterialType t, const ModelType1 m1, ModelType2 m2,
-                 ModelType12 m12 )
+    static_assert(
+        (std::conjunction_v<
+            std::is_same<typename ParameterPackType::template value_type<
+                             Indices>::model_tag,
+                         typename ParameterPackType::template value_type<
+                             0>::model_tag>...>),
+        "All models need the same base model" );
+    using model_tag =
+        typename ParameterPackType::template value_type<0>::model_tag;
+
+    using fracture_type = typename CheckFractureModel<
+        ParameterPackType,
+        std::make_index_sequence<ParameterPackType::size>>::type;
+    using thermal_type = typename CheckTemperatureDependence<
+        ParameterPackType,
+        std::make_index_sequence<ParameterPackType::size>>::type;
+
+    using force_tag =
+        typename FirstModelWithFractureType<fracture_type,
+                                            ParameterPackType>::type::force_tag;
+
+    ForceModelsImpl( MaterialType t, Indexing const& i,
+                     ParameterPackType const& m,
+                     OutsideRangeFunctorType const& o )
         : type( t )
-        , model1( m1 )
-        , model2( m2 )
-        , model12( m12 )
+        , indexing( i )
+        , models( m )
+        , outsideRangeFunctor( o )
     {
         setForceHorizon();
     }
@@ -53,20 +224,14 @@ struct ForceModels
 
     void updateBonds( const int num_local, const int max_neighbors )
     {
-        model1.updateBonds( num_local, max_neighbors );
-        model2.updateBonds( num_local, max_neighbors );
-        model12.updateBonds( num_local, max_neighbors );
+        ( Cabana::get<Indices>( models ).updateBonds( num_local,
+                                                      max_neighbors ),
+          ... );
     }
 
     KOKKOS_INLINE_FUNCTION int getIndex( const int i, const int j ) const
     {
-        const int type_i = type( i );
-        const int type_j = type( j );
-        // FIXME: only for binary.
-        if ( type_i == type_j )
-            return type_i;
-        else
-            return 2;
+        return indexing( type( i ), type( j ) );
     }
 
     // Extract model index and hide template indexing.
@@ -74,16 +239,19 @@ struct ForceModels
     KOKKOS_INLINE_FUNCTION auto operator()( Tag tag, const int i, const int j,
                                             Args... args ) const
     {
+        using commonReturnType = typename std::invoke_result_t<
+            typename ParameterPackType::template value_type<0>, Tag, const int,
+            const int, Args...>;
+
         auto t = getIndex( i, j );
         // Call individual model.
-        if ( t == 0 )
-            return model1( tag, i, j, std::forward<Args>( args )... );
-        else if ( t == 1 )
-            return model2( tag, i, j, std::forward<Args>( args )... );
-        else if ( t == 2 )
-            return model12( tag, i, j, std::forward<Args>( args )... );
+        // if inside the pack
+        if ( static_cast<unsigned>( t ) < ParameterPackType::size )
+            return run_functor_for_index_in_pack_with_args(
+                IdentityFunctor{}, t, models, tag, i, j, args... );
         else
-            Kokkos::abort( "Invalid model index." );
+            return outsideRangeFunctor.template operator()<commonReturnType>(
+                tag, i, j, args... );
     }
 
     // This is only for LPS force/energy, currently the only cases that require
@@ -95,23 +263,23 @@ struct ForceModels
                                             const int i, const int j,
                                             Args... args ) const
     {
+        MultiMaterial mtag;
+        using commonReturnType = typename std::invoke_result_t<
+            typename ParameterPackType::template value_type<0>, Tag,
+            MultiMaterial, const int, const int, Args...>;
+
         const int type_i = type( i );
         const int type_j = type( j );
 
         auto t = getIndex( i, j );
-        MultiMaterial mtag;
         // Call individual model.
-        if ( t == 0 )
-            return model1( tag, mtag, type_i, type_j,
-                           std::forward<Args>( args )... );
-        else if ( t == 1 )
-            return model2( tag, mtag, type_i, type_j,
-                           std::forward<Args>( args )... );
-        else if ( t == 2 )
-            return model12( tag, mtag, type_i, type_j,
-                            std::forward<Args>( args )... );
+        if ( static_cast<unsigned>( t ) < ParameterPackType::size )
+            return run_functor_for_index_in_pack_with_args(
+                IdentityFunctor{}, t, models, tag, mtag, type_i, type_j,
+                args... );
         else
-            Kokkos::abort( "Invalid model index." );
+            return outsideRangeFunctor.template operator()<commonReturnType>(
+                tag, i, j, args... );
     }
 
     template <typename ParticleType>
@@ -119,48 +287,83 @@ struct ForceModels
     {
         type = particles.sliceType();
 
-        // Update any individual model particle fields. One needing update
-        // currently means all need update.
-        if constexpr ( std::is_same_v<typename ModelType1::needs_update,
-                                      std::true_type> )
-        {
-            model1.update( particles );
-            model2.update( particles );
-            model12.update( particles );
-        }
+        // Update any individual model particle fields.
+        (
+            [&]
+            {
+                if constexpr ( std::is_same_v<typename ParameterPackType::
+                                                  template value_type<
+                                                      Indices>::needs_update,
+                                              std::true_type> )
+                    Cabana::get<Indices>( models ).update( particles );
+            }(),
+            ... );
     }
 
     double force_horizon;
     MaterialType type;
-    ModelType1 model1;
-    ModelType2 model2;
-    ModelType12 model12;
+    Indexing indexing;
+    ParameterPackType models;
+    OutsideRangeFunctorType outsideRangeFunctor;
 
   protected:
     void setForceHorizon()
     {
         // Enforce equal cutoff for now.
-        force_horizon = model1.force_horizon;
-        checkHorizon( model2 );
-        checkHorizon( model12 );
-    }
+        const double tol = 1e-10;
+        force_horizon = Cabana::get<1>( models ).force_horizon;
 
-    template <typename Model>
-    auto checkHorizon( Model m, const double tol = 1e-10 )
-    {
-        if ( std::abs( m.force_horizon - force_horizon ) > tol )
+        if ( ( ( std::abs( Cabana::get<Indices>( models ).force_horizon -
+                           force_horizon ) > tol ) ||
+               ... ) )
+        {
             log_err( std::cout, "Horizon for each model must match for "
                                 "multi-material systems." );
+        }
+    }
+};
+} // namespace Impl
+
+/******************************************************************************
+  Multi-material models
+******************************************************************************/
+struct AbortIfOutsideRangeFunctor
+{
+    template <typename ReturnType, typename... Args>
+    KOKKOS_FUNCTION ReturnType operator()( Args... ) const
+    {
+        Kokkos::abort( "Functor outside of range requested" );
+        return ReturnType{};
     }
 };
 
-template <typename ParticleType, typename ModelType1, typename ModelType2,
-          typename ModelType12>
-auto createMultiForceModel( ParticleType particles, ModelType1 m1,
-                            ModelType2 m2, ModelType12 m12 )
+template <typename MaterialType, typename Indexing, typename ParameterPackType,
+          typename OutsideRangeFunctorType = AbortIfOutsideRangeFunctor>
+struct ForceModels
+    : CabanaPD::Impl::ForceModelsImpl<
+          MaterialType, Indexing, ParameterPackType, OutsideRangeFunctorType,
+          std::make_index_sequence<ParameterPackType::size>>
+{
+    ForceModels( MaterialType t, Indexing i, ParameterPackType const& m,
+                 OutsideRangeFunctorType const& o = OutsideRangeFunctorType() )
+        : CabanaPD::Impl::ForceModelsImpl<
+              MaterialType, Indexing, ParameterPackType,
+              OutsideRangeFunctorType,
+              std::make_index_sequence<ParameterPackType::size>>( t, i, m, o )
+    {
+    }
+};
+
+struct AverageTag
+{
+};
+
+template <typename ParticleType, typename Indexing, typename... ModelTypes>
+auto createMultiForceModel( ParticleType particles, Indexing indexing,
+                            ModelTypes... m )
 {
     auto type = particles.sliceType();
-    return ForceModels( type, m1, m2, m12 );
+    return ForceModels( type, indexing, Cabana::makeParameterPack( m... ) );
 }
 
 template <typename ParticleType, typename ModelType1, typename ModelType2>
@@ -168,10 +371,61 @@ auto createMultiForceModel( ParticleType particles, AverageTag, ModelType1 m1,
                             ModelType2 m2 )
 {
     ModelType1 m12( m1, m2 );
-
-    auto type = particles.sliceType();
-    return ForceModels( type, m1, m2, m12 );
+    // the indexing has to match the order that we pass the models to the
+    // multiforce model, as the return index of indexing is used to select the
+    // model from the model list.
+    DiagonalIndexing<2> indexing;
+    return createMultiForceModel( particles, indexing, m1, m2, m12 );
 }
+
+template <typename ParticleType, typename ModelType1, typename ModelType2,
+          typename ModelType3>
+auto createMultiForceModel( ParticleType particles, AverageTag, ModelType1 m1,
+                            ModelType2 m2, ModelType3 m3 )
+{
+    ModelType1 m12( m1, m2 );
+    ModelType2 m23( m2, m3 );
+    ModelType1 m13( m1, m3 );
+
+    // the indexing has to match the order that we pass the models to the
+    // multiforce model, as the return index of indexing is used to select the
+    // model from the model list.
+    DiagonalIndexing<3> indexing;
+    return createMultiForceModel( particles, indexing, m1, m2, m12, m23, m13 );
+}
+
+template <typename ParticleType, typename ModelType1, typename ModelType2,
+          typename ModelType3, typename ModelType4>
+auto createMultiForceModel( ParticleType particles, AverageTag, ModelType1 m1,
+                            ModelType2 m2, ModelType3 m3, ModelType4 m4 )
+{
+    ModelType1 m12( m1, m2 );
+    ModelType2 m23( m2, m3 );
+    ModelType3 m34( m3, m4 );
+
+    ModelType1 m13( m1, m3 );
+    ModelType2 m24( m2, m4 );
+
+    ModelType1 m14( m1, m4 );
+
+    // the indexing has to match the order that we pass the models to the
+    // multiforce model, as the return index of indexing is used to select the
+    // model from the model list.
+    DiagonalIndexing<4> indexing;
+    return createMultiForceModel( particles, indexing, m1, m2, m3, m4, m12, m23,
+                                  m34, m13, m24, m14 );
+}
+
+// TODO autogenerate indexing for arbitrary case
+// template <typename ParticleType, typename... ModelTypes>
+// auto createMultiForceModel( ParticleType particles, AverageTag, ModelTypes...
+// m )
+//{
+//    DiagonalIndexing<sizeof(ModelTypes...)> indexing;
+//    auto models = //TODO
+//    return createMultiForceModel( particles, indexing,
+//    Cabana::makeParameterPack( models ) );
+//}
 
 } // namespace CabanaPD
 

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -270,17 +270,16 @@ struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
 
     // This is only for LPS force/energy, currently the only cases that require
     // type information. When running models individually, the SingleMaterial
-    // tag is used in the model directly; here it is replaced with the
-    // MultiMaterial tag instead.
+    // tag is used in the model directly;
+    // TODO retire this tag dispatch completely
     template <typename Tag, typename... Args>
     KOKKOS_INLINE_FUNCTION auto operator()( Tag tag, SingleMaterial,
                                             const int i, const int j,
                                             Args... args ) const
     {
-        MultiMaterial mtag;
         using commonReturnType = typename std::invoke_result_t<
             typename ParameterPackType::template value_type<0>, Tag,
-            MultiMaterial, const int, const int, Args...>;
+            SingleMaterial, const int, const int, Args...>;
 
         const int type_i = type( i );
         const int type_j = type( j );
@@ -289,8 +288,8 @@ struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
         // Call individual model.
         if ( static_cast<unsigned>( t ) < ParameterPackType::size )
             return run_functor_for_index_in_pack_with_args(
-                IdentityFunctor{}, t, models, tag, mtag, type_i, type_j,
-                args... );
+                IdentityFunctor{}, t, models, tag, SingleMaterial{}, type_i,
+                type_j, args... );
         else
             return outsideRangeFunctor.template operator()<commonReturnType>(
                 tag, i, j, args... );

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -204,8 +204,13 @@ struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
                          typename ParameterPackType::template value_type<
                              0>::force_tag>...>),
         "All forces need the same base type" );
+
     using model_tag =
         typename ParameterPackType::template value_type<0>::model_tag;
+
+    static_assert( is_symmetric<model_tag>::value ==
+                       is_symmetric<Indexing>::value,
+                   "Symmetry of model and indexing must match" );
 
     using fracture_type = typename CheckFractureModel<
         ParameterPackType,

--- a/src/CabanaPD_Indexing.hpp
+++ b/src/CabanaPD_Indexing.hpp
@@ -50,6 +50,22 @@ struct BinaryIndexing
         return firstType != secondType;
     }
 };
+
+template <unsigned NumBaseModels>
+struct FullIndexing
+{
+    static_assert( NumBaseModels > 0, "NumBaseModels must be larger than 0" );
+
+    KOKKOS_FUNCTION unsigned operator()( unsigned firstType,
+                                         unsigned secondType ) const
+    {
+        if ( firstType >= NumBaseModels || secondType >= NumBaseModels )
+            Kokkos::abort( "Index out of range of FullIndexing" );
+
+        return firstType * NumBaseModels + secondType;
+    }
+};
+
 } // namespace CabanaPD
 
 #endif

--- a/src/CabanaPD_Indexing.hpp
+++ b/src/CabanaPD_Indexing.hpp
@@ -42,17 +42,11 @@ struct DiagonalIndexing
 };
 
 // Index same type as 0 and differing types as 1.
-template <unsigned NumBaseModels>
 struct BinaryIndexing
 {
-    static_assert( NumBaseModels > 0, "NumBaseModels must be larger than 0" );
-
     KOKKOS_FUNCTION unsigned operator()( unsigned firstType,
                                          unsigned secondType ) const
     {
-        KOKKOS_ASSERT( firstType < NumBaseModels );
-        KOKKOS_ASSERT( secondType < NumBaseModels );
-
         return firstType != secondType;
     }
 };

--- a/src/CabanaPD_Indexing.hpp
+++ b/src/CabanaPD_Indexing.hpp
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * Copyright (c) 2022 by Oak Ridge National Laboratory                      *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of CabanaPD. CabanaPD is distributed under a           *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef INDEXING_H
+#define INDEXING_H
+
+namespace CabanaPD
+{
+// Index along each diagonal sequentially (symmetric).
+template <unsigned NumBaseModels>
+struct DiagonalIndexing
+{
+    static_assert( NumBaseModels > 0, "NumBaseModels must be larger than 0" );
+
+    KOKKOS_FUNCTION unsigned operator()( unsigned firstType,
+                                         unsigned secondType ) const
+    {
+        if ( firstType >= NumBaseModels || secondType >= NumBaseModels )
+            Kokkos::abort( "Index out of range of DiagonalIndexing" );
+
+        unsigned diagonalOrder = Kokkos::abs( static_cast<int>( secondType ) -
+                                              static_cast<int>( firstType ) );
+        unsigned offset = 0;
+        for ( unsigned order = 0; order < diagonalOrder; ++order )
+        {
+            offset += NumBaseModels - order;
+        }
+
+        unsigned indexAlongDiagonal =
+            firstType < secondType ? firstType : secondType;
+
+        return offset + indexAlongDiagonal;
+    }
+};
+
+// Index same type as 0 and differing types as 1.
+template <unsigned NumBaseModels>
+struct BinaryIndexing
+{
+    static_assert( NumBaseModels > 0, "NumBaseModels must be larger than 0" );
+
+    KOKKOS_FUNCTION unsigned operator()( unsigned firstType,
+                                         unsigned secondType ) const
+    {
+        KOKKOS_ASSERT( firstType < NumBaseModels );
+        KOKKOS_ASSERT( secondType < NumBaseModels );
+
+        return firstType != secondType;
+    }
+};
+} // namespace CabanaPD
+
+#endif

--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -160,6 +160,36 @@ struct LinearLPS
     using model_tag = LPS;
 };
 
+template <typename T>
+struct is_symmetric : public std::false_type
+{
+};
+// Force models
+template <>
+struct is_symmetric<PMB> : public std::true_type
+{
+};
+
+template <>
+struct is_symmetric<LinearPMB> : public std::true_type
+{
+};
+// Indexing
+template <unsigned NumBaseModels>
+struct DiagonalIndexing;
+
+struct BinaryIndexing;
+
+template <unsigned NumBaseModels>
+struct is_symmetric<DiagonalIndexing<NumBaseModels>> : public std::true_type
+{
+};
+
+template <>
+struct is_symmetric<BinaryIndexing> : public std::true_type
+{
+};
+
 // Contact and DEM (contact without PD) tags.
 struct Contact
 {

--- a/src/force/CabanaPD_LPS.hpp
+++ b/src/force/CabanaPD_LPS.hpp
@@ -163,8 +163,8 @@ class Force<MemorySpace, LPS, NoFracture> : public BaseForce<MemorySpace>
             getDistance( x, u, i, j, xi, r, s, rx, ry, rz );
 
             const double coeff =
-                model( ForceCoeffTag{}, SingleMaterial{}, i, j, s, xi, vol( j ),
-                       m( i ), m( j ), theta( i ), theta( j ) );
+                model( ForceCoeffTag{}, i, j, s, xi, vol( j ), m( i ), m( j ),
+                       theta( i ), theta( j ) );
             fx_i = coeff * rx / r;
             fy_i = coeff * ry / r;
             fz_i = coeff * rz / r;
@@ -204,8 +204,8 @@ class Force<MemorySpace, LPS, NoFracture> : public BaseForce<MemorySpace>
                 Cabana::NeighborList<neighbor_list_type>::numNeighbor(
                     neigh_list, i ) );
 
-            double w = model( EnergyTag{}, SingleMaterial{}, i, j, s, xi,
-                              vol( j ), m( i ), theta( i ), num_neighbors );
+            double w = model( EnergyTag{}, i, j, s, xi, vol( j ), m( i ),
+                              theta( i ), num_neighbors );
             W( i ) += w;
             Phi += w * vol( i );
         };
@@ -238,9 +238,8 @@ class Force<MemorySpace, LPS, NoFracture> : public BaseForce<MemorySpace>
             double xi_x, xi_y, xi_z;
             getDistance( x, u, i, j, xi, r, s, rx, ry, rz, xi_x, xi_y, xi_z );
 
-            double coeff =
-                model( ForceCoeffTag{}, SingleMaterial{}, i, j, s, xi, vol( j ),
-                       m( i ), m( j ), theta( i ), theta( j ) );
+            double coeff = model( ForceCoeffTag{}, i, j, s, xi, vol( j ),
+                                  m( i ), m( j ), theta( i ), theta( j ) );
             coeff *= 0.5;
             const double fx_i = coeff * rx / r;
             const double fy_i = coeff * ry / r;
@@ -425,9 +424,9 @@ class Force<MemorySpace, LPS, Fracture> : public BaseForce<MemorySpace>
                 // avoid dividing by zero.
                 else if ( mu( i, n ) > 0 )
                 {
-                    const double coeff = model(
-                        ForceCoeffTag{}, SingleMaterial{}, i, j, s, xi,
-                        vol( j ), m( i ), m( j ), theta( i ), theta( j ) );
+                    const double coeff =
+                        model( ForceCoeffTag{}, i, j, s, xi, vol( j ), m( i ),
+                               m( j ), theta( i ), theta( j ) );
                     double muij = mu( i, n );
                     fx_i = muij * coeff * rx / r;
                     fy_i = muij * coeff * ry / r;
@@ -483,9 +482,9 @@ class Force<MemorySpace, LPS, Fracture> : public BaseForce<MemorySpace>
                 double xi, r, s;
                 getDistance( x, u, i, j, xi, r, s );
 
-                double w = mu( i, n ) * model( EnergyTag{}, SingleMaterial{}, i,
-                                               j, s, xi, vol( j ), m( i ),
-                                               theta( i ), num_bonds );
+                double w =
+                    mu( i, n ) * model( EnergyTag{}, i, j, s, xi, vol( j ),
+                                        m( i ), theta( i ), num_bonds );
                 W( i ) += w;
 
                 phi_i += mu( i, n ) * vol( j );
@@ -539,9 +538,9 @@ class Force<MemorySpace, LPS, Fracture> : public BaseForce<MemorySpace>
                     getDistance( x, u, i, j, xi, r, s, rx, ry, rz, xi_x, xi_y,
                                  xi_z );
 
-                    double coeff = model( ForceCoeffTag{}, SingleMaterial{}, i,
-                                          j, s, xi, vol( j ), m( i ), m( j ),
-                                          theta( i ), theta( j ) );
+                    double coeff =
+                        model( ForceCoeffTag{}, i, j, s, xi, vol( j ), m( i ),
+                               m( j ), theta( i ), theta( j ) );
                     coeff *= 0.5;
                     const double muij = mu( i, n );
                     const double fx_i = muij * coeff * rx / r;
@@ -618,8 +617,8 @@ class Force<MemorySpace, LinearLPS, NoFracture>
             getLinearizedDistance( x, u, i, j, xi, linear_s, xi_x, xi_y, xi_z );
 
             const double coeff =
-                model( ForceCoeffTag{}, SingleMaterial{}, i, j, linear_s, xi,
-                       vol( j ), m( i ), m( j ), theta( i ), theta( j ) );
+                model( ForceCoeffTag{}, i, j, linear_s, xi, vol( j ), m( i ),
+                       m( j ), theta( i ), theta( j ) );
             fx_i = coeff * xi_x / xi;
             fy_i = coeff * xi_y / xi;
             fz_i = coeff * xi_z / xi;
@@ -661,8 +660,8 @@ class Force<MemorySpace, LinearLPS, NoFracture>
                 Cabana::NeighborList<neighbor_list_type>::numNeighbor(
                     neigh_list, i ) );
 
-            double w = model( EnergyTag{}, SingleMaterial{}, i, j, linear_s, xi,
-                              vol( j ), m( i ), theta( i ), num_neighbors );
+            double w = model( EnergyTag{}, i, j, linear_s, xi, vol( j ), m( i ),
+                              theta( i ), num_neighbors );
             W( i ) += w;
             Phi += w * vol( i );
         };
@@ -695,9 +694,8 @@ class Force<MemorySpace, LinearLPS, NoFracture>
             double xi_x, xi_y, xi_z;
             getLinearizedDistance( x, u, i, j, xi, linear_s, xi_x, xi_y, xi_z );
 
-            double coeff =
-                model( ForceCoeffTag{}, SingleMaterial{}, i, j, linear_s, xi,
-                       vol( j ), m( i ), m( j ), theta( i ), theta( j ) );
+            double coeff = model( ForceCoeffTag{}, i, j, linear_s, xi, vol( j ),
+                                  m( i ), m( j ), theta( i ), theta( j ) );
             coeff *= 0.5;
             const double fx_i = coeff * xi_x / xi;
             const double fy_i = coeff * xi_y / xi;

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -32,6 +32,7 @@
 #include <CabanaPD_ForceModelsMulti.hpp>
 #include <CabanaPD_Input.hpp>
 #include <CabanaPD_Particles.hpp>
+#include <CabanaPD_Types.hpp>
 #include <force/CabanaPD_LPS.hpp>
 #include <force/CabanaPD_PMB.hpp>
 #include <force_models/CabanaPD_LPS.hpp>
@@ -1274,9 +1275,7 @@ TEST( TEST_CATEGORY, test_force_lps_binary )
     double G = 0.5;
     double G0 = 1000.0;
     using model_type = CabanaPD::LPS;
-    CabanaPD::ForceModel model1( model_type{}, CabanaPD::Elastic{},
-                                 CabanaPD::NoFracture{}, force_horizon, K, G,
-                                 1 );
+    CabanaPD::ForceModel model1( model_type{}, force_horizon, K, G, G0, 1 );
     CabanaPD::ForceModel model2( model_type{}, force_horizon, K, G, G0, 1 );
 
     auto particles = createParticles( model_type{}, LinearTag{}, dx, 0.1,
@@ -1340,9 +1339,7 @@ TEST( TEST_CATEGORY, test_force_lps_ternary )
     double G = 0.5;
     double G0 = 1000.0;
     using model_type = CabanaPD::LPS;
-    CabanaPD::ForceModel model1( model_type{}, CabanaPD::Elastic{},
-                                 CabanaPD::NoFracture{}, force_horizon, K, G,
-                                 1 );
+    CabanaPD::ForceModel model1( model_type{}, force_horizon, K, G, G0, 1 );
     CabanaPD::ForceModel model2( model_type{}, force_horizon, K, G, G0, 1 );
     CabanaPD::ForceModel model3( model_type{}, force_horizon, K, G, G0, 1 );
 
@@ -1439,9 +1436,7 @@ TEST( TEST_CATEGORY, test_force_lps_quaternary )
     double G = 0.5;
     double G0 = 1000.0;
     using model_type = CabanaPD::LPS;
-    CabanaPD::ForceModel model1( model_type{}, CabanaPD::Elastic{},
-                                 CabanaPD::NoFracture{}, force_horizon, K, G,
-                                 1 );
+    CabanaPD::ForceModel model1( model_type{}, force_horizon, K, G, G0, 1 );
     CabanaPD::ForceModel model2( model_type{}, force_horizon, K, G, G0, 1 );
     CabanaPD::ForceModel model3( model_type{}, force_horizon, K, G, G0, 1 );
     CabanaPD::ForceModel model4( model_type{}, force_horizon, K, G, G0, 1 );
@@ -1471,9 +1466,11 @@ namespace
 struct FirstTestTag
 {
 };
+
 struct BaseModelDummy
 {
 };
+
 struct BaseForceDummy
 {
 };
@@ -1526,7 +1523,7 @@ struct TestModel
 
 TEST( TEST_CATEGORY, test_forceModelsMulti_binary )
 {
-    int parameter[3] = { 1, 2, 3 };
+    int parameter[4] = { 1, 2, 3, 4 };
     TestModel<TestModelType<BaseModelDummy>, BaseForceDummy,
               CabanaPD::NoFracture, CabanaPD::TemperatureIndependent>
         model1{ 0, 0, parameter[0] };
@@ -1536,10 +1533,13 @@ TEST( TEST_CATEGORY, test_forceModelsMulti_binary )
     TestModel<TestModelType<BaseModelDummy>, BaseForceDummy, CabanaPD::Fracture,
               CabanaPD::TemperatureIndependent>
         model12{ 0, 1, parameter[2] };
+    TestModel<TestModelType<BaseModelDummy>, BaseForceDummy, CabanaPD::Fracture,
+              CabanaPD::TemperatureIndependent>
+        model21{ 1, 0, parameter[3] };
 
     CabanaPD::ForceModels models(
-        TestModelType<BaseModelDummy>{}, CabanaPD::DiagonalIndexing<2>{},
-        Cabana::makeParameterPack( model1, model2, model12 ) );
+        TestModelType<BaseModelDummy>{}, CabanaPD::FullIndexing<2>{},
+        Cabana::makeParameterPack( model1, model12, model21, model2 ) );
 
     static_assert( std::is_same_v<CabanaPD::Fracture,
                                   typename decltype( models )::fracture_type> );
@@ -1549,6 +1549,7 @@ TEST( TEST_CATEGORY, test_forceModelsMulti_binary )
     models( FirstTestTag{}, CabanaPD::SingleMaterial{}, 0, 0, parameter[0] );
     models( FirstTestTag{}, CabanaPD::SingleMaterial{}, 1, 1, parameter[1] );
     models( FirstTestTag{}, CabanaPD::SingleMaterial{}, 0, 1, parameter[2] );
+    models( FirstTestTag{}, CabanaPD::SingleMaterial{}, 1, 0, parameter[3] );
 }
 
 } // end namespace Test

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -1512,7 +1512,7 @@ struct TestModel
     }
 
     KOKKOS_INLINE_FUNCTION bool operator()( FirstTestTag,
-                                            CabanaPD::MultiMaterial,
+                                            CabanaPD::SingleMaterial,
                                             const int typeI, const int typeJ,
                                             const int inputValue ) const
     {

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -376,8 +376,7 @@ auto computeReferenceStress(
                 {
                     // We assume the dilatation and weighted volume are constant
                     f_mag =
-                        model( CabanaPD::ForceCoeffTag{},
-                               CabanaPD::SingleMaterial{}, 0, 0, s0, xi, vol,
+                        model( CabanaPD::ForceCoeffTag{}, 0, 0, s0, xi, vol,
                                weighted_volume, weighted_volume, theta, theta );
                     f_x = f_mag * xi_x / xi;
                     f_y = f_mag * xi_y / xi;
@@ -428,8 +427,7 @@ double computeReferenceStrainEnergyDensity(
 
                 if ( xi > 0.0 && xi < model.force_horizon + 1e-14 )
                 {
-                    W += model( CabanaPD::EnergyTag{},
-                                CabanaPD::SingleMaterial{}, 0, 0, s0, xi, vol,
+                    W += model( CabanaPD::EnergyTag{}, 0, 0, s0, xi, vol,
                                 weighted_volume, theta, num_neighbors );
                 }
             }
@@ -472,8 +470,7 @@ double computeReferenceStrainEnergyDensity(
 
                 if ( xi > 0.0 && xi < model.force_horizon + 1e-14 )
                 {
-                    W += model( CabanaPD::EnergyTag{},
-                                CabanaPD::SingleMaterial{}, 0, 0, s, xi, vol,
+                    W += model( CabanaPD::EnergyTag{}, 0, 0, s, xi, vol,
                                 weighted_volume, theta_i, num_neighbors );
                 }
             }
@@ -517,8 +514,7 @@ double computeReferenceForceX(
                     model, m, u11, vol, weighted_volume, x_j );
                 if ( xi > 0.0 && xi < model.force_horizon + 1e-14 )
                 {
-                    fx += model( CabanaPD::ForceCoeffTag{},
-                                 CabanaPD::SingleMaterial{}, 0, 0, s, xi, vol,
+                    fx += model( CabanaPD::ForceCoeffTag{}, 0, 0, s, xi, vol,
                                  weighted_volume, weighted_volume, theta_i,
                                  theta_j ) *
                           rx / r;
@@ -1546,10 +1542,10 @@ TEST( TEST_CATEGORY, test_forceModelsMulti_binary )
     static_assert( std::is_same_v<CabanaPD::TemperatureDependent,
                                   typename decltype( models )::thermal_type> );
 
-    models( FirstTestTag{}, CabanaPD::SingleMaterial{}, 0, 0, parameter[0] );
-    models( FirstTestTag{}, CabanaPD::SingleMaterial{}, 1, 1, parameter[1] );
-    models( FirstTestTag{}, CabanaPD::SingleMaterial{}, 0, 1, parameter[2] );
-    models( FirstTestTag{}, CabanaPD::SingleMaterial{}, 1, 0, parameter[3] );
+    models( FirstTestTag{}, 0, 0, parameter[0] );
+    models( FirstTestTag{}, 1, 1, parameter[1] );
+    models( FirstTestTag{}, 0, 1, parameter[2] );
+    models( FirstTestTag{}, 1, 0, parameter[3] );
 }
 
 } // end namespace Test

--- a/unit_test/tstIndexing.hpp
+++ b/unit_test/tstIndexing.hpp
@@ -97,33 +97,18 @@ TEST( TEST_CATEGORY, test_diagonalIndexing_death )
 
 TEST( TEST_CATEGORY, test_binaryIndexing )
 {
-    // test binary indexing for N=1
-    CabanaPD::BinaryIndexing<1> indexing1;
-
-    ASSERT_EQ( indexing1( 0, 0 ), 0 );
-
-    // test binary indexing for N=2
-    CabanaPD::BinaryIndexing<2> indexing2;
-
-    // main binary
-    ASSERT_EQ( indexing2( 0, 0 ), 0 );
-    ASSERT_EQ( indexing2( 1, 1 ), 0 );
-
-    // first minor binary (incl symmetric terms)
-    ASSERT_EQ( indexing2( 0, 1 ), 1 );
-    ASSERT_EQ( indexing2( 1, 0 ), 1 );
+    // test binary indexing
+    CabanaPD::BinaryIndexing indexing;
 
     // test binary indexing for N=3
-    CabanaPD::BinaryIndexing<3> indexing3;
-
     for ( unsigned i = 0; 3 < i; ++i )
     {
         for ( unsigned j = 0; 3 < j; ++j )
         {
             if ( i == j )
-                ASSERT_EQ( indexing3( i, j ), 0 );
+                ASSERT_EQ( indexing( i, j ), 0 );
             else
-                ASSERT_EQ( indexing3( i, j ), 1 );
+                ASSERT_EQ( indexing( i, j ), 1 );
         }
     }
 }

--- a/unit_test/tstIndexing.hpp
+++ b/unit_test/tstIndexing.hpp
@@ -1,0 +1,150 @@
+/****************************************************************************
+ * Copyright (c) 2022 by Oak Ridge National Laboratory                      *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of CabanaPD. CabanaPD is distributed under a           *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Copyright (c) 2018-2021 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <Cabana_Core.hpp>
+#include <Kokkos_Core.hpp>
+
+#include <CabanaPD_Indexing.hpp>
+#include <CabanaPD_config.hpp>
+
+#include <type_traits>
+
+namespace Test
+{
+
+TEST( TEST_CATEGORY, test_diagonalIndexing )
+{
+    // since DiagonalIndexing is a generative indexing following the diagonals
+    // of a matrix of combinations of types,
+    // it is tested with an induction proof. for the first element (N=1) this is
+    // trivial. If it holds for N=2 and N=3 then the indexing should also be
+    // valid for higher values of N.
+
+    // test diagonal indexing for N=1
+    CabanaPD::DiagonalIndexing<1> indexing1;
+
+    ASSERT_EQ( indexing1( 0, 0 ), 0 );
+
+    // test diagonal indexing for N=2
+    CabanaPD::DiagonalIndexing<2> indexing2;
+
+    // main diagonal
+    ASSERT_EQ( indexing2( 0, 0 ), 0 );
+    ASSERT_EQ( indexing2( 1, 1 ), 1 );
+
+    // first minor diagonal (incl symmetric terms)
+    ASSERT_EQ( indexing2( 0, 1 ), 2 );
+    ASSERT_EQ( indexing2( 1, 0 ), 2 );
+
+    // test diagonal indexing for N=3
+    CabanaPD::DiagonalIndexing<3> indexing3;
+
+    // main diagonal
+    ASSERT_EQ( indexing3( 0, 0 ), 0 );
+    ASSERT_EQ( indexing3( 1, 1 ), 1 );
+    ASSERT_EQ( indexing3( 2, 2 ), 2 );
+
+    // first minor diagonal (incl symmetric terms)
+    ASSERT_EQ( indexing3( 0, 1 ), 3 );
+    ASSERT_EQ( indexing3( 1, 2 ), 4 );
+    ASSERT_EQ( indexing3( 1, 0 ), 3 );
+    ASSERT_EQ( indexing3( 2, 1 ), 4 );
+
+    // second minor diagonal (incl symmetric terms)
+    ASSERT_EQ( indexing3( 0, 2 ), 5 );
+    ASSERT_EQ( indexing3( 2, 0 ), 5 );
+}
+
+TEST( TEST_CATEGORY, test_diagonalIndexing_death )
+{
+    // assert death for out of scope indexing
+    ASSERT_DEATH(
+        {
+            CabanaPD::DiagonalIndexing<2> indexing;
+            auto i = indexing( 2, 0 );
+            (void)i;
+        },
+        "Index out of range of DiagonalIndexing" );
+    ASSERT_DEATH(
+        {
+            CabanaPD::DiagonalIndexing<2> indexing;
+            auto i = indexing( 0, 2 );
+            (void)i;
+        },
+        "Index out of range of DiagonalIndexing" );
+}
+
+TEST( TEST_CATEGORY, test_binaryIndexing )
+{
+    // test binary indexing for N=1
+    CabanaPD::BinaryIndexing<1> indexing1;
+
+    ASSERT_EQ( indexing1( 0, 0 ), 0 );
+
+    // test binary indexing for N=2
+    CabanaPD::BinaryIndexing<2> indexing2;
+
+    // main binary
+    ASSERT_EQ( indexing2( 0, 0 ), 0 );
+    ASSERT_EQ( indexing2( 1, 1 ), 0 );
+
+    // first minor binary (incl symmetric terms)
+    ASSERT_EQ( indexing2( 0, 1 ), 1 );
+    ASSERT_EQ( indexing2( 1, 0 ), 1 );
+
+    // test binary indexing for N=3
+    CabanaPD::BinaryIndexing<3> indexing3;
+
+    for ( unsigned i = 0; 3 < i; ++i )
+    {
+        for ( unsigned j = 0; 3 < j; ++j )
+        {
+            if ( i == j )
+                ASSERT_EQ( indexing3( i, j ), 0 );
+            else
+                ASSERT_EQ( indexing3( i, j ), 1 );
+        }
+    }
+}
+
+TEST( TEST_CATEGORY, test_binaryIndexing_death )
+{
+    // assert death for out of scope indexing
+    ASSERT_DEATH(
+        {
+            CabanaPD::BinaryIndexing<2> indexing;
+            auto i = indexing( 2, 0 );
+            (void)i;
+        },
+        "" );
+    ASSERT_DEATH(
+        {
+            CabanaPD::BinaryIndexing<2> indexing;
+            auto i = indexing( 0, 2 );
+            (void)i;
+        },
+        "" );
+}
+
+} // end namespace Test

--- a/unit_test/tstIndexing.hpp
+++ b/unit_test/tstIndexing.hpp
@@ -127,24 +127,4 @@ TEST( TEST_CATEGORY, test_binaryIndexing )
         }
     }
 }
-
-TEST( TEST_CATEGORY, test_binaryIndexing_death )
-{
-    // assert death for out of scope indexing
-    ASSERT_DEATH(
-        {
-            CabanaPD::BinaryIndexing<2> indexing;
-            auto i = indexing( 2, 0 );
-            (void)i;
-        },
-        "" );
-    ASSERT_DEATH(
-        {
-            CabanaPD::BinaryIndexing<2> indexing;
-            auto i = indexing( 0, 2 );
-            (void)i;
-        },
-        "" );
-}
-
 } // end namespace Test


### PR DESCRIPTION
This is a first template for how a the Multiforce model can be changed so it accepts a unspecified number of models.

It requires some meta-template tinkering and some work still:

- [x] It will need https://github.com/ECP-copa/Cabana/pull/855
- [x] We need to decide what to do with the index calculations
- [x] We need to decide what do to with the nested using declarations
