### PR TITLE
Allow automatic variadic model averaging with `DiagonalIndexing` and `FullIndexing` in `ForceModelsMulti`

### DIFF
--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -186,7 +186,7 @@ auto generateAllModelCombinationsForDiagonalIndexing(
         // index in the pair and will get the basemodels of the first and second
         // index in the pair as constructor arguments
         (
-            typename BaseModelPackType::value_type<
+            typename BaseModelPackType::template value_type<
                 IndexingType::template getInverseIndexPair<AveragingIndices>()
                     .first>{
                 Cabana::get<IndexingType::template getInverseIndexPair<

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -179,7 +179,12 @@ auto generateAllModelCombinationsForDiagonalIndexing(
     std::index_sequence<AveragingIndices...> )
 {
     return Cabana::makeParameterPack(
+        // first unpack the base models
         ( Cabana::get<BaseIndices>( baseModels ), ... ),
+        // then create one model per index pair for each index in the averaging
+        // indices the model is created as type of the basemodels of the first
+        // index in the pair and will get the basemodels of the first and second
+        // index in the pair as constructor arguments
         (
             typename BaseModelPackType::value_type<
                 IndexingType::template getInverseIndexPair<AveragingIndices>()
@@ -384,7 +389,8 @@ auto createMultiForceModel( ParticleType particles, AverageTag, ModelType1 m1,
                             ModelType2 m2 )
 {
     using IndexingType = DiagonalIndexing<sizeof...( ModelTypes )>;
-    IndexingType indexing;
+    IndexingType indexing; // needs to support NumTotalModels and
+                           // getInverseIndexPair as constexpr.
     auto type = particles.sliceType();
     auto baseModels = Cabana::makeParameterPack( m... );
 

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -388,9 +388,8 @@ template <
 auto createMultiForceModel( ParticleType particles, AverageTag, ModelType1 m1,
                             ModelType2 m2 )
 {
-    using IndexingType = DiagonalIndexing<sizeof...( ModelTypes )>;
-    IndexingType indexing; // needs to support NumTotalModels and
-                           // getInverseIndexPair as constexpr.
+    // IndexingType needs to support NumTotalModels and
+    // getInverseIndexPair as constexpr.
     auto type = particles.sliceType();
     auto baseModels = Cabana::makeParameterPack( m... );
 
@@ -399,7 +398,7 @@ auto createMultiForceModel( ParticleType particles, AverageTag, ModelType1 m1,
         CabanaPD::Impl::generateAllModelCombinationsForDiagonalIndexing(
             baseModels, indexing,
             std::make_index_sequence<sizeof...( ModelTypes )>{},
-            std::make_index_sequence<IndexingType::NumTotalModels -
+            std::make_index_sequence<indexing.NumTotalModels -
                                      sizeof...( ModelTypes )>{} ) );
 }
 template <

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -345,17 +345,18 @@ struct AbortIfOutsideRangeFunctor
     }
 };
 
-template <typename MaterialType, typename Indexing, typename ParameterPackType,
+template <typename MaterialType, typename IndexingType,
+          typename ParameterPackType,
           typename OutsideRangeFunctorType = AbortIfOutsideRangeFunctor>
-struct ForceModels
-    : CabanaPD::Impl::ForceModelsImpl<
-          MaterialType, Indexing, ParameterPackType, OutsideRangeFunctorType,
-          std::make_index_sequence<ParameterPackType::size>>
+struct ForceModels : CabanaPD::Impl::ForceModelsImpl<
+                         MaterialType, IndexingType, ParameterPackType,
+                         OutsideRangeFunctorType,
+                         std::make_index_sequence<ParameterPackType::size>>
 {
-    ForceModels( MaterialType t, Indexing i, ParameterPackType const& m,
+    ForceModels( MaterialType t, IndexingType i, ParameterPackType const& m,
                  OutsideRangeFunctorType const& o = OutsideRangeFunctorType() )
         : CabanaPD::Impl::ForceModelsImpl<
-              MaterialType, Indexing, ParameterPackType,
+              MaterialType, IndexingType, ParameterPackType,
               OutsideRangeFunctorType,
               std::make_index_sequence<ParameterPackType::size>>( t, i, m, o )
     {
@@ -366,8 +367,8 @@ struct AverageTag
 {
 };
 
-template <typename ParticleType, typename Indexing, typename... ModelTypes>
-auto createMultiForceModel( ParticleType particles, Indexing indexing,
+template <typename ParticleType, typename IndexingType, typename... ModelTypes>
+auto createMultiForceModel( ParticleType particles, IndexingType indexing,
                             ModelTypes... m )
 {
     auto type = particles.sliceType();

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -398,7 +398,7 @@ auto createMultiForceModel( ParticleType particles, AverageTag, ModelType1 m1,
         CabanaPD::Impl::generateAllModelCombinationsForDiagonalIndexing(
             baseModels, indexing,
             std::make_index_sequence<sizeof...( ModelTypes )>{},
-            std::make_index_sequence<indexing.NumTotalModels -
+            std::make_index_sequence<IndexingType::NumTotalModels -
                                      sizeof...( ModelTypes )>{} ) );
 }
 template <

--- a/src/CabanaPD_Indexing.hpp
+++ b/src/CabanaPD_Indexing.hpp
@@ -18,8 +18,8 @@ namespace CabanaPD
 template <unsigned FIRST, unsigned SECOND>
 struct IndexPair
 {
-    static const unsigned first = FIRST;
-    static const unsigned second = SECOND;
+    static constexpr unsigned first = FIRST;
+    static constexpr unsigned second = SECOND;
 };
 
 template <unsigned N, unsigned Index, unsigned Diagonal = 0>
@@ -28,7 +28,7 @@ constexpr auto getDiagonalIndexPair()
     if constexpr ( Index < N )
         return IndexPair<Index, Index + Diagonal>{};
     else
-        return getDiagonalIndexPair<N, Index - N, Diagonal + 1>();
+        return getDiagonalIndexPair<N-1, Index - N, Diagonal + 1>();
 }
 
 // Index along each diagonal sequentially (symmetric).

--- a/src/CabanaPD_Indexing.hpp
+++ b/src/CabanaPD_Indexing.hpp
@@ -15,6 +15,9 @@
 namespace CabanaPD
 {
 
+template <typename T, typename... Args>
+static constexpr bool is_Indexing = false;
+
 template <unsigned FIRST, unsigned SECOND>
 struct IndexPair
 {
@@ -28,7 +31,7 @@ constexpr auto getDiagonalIndexPair()
     if constexpr ( Index < N )
         return IndexPair<Index, Index + Diagonal>{};
     else
-        return getDiagonalIndexPair<N-1, Index - N, Diagonal + 1>();
+        return getDiagonalIndexPair<N - 1, Index - N, Diagonal + 1>();
 }
 
 // Index along each diagonal sequentially (symmetric).
@@ -93,6 +96,8 @@ struct FullIndexing
     }
 };
 
+template <unsigned NumBaseModels>
+static constexpr bool is_Indexing<DiagonalIndexing<NumBaseModels>> = true;
 } // namespace CabanaPD
 
 #endif

--- a/src/CabanaPD_Indexing.hpp
+++ b/src/CabanaPD_Indexing.hpp
@@ -14,6 +14,23 @@
 
 namespace CabanaPD
 {
+
+template <unsigned FIRST, unsigned SECOND>
+struct IndexPair
+{
+    static const unsigned first = FIRST;
+    static const unsigned second = SECOND;
+};
+
+template <unsigned N, unsigned Index, unsigned Diagonal = 0>
+constexpr auto getDiagonalIndexPair()
+{
+    if constexpr ( Index < N )
+        return IndexPair<Index, Index + Diagonal>{};
+    else
+        return getDiagonalIndexPair<N, Index - N, Diagonal + 1>();
+}
+
 // Index along each diagonal sequentially (symmetric).
 template <unsigned NumBaseModels>
 struct DiagonalIndexing
@@ -39,6 +56,17 @@ struct DiagonalIndexing
 
         return offset + indexAlongDiagonal;
     }
+
+    static constexpr unsigned NumTotalModels =
+        ( NumBaseModels * NumBaseModels + NumBaseModels ) / 2;
+
+    template <unsigned Index>
+    static constexpr auto getInverseIndexPair()
+    {
+        static_assert( Index < NumTotalModels,
+                       "Requested inverse index out of range" );
+        return getDiagonalIndexPair<NumBaseModels, Index>();
+    }
 };
 
 // Index same type as 0 and differing types as 1.
@@ -51,7 +79,6 @@ struct BinaryIndexing
     }
 };
 
-template <unsigned NumBaseModels>
 struct FullIndexing
 {
     static_assert( NumBaseModels > 0, "NumBaseModels must be larger than 0" );

--- a/src/CabanaPD_Indexing.hpp
+++ b/src/CabanaPD_Indexing.hpp
@@ -66,8 +66,9 @@ struct DiagonalIndexing
     template <unsigned Index>
     static constexpr auto getInverseIndexPair()
     {
-        static_assert( Index < NumTotalModels,
-                       "Requested inverse index out of range" );
+        static_assert(
+            Index < NumTotalModels,
+            "Requested inverse index out of range of DiagonalIndexing" );
         return getDiagonalIndexPair<NumBaseModels, Index>();
     }
 };
@@ -82,6 +83,12 @@ struct BinaryIndexing
     }
 };
 
+template <unsigned N, unsigned Index>
+constexpr auto getFullIndexPair()
+{
+}
+// Full indexing with all combinatoric indices
+template <unsigned NumBaseModels>
 struct FullIndexing
 {
     static_assert( NumBaseModels > 0, "NumBaseModels must be larger than 0" );
@@ -94,10 +101,24 @@ struct FullIndexing
 
         return firstType * NumBaseModels + secondType;
     }
+
+    static constexpr unsigned NumTotalModels = NumBaseModels * NumBaseModels;
+
+    template <unsigned Index>
+    static constexpr auto getInverseIndexPair()
+    {
+        static_assert( Index < NumTotalModels,
+                       "Requested inverse index out of range of FullIndexing" );
+        return IndexPair<Index / NumBaseModels,
+                         Index - ( Index / NumBaseModels ) * NumBaseModels>{};
+    }
 };
 
 template <unsigned NumBaseModels>
 static constexpr bool is_Indexing<DiagonalIndexing<NumBaseModels>> = true;
+
+template <unsigned NumBaseModels>
+static constexpr bool is_Indexing<FullIndexing<NumBaseModels>> = true;
 } // namespace CabanaPD
 
 #endif

--- a/src/CabanaPD_Indexing.hpp
+++ b/src/CabanaPD_Indexing.hpp
@@ -83,10 +83,6 @@ struct BinaryIndexing
     }
 };
 
-template <unsigned N, unsigned Index>
-constexpr auto getFullIndexPair()
-{
-}
 // Full indexing with all combinatoric indices
 template <unsigned NumBaseModels>
 struct FullIndexing

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(${PROJECT_SOURCE_DIR}/test_harness/CabanaPD_testing_macros.cmake)
 
-CabanaPD_add_tests(PREFIX UnitTest NAMES Particles Force Integrator NormalRepulsion)
+CabanaPD_add_tests(PREFIX UnitTest NAMES Particles Force Integrator NormalRepulsion Indexing)
 
 CabanaPD_add_tests(MPI PREFIX UnitTest NAMES Comm)

--- a/unit_test/tstIndexing.hpp
+++ b/unit_test/tstIndexing.hpp
@@ -122,9 +122,9 @@ TEST( TEST_CATEGORY, test_binaryIndexing )
     CabanaPD::BinaryIndexing indexing;
 
     // test binary indexing for N=3
-    for ( unsigned i = 0; 3 < i; ++i )
+    for ( unsigned i = 0; i < 3; ++i )
     {
-        for ( unsigned j = 0; 3 < j; ++j )
+        for ( unsigned j = 0; j < 3; ++j )
         {
             if ( i == j )
                 ASSERT_EQ( indexing( i, j ), 0 );

--- a/unit_test/tstIndexing.hpp
+++ b/unit_test/tstIndexing.hpp
@@ -133,4 +133,82 @@ TEST( TEST_CATEGORY, test_binaryIndexing )
         }
     }
 }
+
+TEST( TEST_CATEGORY, test_fullIndexing )
+{
+    // test full indexing for N=1
+    using IndexingType1 = CabanaPD::FullIndexing<1>;
+    IndexingType1 indexing1;
+
+    ASSERT_EQ( indexing1( 0, 0 ), 0 );
+
+    // test inverse indexing
+    ASSERT_EQ( IndexingType1::template getInverseIndexPair<0>().first, 0 );
+    ASSERT_EQ( IndexingType1::template getInverseIndexPair<0>().second, 0 );
+
+    // test diagonal indexing for N=2
+    using IndexingType2 = CabanaPD::FullIndexing<2>;
+    IndexingType2 indexing2;
+
+    ASSERT_EQ( indexing2( 0, 0 ), 0 );
+    ASSERT_EQ( indexing2( 0, 1 ), 1 );
+    ASSERT_EQ( indexing2( 1, 0 ), 2 );
+    ASSERT_EQ( indexing2( 1, 1 ), 3 );
+
+    // test inverse indexing
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<0>().first, 0 );
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<0>().second, 0 );
+
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<1>().first, 0 );
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<1>().second, 1 );
+
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<2>().first, 1 );
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<2>().second, 0 );
+
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<3>().first, 1 );
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<3>().second, 1 );
+
+    // test diagonal indexing for N=3
+    using IndexingType3 = CabanaPD::FullIndexing<3>;
+    IndexingType3 indexing3;
+
+    ASSERT_EQ( indexing3( 0, 0 ), 0 );
+    ASSERT_EQ( indexing3( 0, 1 ), 1 );
+    ASSERT_EQ( indexing3( 0, 2 ), 2 );
+    ASSERT_EQ( indexing3( 1, 0 ), 3 );
+    ASSERT_EQ( indexing3( 1, 1 ), 4 );
+    ASSERT_EQ( indexing3( 1, 2 ), 5 );
+    ASSERT_EQ( indexing3( 2, 0 ), 6 );
+    ASSERT_EQ( indexing3( 2, 1 ), 7 );
+    ASSERT_EQ( indexing3( 2, 2 ), 8 );
+
+    // test inverse indexing
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<3>().first, 1 );
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<3>().second, 0 );
+
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<4>().first, 1 );
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<4>().second, 1 );
+
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<5>().first, 1 );
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<5>().second, 2 );
+}
+
+TEST( TEST_CATEGORY, test_fullIndexing_death )
+{
+    // assert death for out of scope indexing
+    ASSERT_DEATH(
+        {
+            CabanaPD::FullIndexing<2> indexing;
+            auto i = indexing( 2, 0 );
+            (void)i;
+        },
+        "Index out of range of FullIndexing" );
+    ASSERT_DEATH(
+        {
+            CabanaPD::FullIndexing<2> indexing;
+            auto i = indexing( 0, 2 );
+            (void)i;
+        },
+        "Index out of range of FullIndexing" );
+}
 } // end namespace Test

--- a/unit_test/tstIndexing.hpp
+++ b/unit_test/tstIndexing.hpp
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-
 #include <gtest/gtest.h>
 
 #include <Cabana_Core.hpp>

--- a/unit_test/tstIndexing.hpp
+++ b/unit_test/tstIndexing.hpp
@@ -20,6 +20,7 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+
 #include <gtest/gtest.h>
 
 #include <Cabana_Core.hpp>
@@ -42,12 +43,18 @@ TEST( TEST_CATEGORY, test_diagonalIndexing )
     // valid for higher values of N.
 
     // test diagonal indexing for N=1
-    CabanaPD::DiagonalIndexing<1> indexing1;
+    using IndexingType1 = CabanaPD::DiagonalIndexing<1>;
+    IndexingType1 indexing1;
 
     ASSERT_EQ( indexing1( 0, 0 ), 0 );
 
+    // test inverse indexing
+    ASSERT_EQ( IndexingType1::template getInverseIndexPair<0>().first, 0 );
+    ASSERT_EQ( IndexingType1::template getInverseIndexPair<0>().second, 0 );
+
     // test diagonal indexing for N=2
-    CabanaPD::DiagonalIndexing<2> indexing2;
+    using IndexingType2 = CabanaPD::DiagonalIndexing<2>;
+    IndexingType2 indexing2;
 
     // main diagonal
     ASSERT_EQ( indexing2( 0, 0 ), 0 );
@@ -57,8 +64,13 @@ TEST( TEST_CATEGORY, test_diagonalIndexing )
     ASSERT_EQ( indexing2( 0, 1 ), 2 );
     ASSERT_EQ( indexing2( 1, 0 ), 2 );
 
+    // test inverse indexing
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<2>().first, 0 );
+    ASSERT_EQ( IndexingType2::template getInverseIndexPair<2>().second, 1 );
+
     // test diagonal indexing for N=3
-    CabanaPD::DiagonalIndexing<3> indexing3;
+    using IndexingType3 = CabanaPD::DiagonalIndexing<3>;
+    IndexingType3 indexing3;
 
     // main diagonal
     ASSERT_EQ( indexing3( 0, 0 ), 0 );
@@ -74,6 +86,16 @@ TEST( TEST_CATEGORY, test_diagonalIndexing )
     // second minor diagonal (incl symmetric terms)
     ASSERT_EQ( indexing3( 0, 2 ), 5 );
     ASSERT_EQ( indexing3( 2, 0 ), 5 );
+
+    // test inverse indexing
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<3>().first, 0 );
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<3>().second, 1 );
+
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<4>().first, 1 );
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<4>().second, 2 );
+
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<5>().first, 0 );
+    ASSERT_EQ( IndexingType3::template getInverseIndexPair<5>().second, 2 );
 }
 
 TEST( TEST_CATEGORY, test_diagonalIndexing_death )


### PR DESCRIPTION
Extends the existing variadic `ForceModelsMulti` by a helper function to create a `ForceModelsMulti` from a pack of base models using averaging of models. (So far this was only implemented manually for up to 4 models).

This approach implements this averaging creation from `N` base models for any `IndexingType` that has compile time expressions for the `NumTotalModels` and `getInverseIndexPair`. 