### PR TITLE
Simplify model constructors

### DIFF
--- a/src/force_models/CabanaPD_LPS.hpp
+++ b/src/force_models/CabanaPD_LPS.hpp
@@ -306,14 +306,16 @@ struct ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>
     }
 };
 
-template <>
-struct ForceModel<LinearLPS, Elastic, NoFracture, TemperatureIndependent>
-    : public ForceModel<LPS, Elastic, NoFracture, TemperatureIndependent>
+template <typename FractureType>
+struct ForceModel<LinearLPS, Elastic, FractureType, TemperatureIndependent>
+    : public ForceModel<LPS, Elastic, FractureType, TemperatureIndependent>
 {
     using base_type =
-        ForceModel<LPS, Elastic, NoFracture, TemperatureIndependent>;
-    // Tag to dispatch to force iteration.
-    using force_tag = LinearLPS;
+        ForceModel<LPS, Elastic, FractureType, TemperatureIndependent>;
+    using model_type = LinearLPS;
+
+    using base_type::base_type;
+    using base_type::operator();
 
     template <typename... Args>
     ForceModel( LinearLPS, Args&&... args )
@@ -321,30 +323,6 @@ struct ForceModel<LinearLPS, Elastic, NoFracture, TemperatureIndependent>
                      std::forward<Args>( args )... )
     {
     }
-
-    using base_type::base_type;
-    using base_type::operator();
-};
-
-template <>
-struct ForceModel<LinearLPS, Elastic, Fracture, TemperatureIndependent>
-    : public ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>
-{
-    using base_type =
-        ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>;
-
-    // Tag to dispatch to force iteration.
-    using force_tag = LinearLPS;
-
-    template <typename... Args>
-    ForceModel( LinearLPS, Args&&... args )
-        : base_type( typename base_type::model_tag{},
-                     std::forward<Args>( args )... )
-    {
-    }
-
-    using base_type::base_type;
-    using base_type::operator();
 };
 
 template <typename ModelType>

--- a/src/force_models/CabanaPD_LPS.hpp
+++ b/src/force_models/CabanaPD_LPS.hpp
@@ -43,19 +43,8 @@ struct BaseForceModelLPS<Elastic> : public BaseForceModel
     Kokkos::Array<double, 2> theta_coeff;
     Kokkos::Array<double, 2> s_coeff;
 
-    BaseForceModelLPS( LPS, NoFracture, const double _force_horizon,
-                       const double _K, const double _G,
-                       const int _influence = 0 )
-        : base_type( _force_horizon, _K )
-        , influence_type( _influence )
-        , G( _G )
-    {
-        init();
-    }
-
-    BaseForceModelLPS( LPS, Elastic, NoFracture, const double _force_horizon,
-                       const double _K, const double _G,
-                       const int _influence = 0 )
+    BaseForceModelLPS( const double _force_horizon, const double _K,
+                       const double _G, const int _influence = 0 )
         : base_type( _force_horizon, _K )
         , influence_type( _influence )
         , G( _G )
@@ -221,6 +210,18 @@ struct ForceModel<LPS, Elastic, NoFracture, TemperatureIndependent>
     using base_temperature_type::operator();
 
     using base_type::influence_type;
+
+    ForceModel( LPS, NoFracture, const double _force_horizon, const double _K,
+                const double _G, const int _influence = 0 )
+        : base_type( _force_horizon, _K, _G, _influence )
+    {
+    }
+
+    ForceModel( LPS, Elastic, NoFracture, const double _force_horizon,
+                const double _K, const double _G, const int _influence = 0 )
+        : base_type( _force_horizon, _K, _G, _influence )
+    {
+    }
 };
 
 template <>
@@ -248,51 +249,10 @@ struct ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>
     using base_fracture_type::operator();
     using base_temperature_type::operator();
 
-    ForceModel( LPS model, const double _force_horizon, const double _K,
+    ForceModel( LPS, const double _force_horizon, const double _K,
                 const double _G, const double _G0, const int _influence = 0 )
-        : base_type( model, NoFracture{}, _force_horizon, _K, _G, _influence )
+        : base_type( _force_horizon, _K, _G, _influence )
         , base_fracture_type( _force_horizon, _K, _G0, _influence )
-    {
-        init();
-    }
-
-    ForceModel( LPS model, Fracture, const double _force_horizon,
-                const double _K, const double _G, const double _G0,
-                const int _influence = 0 )
-        : base_type( model, NoFracture{}, _force_horizon, _K, _G, _influence )
-        , base_fracture_type( _force_horizon, _K, _G0, _influence )
-    {
-        init();
-    }
-
-    ForceModel( LPS model, Elastic, const double _force_horizon,
-                const double _K, const double _G, const double _G0,
-                const int _influence = 0 )
-        : base_type( model, NoFracture{}, _force_horizon, _K, _G, _influence )
-        , base_fracture_type( _force_horizon, _K, _G0, _influence )
-    {
-        init();
-    }
-
-    ForceModel( LPS model, Elastic elastic, Fracture,
-                const double _force_horizon, const double _K, const double _G,
-                const double _G0, const int _influence = 0 )
-        : base_type( model, elastic, NoFracture{}, _force_horizon, _K, _G,
-                     _influence )
-        , base_fracture_type( _force_horizon, _K, _G0, _influence )
-    {
-        init();
-    }
-
-    // Constructor to average from existing models.
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-        , base_fracture_type( model1, model2 )
-    {
-    }
-
-    void init()
     {
         if ( influence_type == 1 )
         {
@@ -303,6 +263,35 @@ struct ForceModel<LPS, Elastic, Fracture, TemperatureIndependent>
             s0 = Kokkos::sqrt( 8.0 * G0 / 15.0 / K / force_horizon ); // 1
         }
         bond_break_coeff = ( 1.0 + s0 ) * ( 1.0 + s0 );
+    }
+
+    ForceModel( LPS model, Fracture, const double _force_horizon,
+                const double _K, const double _G, const double _G0,
+                const int _influence = 0 )
+        : ForceModel( model, _force_horizon, _K, _G, _G0, _influence )
+    {
+    }
+
+    ForceModel( LPS model, Elastic, const double _force_horizon,
+                const double _K, const double _G, const double _G0,
+                const int _influence = 0 )
+        : ForceModel( model, _force_horizon, _K, _G, _G0, _influence )
+    {
+    }
+
+    ForceModel( LPS model, Elastic, Fracture, const double _force_horizon,
+                const double _K, const double _G, const double _G0,
+                const int _influence = 0 )
+        : ForceModel( model, _force_horizon, _K, _G, _G0, _influence )
+    {
+    }
+
+    // Constructor to average from existing models.
+    template <typename ModelType1, typename ModelType2>
+    ForceModel( const ModelType1& model1, const ModelType2& model2 )
+        : base_type( model1, model2 )
+        , base_fracture_type( model1, model2 )
+    {
     }
 };
 

--- a/src/force_models/CabanaPD_PMB.hpp
+++ b/src/force_models/CabanaPD_PMB.hpp
@@ -569,31 +569,15 @@ ForceModel( ModelType, ElasticPerfectlyPlastic, const double horizon,
 /******************************************************************************
  Linear PMB.
 ******************************************************************************/
-template <>
-struct ForceModel<LinearPMB, Elastic, NoFracture, TemperatureIndependent>
-    : public ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
+template <typename MechanicsType, typename FractureType, typename ThermalType,
+          typename... FieldTypes>
+struct ForceModel<LinearPMB, MechanicsType, FractureType, ThermalType,
+                  FieldTypes...>
+    : public ForceModel<PMB, MechanicsType, FractureType, ThermalType,
+                        FieldTypes...>
 {
-    using base_type =
-        ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>;
-    // Tag to dispatch to force iteration.
-    using force_tag = LinearPMB;
-
-    using base_type::base_type;
-    using base_type::operator();
-
-    template <typename... Args>
-    ForceModel( LinearPMB, Args... args )
-        : base_type( typename base_type::model_tag{}, args... )
-    {
-    }
-};
-
-template <>
-struct ForceModel<LinearPMB, Elastic, Fracture, TemperatureIndependent>
-    : public ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
-{
-    using base_type =
-        ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>;
+    using base_type = ForceModel<PMB, MechanicsType, FractureType, ThermalType,
+                                 FieldTypes...>;
 
     // Tag to dispatch to force iteration.
     using force_tag = LinearPMB;
@@ -603,50 +587,6 @@ struct ForceModel<LinearPMB, Elastic, Fracture, TemperatureIndependent>
     template <typename... Args>
     ForceModel( LinearPMB, Args... args )
         : base_type( typename base_type::model_tag{},
-                     std::forward<Args>( args )... )
-    {
-    }
-};
-
-template <typename MemorySpace>
-struct ForceModel<LinearPMB, ElasticPerfectlyPlastic, Fracture,
-                  TemperatureIndependent, MemorySpace>
-    : public ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
-                        TemperatureIndependent, MemorySpace>
-{
-    using base_type = ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
-                                 TemperatureIndependent, MemorySpace>;
-
-    // Tag to dispatch to force iteration.
-    using force_tag = LinearPMB;
-
-    using base_type::operator();
-
-    template <typename... Args>
-    ForceModel( LinearPMB, Args... args )
-        : base_type( typename base_type::base_model{},
-                     std::forward<Args>( args )... )
-    {
-    }
-};
-
-template <typename MechanicsType, typename ThermalType, typename... FieldTypes>
-struct ForceModel<LinearPMB, MechanicsType, Fracture, ThermalType,
-                  FieldTypes...>
-    : public ForceModel<PMB, MechanicsType, Fracture, ThermalType,
-                        FieldTypes...>
-{
-    using base_type =
-        ForceModel<PMB, MechanicsType, Fracture, ThermalType, FieldTypes...>;
-
-    // Tag to dispatch to force iteration.
-    using force_tag = LinearPMB;
-
-    using base_type::operator();
-
-    template <typename... Args>
-    ForceModel( LinearPMB, Args... args )
-        : base_type( typename base_type::base_model{},
                      std::forward<Args>( args )... )
     {
     }

--- a/src/force_models/CabanaPD_PMB.hpp
+++ b/src/force_models/CabanaPD_PMB.hpp
@@ -38,21 +38,8 @@ struct BaseForceModelPMB<Elastic> : public BaseForceModel
     using base_type::K;
     double c;
 
-    BaseForceModelPMB( PMB, NoFracture, const double force_horizon,
-                       const double _K )
+    BaseForceModelPMB( const double force_horizon, const double _K )
         : base_type( force_horizon, _K )
-    {
-        init();
-    }
-
-    BaseForceModelPMB( PMB, Elastic, NoFracture, const double force_horizon,
-                       const double _K )
-        : base_type( force_horizon, _K )
-    {
-        init();
-    }
-
-    void init()
     {
         c = 18.0 * K /
             ( pi * force_horizon * force_horizon * force_horizon *
@@ -99,10 +86,9 @@ struct BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>
 
     using base_plasticity_type::updateBonds;
 
-    BaseForceModelPMB( PMB model, mechanics_type, MemorySpace,
-                       const double force_horizon, const double K,
+    BaseForceModelPMB( MemorySpace, const double force_horizon, const double K,
                        const double sigma_y )
-        : base_type( model, NoFracture{}, force_horizon, K )
+        : base_type( force_horizon, K )
         , base_plasticity_type()
         , s_Y( sigma_y / 3.0 / K )
     {
@@ -175,6 +161,17 @@ struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
     using base_type::operator();
     using base_fracture_type::operator();
     using base_temperature_type::operator();
+
+    ForceModel( PMB, NoFracture, const double force_horizon, const double K )
+        : base_type( force_horizon, K )
+    {
+    }
+
+    ForceModel( PMB, Elastic, NoFracture, const double force_horizon,
+                const double K )
+        : base_type( force_horizon, K )
+    {
+    }
 };
 
 template <>
@@ -191,38 +188,35 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
     using base_fracture_type::operator();
     using base_temperature_type::operator();
 
-    ForceModel( PMB model, const double force_horizon, const double K,
+    ForceModel( PMB, const double force_horizon, const double K,
                 const double G0, const int influence_type = 1 )
-        : base_type( model, NoFracture{}, force_horizon, K )
+        : base_type( force_horizon, K )
         , base_fracture_type( force_horizon, K, G0, influence_type )
     {
     }
 
-    ForceModel( PMB model, Elastic elastic, const double force_horizon,
-                const double K, const double G0, const int influence_type = 1 )
-        : base_type( model, elastic, NoFracture{}, force_horizon, K )
-        , base_fracture_type( force_horizon, K, G0, influence_type )
+    ForceModel( PMB model, Elastic, const double force_horizon, const double K,
+                const double G0, const int influence_type = 1 )
+        : ForceModel( model, force_horizon, K, G0, influence_type )
     {
     }
 
     ForceModel( PMB model, Fracture, const double force_horizon, const double K,
                 const double G0, const int influence_type = 1 )
-        : base_type( model, Elastic{}, NoFracture{}, force_horizon, K )
-        , base_fracture_type( force_horizon, K, G0, influence_type )
+        : ForceModel( model, force_horizon, K, G0, influence_type )
     {
     }
 
     ForceModel( PMB model, Elastic, Fracture, const double force_horizon,
                 const double K, const double G0, const int influence_type = 1 )
-        : base_type( model, NoFracture{}, force_horizon, K )
-        , base_fracture_type( force_horizon, K, G0, influence_type )
+        : ForceModel( model, force_horizon, K, G0, influence_type )
     {
     }
 
     // Constructor to work with plasticity.
-    ForceModel( PMB model, Elastic elastic, const double force_horizon,
-                const double K, const double G0, const double s0 )
-        : base_type( model, elastic, NoFracture{}, force_horizon, K )
+    ForceModel( PMB, Elastic, const double force_horizon, const double K,
+                const double G0, const double s0 )
+        : base_type( force_horizon, K )
         , base_fracture_type( G0, s0 )
     {
     }
@@ -252,15 +246,22 @@ struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
     using base_temperature_type::operator();
     using base_type::updateBonds;
 
-    ForceModel( PMB model, ElasticPerfectlyPlastic mechanics, MemorySpace space,
+    ForceModel( PMB, ElasticPerfectlyPlastic, MemorySpace space,
                 const double force_horizon, const double K, const double G0,
                 const double sigma_y )
-        : base_type( model, mechanics, space, force_horizon, K, sigma_y )
+        : base_type( space, force_horizon, K, sigma_y )
         , base_fracture_type(
               G0,
               // s0
               ( 5.0 * G0 / sigma_y / force_horizon + sigma_y / K ) / 6.0 )
         , base_temperature_type()
+    {
+    }
+
+    ForceModel( PMB model, ElasticPerfectlyPlastic mechanics, Fracture,
+                MemorySpace space, const double force_horizon, const double K,
+                const double G0, const double sigma_y )
+        : ForceModel( model, mechanics, space, force_horizon, K, G0, sigma_y )
     {
     }
 
@@ -317,10 +318,10 @@ struct ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
     using base_temperature_type::operator();
     using typename base_temperature_type::needs_update;
 
-    ForceModel( PMB model, NoFracture fracture, const double _force_horizon,
-                const double _K, const TemperatureType _temp,
-                const double _alpha, const double _temp0 = 0.0 )
-        : base_type( model, fracture, _force_horizon, _K )
+    ForceModel( PMB, NoFracture, const double _force_horizon, const double _K,
+                const TemperatureType _temp, const double _alpha,
+                const double _temp0 = 0.0 )
+        : base_type( _force_horizon, _K )
         , base_temperature_type( _temp, _alpha, _temp0 )
     {
     }
@@ -345,10 +346,10 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureDependent, TemperatureType>
     using base_temperature_type::operator();
     using typename base_temperature_type::needs_update;
 
-    ForceModel( PMB model, const double _horizon, const double _K,
-                const double _G0, const TemperatureType _temp,
-                const double _alpha, const double _temp0 = 0.0 )
-        : base_type( model, NoFracture{}, _horizon, _K )
+    ForceModel( PMB, const double _horizon, const double _K, const double _G0,
+                const TemperatureType _temp, const double _alpha,
+                const double _temp0 = 0.0 )
+        : base_type( _horizon, _K )
         , base_temperature_type( _horizon, _K, _G0, _temp, _alpha, _temp0 )
     {
     }
@@ -377,12 +378,12 @@ struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, TemperatureDependent,
     using base_temperature_type::operator();
     using typename base_temperature_type::needs_update;
 
-    ForceModel( PMB model, ElasticPerfectlyPlastic mechanics,
-                const double _horizon, const double _K, const double _G0,
-                const double sigma_y, const TemperatureType _temp,
-                const double _alpha, const double _temp0 = 0.0 )
-        : base_type( model, mechanics, typename TemperatureType::memory_space{},
-                     _horizon, _K, sigma_y )
+    ForceModel( PMB, ElasticPerfectlyPlastic, const double _horizon,
+                const double _K, const double _G0, const double sigma_y,
+                const TemperatureType _temp, const double _alpha,
+                const double _temp0 = 0.0 )
+        : base_type( typename TemperatureType::memory_space{}, _horizon, _K,
+                     sigma_y )
         , base_temperature_type( _horizon, _K, _G0, _temp, _alpha, _temp0 )
     {
     }
@@ -437,12 +438,12 @@ struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>
     using base_temperature_type::operator();
     using typename base_temperature_type::needs_update;
 
-    ForceModel( PMB model, NoFracture fracture, const double _horizon,
-                const double _K, const TemperatureType& _temp,
-                const double _kappa, const double _cp, const double _alpha,
+    ForceModel( PMB, NoFracture, const double _horizon, const double _K,
+                const TemperatureType& _temp, const double _kappa,
+                const double _cp, const double _alpha,
                 const double _temp0 = 0.0,
                 const bool _constant_microconductivity = true )
-        : base_type( model, fracture, _horizon, _K )
+        : base_type( _horizon, _K )
         , base_temperature_type( _temp, _alpha, _temp0 )
         , base_heat_transfer_type( _horizon, _kappa, _cp,
                                    _constant_microconductivity )
@@ -483,12 +484,12 @@ struct ForceModel<ModelType, Elastic, Fracture, DynamicTemperature,
     using base_temperature_type::operator();
     using typename base_temperature_type::needs_update;
 
-    ForceModel( PMB model, const double _horizon, const double _K,
-                const double _G0, const TemperatureType _temp,
-                const double _kappa, const double _cp, const double _alpha,
+    ForceModel( PMB, const double _horizon, const double _K, const double _G0,
+                const TemperatureType _temp, const double _kappa,
+                const double _cp, const double _alpha,
                 const double _temp0 = 0.0,
                 const bool _constant_microconductivity = true )
-        : base_type( model, NoFracture{}, _horizon, _K )
+        : base_type( _horizon, _K )
         , base_temperature_type( _horizon, _K, _G0, _temp, _alpha, _temp0 )
         , base_heat_transfer_type( _horizon, _kappa, _cp,
                                    _constant_microconductivity )
@@ -533,14 +534,14 @@ struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, DynamicTemperature,
     using base_temperature_type::operator();
     using typename base_temperature_type::needs_update;
 
-    ForceModel( PMB model, ElasticPerfectlyPlastic mechanics,
-                const double _horizon, const double _K, const double _G0,
-                const double sigma_y, const TemperatureType _temp,
-                const double _kappa, const double _cp, const double _alpha,
+    ForceModel( PMB, ElasticPerfectlyPlastic, const double _horizon,
+                const double _K, const double _G0, const double sigma_y,
+                const TemperatureType _temp, const double _kappa,
+                const double _cp, const double _alpha,
                 const double _temp0 = 0.0,
                 const bool _constant_microconductivity = true )
-        : base_type( model, mechanics, typename TemperatureType::memory_space{},
-                     _horizon, _K, sigma_y )
+        : base_type( typename TemperatureType::memory_space{}, _horizon, _K,
+                     sigma_y )
         , base_temperature_type( _horizon, _K, _G0, _temp, _alpha, _temp0 )
         , base_heat_transfer_type( _horizon, _kappa, _cp,
                                    _constant_microconductivity )


### PR DESCRIPTION
- Separate linear model definitions are unnecessary (each forwards to the corresponding non-linear model)
- Consolidate constructors with delegation and moving tagged versions to specific models only (no reason for the base models to ever deal with the tags)