### PR TITLE
Separate mechanics, fracture, and thermal models

### DIFF
--- a/examples/mechanics/crack_branching.cpp
+++ b/examples/mechanics/crack_branching.cpp
@@ -66,7 +66,10 @@ void crackBranchingExample( const std::string filename )
     //                    Force model
     // ====================================================
     using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel force_model( model_type{}, horizon, K, G0 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
+                                                    fracture_model );
 
     // ====================================================
     //                 Particle generation

--- a/examples/mechanics/crack_branching.cpp
+++ b/examples/mechanics/crack_branching.cpp
@@ -68,8 +68,7 @@ void crackBranchingExample( const std::string filename )
     using model_type = CabanaPD::PMB;
     CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
     CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
-                                                    fracture_model );
+    CabanaPD::ForceModel force_model( mechanics_model, fracture_model );
 
     // ====================================================
     //                 Particle generation

--- a/examples/mechanics/crack_inclusion.cpp
+++ b/examples/mechanics/crack_inclusion.cpp
@@ -79,11 +79,17 @@ void crackInclusionExample( const std::string filename )
     using model_type = CabanaPD::LPS;
 
     // Plate material
-    CabanaPD::ForceModel force_model_plate( model_type{}, horizon, K, G, G0 );
-
+    CabanaPD::FractureModel fracture_model_plate( horizon, K, G0 );
+    CabanaPD::MechanicsModel mechanics_model_plate( model_type{}, horizon, K,
+                                                    G );
+    CabanaPD::Experimental::ForceModel force_model_plate(
+        mechanics_model_plate, fracture_model_plate );
     // Inclusion material
-    CabanaPD::ForceModel force_model_inclusion( model_type{}, horizon, K_I, G_I,
-                                                G0_I );
+    CabanaPD::FractureModel fracture_model_inclusion( horizon, K_I, G0_I );
+    CabanaPD::MechanicsModel mechanics_model_inclusion( model_type{}, horizon,
+                                                        K_I, G_I );
+    CabanaPD::Experimental::ForceModel force_model_inclusion(
+        mechanics_model_inclusion, fracture_model_inclusion );
 
     // ====================================================
     //                 Particle generation

--- a/examples/mechanics/crack_inclusion.cpp
+++ b/examples/mechanics/crack_inclusion.cpp
@@ -82,14 +82,14 @@ void crackInclusionExample( const std::string filename )
     CabanaPD::FractureModel fracture_model_plate( horizon, K, G0 );
     CabanaPD::MechanicsModel mechanics_model_plate( model_type{}, horizon, K,
                                                     G );
-    CabanaPD::Experimental::ForceModel force_model_plate(
-        mechanics_model_plate, fracture_model_plate );
+    CabanaPD::ForceModel force_model_plate( mechanics_model_plate,
+                                            fracture_model_plate );
     // Inclusion material
     CabanaPD::FractureModel fracture_model_inclusion( horizon, K_I, G0_I );
     CabanaPD::MechanicsModel mechanics_model_inclusion( model_type{}, horizon,
                                                         K_I, G_I );
-    CabanaPD::Experimental::ForceModel force_model_inclusion(
-        mechanics_model_inclusion, fracture_model_inclusion );
+    CabanaPD::ForceModel force_model_inclusion( mechanics_model_inclusion,
+                                                fracture_model_inclusion );
 
     // ====================================================
     //                 Particle generation

--- a/examples/mechanics/dogbone_tensile_test.cpp
+++ b/examples/mechanics/dogbone_tensile_test.cpp
@@ -154,8 +154,11 @@ void dogboneTensileTestExample( const std::string filename )
     // ====================================================
     //                    Force model
     // ====================================================
-    CabanaPD::ForceModel force_model( model_type{}, mechanics_type{},
-                                      memory_space{}, horizon, K, G0, sigma_y );
+    CabanaPD::MechanicsModel mechanics_model(
+        model_type{}, mechanics_type{}, memory_space{}, horizon, K, sigma_y );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
+                                                    fracture_model );
 
     // ====================================================
     //                   Create solver

--- a/examples/mechanics/dogbone_tensile_test.cpp
+++ b/examples/mechanics/dogbone_tensile_test.cpp
@@ -157,8 +157,7 @@ void dogboneTensileTestExample( const std::string filename )
     CabanaPD::MechanicsModel mechanics_model(
         model_type{}, mechanics_type{}, memory_space{}, horizon, K, sigma_y );
     CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
-                                                    fracture_model );
+    CabanaPD::ForceModel force_model( mechanics_model, fracture_model );
 
     // ====================================================
     //                   Create solver

--- a/examples/mechanics/elastic_wave.cpp
+++ b/examples/mechanics/elastic_wave.cpp
@@ -55,8 +55,8 @@ void elasticWaveExample( const std::string filename )
     //                    Force model
     // ====================================================
     using model_type = CabanaPD::LinearLPS;
-    CabanaPD::ForceModel force_model( model_type{}, CabanaPD::NoFracture{},
-                                      horizon, K, G );
+    CabanaPD::MechanicsModel lps_model( model_type{}, horizon, K, G );
+    CabanaPD::Experimental::ForceModel force_model( lps_model );
 
     // ====================================================
     //                 Particle generation

--- a/examples/mechanics/elastic_wave.cpp
+++ b/examples/mechanics/elastic_wave.cpp
@@ -56,7 +56,7 @@ void elasticWaveExample( const std::string filename )
     // ====================================================
     using model_type = CabanaPD::LinearLPS;
     CabanaPD::MechanicsModel lps_model( model_type{}, horizon, K, G );
-    CabanaPD::Experimental::ForceModel force_model( lps_model );
+    CabanaPD::ForceModel force_model( lps_model );
 
     // ====================================================
     //                 Particle generation

--- a/examples/mechanics/fragmenting_cylinder.cpp
+++ b/examples/mechanics/fragmenting_cylinder.cpp
@@ -60,7 +60,10 @@ void fragmentingCylinderExample( const std::string filename )
     //                    Force model
     // ====================================================
     using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel force_model( model_type{}, horizon, K, G0 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
+                                                    fracture_model );
 
     // ====================================================
     //    Custom particle generation and initialization

--- a/examples/mechanics/fragmenting_cylinder.cpp
+++ b/examples/mechanics/fragmenting_cylinder.cpp
@@ -62,8 +62,7 @@ void fragmentingCylinderExample( const std::string filename )
     using model_type = CabanaPD::PMB;
     CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
     CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
-                                                    fracture_model );
+    CabanaPD::ForceModel force_model( mechanics_model, fracture_model );
 
     // ====================================================
     //    Custom particle generation and initialization

--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -77,10 +77,13 @@ void kalthoffWinklerExample( const std::string filename )
     // ====================================================
     //                    Force model
     // ====================================================
-    using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel force_model( model_type{}, horizon, K, G0 );
-    // using model_type = CabanaPD::LPS;
-    // CabanaPD::ForceModel force_model( model_type{}, horizon, K, G, G0 );
+    using model_type = CabanaPD::PMB; // CabanaPD::LPS;
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    // CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K, G );
+
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
+                                                    fracture_model );
 
     // ====================================================
     //                 Particle generation

--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -82,8 +82,7 @@ void kalthoffWinklerExample( const std::string filename )
     // CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K, G );
 
     CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
-                                                    fracture_model );
+    CabanaPD::ForceModel force_model( mechanics_model, fracture_model );
 
     // ====================================================
     //                 Particle generation

--- a/examples/mechanics/plate_with_hole.cpp
+++ b/examples/mechanics/plate_with_hole.cpp
@@ -58,7 +58,10 @@ void plateWithHoleExample( const std::string filename )
     //                    Force model
     // ====================================================
     using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel force_model( model_type{}, horizon, K, G0 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
+                                                    fracture_model );
 
     // ====================================================
     //    Custom particle generation and initialization

--- a/examples/mechanics/plate_with_hole.cpp
+++ b/examples/mechanics/plate_with_hole.cpp
@@ -60,8 +60,7 @@ void plateWithHoleExample( const std::string filename )
     using model_type = CabanaPD::PMB;
     CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
     CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
-                                                    fracture_model );
+    CabanaPD::ForceModel force_model( mechanics_model, fracture_model );
 
     // ====================================================
     //    Custom particle generation and initialization

--- a/examples/mechanics/random_cracks.cpp
+++ b/examples/mechanics/random_cracks.cpp
@@ -119,7 +119,10 @@ void randomCracksExample( const std::string filename )
     //                    Force model
     // ====================================================
     using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel force_model( model_type{}, horizon, K, G0 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
+                                                    fracture_model );
 
     // ====================================================
     //                 Particle generation

--- a/examples/mechanics/random_cracks.cpp
+++ b/examples/mechanics/random_cracks.cpp
@@ -121,8 +121,7 @@ void randomCracksExample( const std::string filename )
     using model_type = CabanaPD::PMB;
     CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
     CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-    CabanaPD::Experimental::ForceModel force_model( mechanics_model,
-                                                    fracture_model );
+    CabanaPD::ForceModel force_model( mechanics_model, fracture_model );
 
     // ====================================================
     //                 Particle generation

--- a/examples/thermomechanics/thermal_crack.cpp
+++ b/examples/thermomechanics/thermal_crack.cpp
@@ -86,14 +86,17 @@ void thermalCrackExample( const std::string filename )
     // ====================================================
     //                    Force model
     // ====================================================
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+
     auto temp = particles.sliceTemperature();
-    CabanaPD::ForceModel force_model( model_type{}, horizon, K, G0, temp, alpha,
-                                      temp0 );
+    CabanaPD::ThermalModel thermal_model( fracture_model, temp, alpha, temp0 );
+    CabanaPD::Experimental::ThermalForceModel force_model( mechanics_model,
+                                                           thermal_model );
 
     // ====================================================
     //                   Create solver
     // ====================================================
-
     CabanaPD::Solver solver( inputs, particles, force_model );
 
     // --------------------------------------------

--- a/examples/thermomechanics/thermal_crack.cpp
+++ b/examples/thermomechanics/thermal_crack.cpp
@@ -90,9 +90,9 @@ void thermalCrackExample( const std::string filename )
     CabanaPD::FractureModel fracture_model( horizon, K, G0 );
 
     auto temp = particles.sliceTemperature();
-    CabanaPD::ThermalModel thermal_model( fracture_model, temp, alpha, temp0 );
-    CabanaPD::Experimental::ThermalForceModel force_model( mechanics_model,
-                                                           thermal_model );
+    const double s0 = fracture_model.criticalStretch();
+    CabanaPD::ThermalModel thermal_model( s0, temp, alpha, temp0 );
+    CabanaPD::ThermalForceModel force_model( mechanics_model, thermal_model );
 
     // ====================================================
     //                   Create solver

--- a/examples/thermomechanics/thermal_crack.cpp
+++ b/examples/thermomechanics/thermal_crack.cpp
@@ -87,10 +87,9 @@ void thermalCrackExample( const std::string filename )
     //                    Force model
     // ====================================================
     CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
-    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
 
     auto temp = particles.sliceTemperature();
-    const double s0 = fracture_model.criticalStretch();
+    const double s0 = CabanaPD::criticalStretch( horizon, K, G0 );
     CabanaPD::ThermalModel thermal_model( s0, temp, alpha, temp0 );
     CabanaPD::ThermalForceModel force_model( mechanics_model, thermal_model );
 

--- a/examples/thermomechanics/thermal_deformation.cpp
+++ b/examples/thermomechanics/thermal_deformation.cpp
@@ -83,8 +83,10 @@ void thermalDeformationExample( const std::string filename )
     //                    Force model
     // ====================================================
     auto temp = particles.sliceTemperature();
-    CabanaPD::ForceModel force_model( model_type{}, CabanaPD::NoFracture{},
-                                      horizon, K, temp, alpha, temp0 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::ThermalModel thermal_model( temp, alpha, temp0 );
+    CabanaPD::Experimental::ThermalForceModel force_model( mechanics_model,
+                                                           thermal_model );
 
     // ====================================================
     //                   Create solver

--- a/examples/thermomechanics/thermal_deformation.cpp
+++ b/examples/thermomechanics/thermal_deformation.cpp
@@ -85,8 +85,7 @@ void thermalDeformationExample( const std::string filename )
     auto temp = particles.sliceTemperature();
     CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
     CabanaPD::ThermalModel thermal_model( temp, alpha, temp0 );
-    CabanaPD::Experimental::ThermalForceModel force_model( mechanics_model,
-                                                           thermal_model );
+    CabanaPD::ThermalForceModel force_model( mechanics_model, thermal_model );
 
     // ====================================================
     //                   Create solver

--- a/examples/thermomechanics/thermal_deformation_bimaterial.cpp
+++ b/examples/thermomechanics/thermal_deformation_bimaterial.cpp
@@ -91,13 +91,14 @@ void thermalDeformationExample( const std::string filename )
     // ====================================================
     //                    Force model
     // ====================================================
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
     auto temp = particles.sliceTemperature();
-    CabanaPD::ForceModel force_model_upper( model_type{},
-                                            CabanaPD::NoFracture{}, horizon, K,
-                                            temp, alpha[0], temp0 );
-    CabanaPD::ForceModel force_model_lower( model_type{},
-                                            CabanaPD::NoFracture{}, horizon, K,
-                                            temp, alpha[1], temp0 );
+    CabanaPD::ThermalModel thermal_model_upper( temp, alpha[0], temp0 );
+    CabanaPD::ThermalModel thermal_model_lower( temp, alpha[1], temp0 );
+    CabanaPD::Experimental::ThermalForceModel force_model_upper(
+        mechanics_model, thermal_model_upper );
+    CabanaPD::Experimental::ThermalForceModel force_model_lower(
+        mechanics_model, thermal_model_lower );
 
     auto models =
         CabanaPD::createMultiForceModel( particles, CabanaPD::AverageTag{},

--- a/examples/thermomechanics/thermal_deformation_bimaterial.cpp
+++ b/examples/thermomechanics/thermal_deformation_bimaterial.cpp
@@ -95,10 +95,10 @@ void thermalDeformationExample( const std::string filename )
     auto temp = particles.sliceTemperature();
     CabanaPD::ThermalModel thermal_model_upper( temp, alpha[0], temp0 );
     CabanaPD::ThermalModel thermal_model_lower( temp, alpha[1], temp0 );
-    CabanaPD::Experimental::ThermalForceModel force_model_upper(
-        mechanics_model, thermal_model_upper );
-    CabanaPD::Experimental::ThermalForceModel force_model_lower(
-        mechanics_model, thermal_model_lower );
+    CabanaPD::ThermalForceModel force_model_upper( mechanics_model,
+                                                   thermal_model_upper );
+    CabanaPD::ThermalForceModel force_model_lower( mechanics_model,
+                                                   thermal_model_lower );
 
     auto models =
         CabanaPD::createMultiForceModel( particles, CabanaPD::AverageTag{},

--- a/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
@@ -92,8 +92,10 @@ void thermalDeformationHeatTransferExample( const std::string filename )
     //                    Force model
     // ====================================================
     CabanaPD::ForceModel force_model( model_type{}, CabanaPD::NoFracture{},
-                                      horizon, K, temp, kappa, cp, alpha,
-                                      temp0 );
+                                      horizon, K );
+    CabanaPD::ThermalModel thermal_model( temp, horizon, kappa, cp, alpha,
+                                          temp0 );
+    CabanaPD::Experimental::ThermalForceModel( force_model, thermal_model );
 
     // ====================================================
     //                   Create solver

--- a/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer.cpp
@@ -91,11 +91,10 @@ void thermalDeformationHeatTransferExample( const std::string filename )
     // ====================================================
     //                    Force model
     // ====================================================
-    CabanaPD::ForceModel force_model( model_type{}, CabanaPD::NoFracture{},
-                                      horizon, K );
-    CabanaPD::ThermalModel thermal_model( temp, horizon, kappa, cp, alpha,
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::ThermalModel thermal_model( horizon, temp, alpha, kappa, cp,
                                           temp0 );
-    CabanaPD::Experimental::ThermalForceModel( force_model, thermal_model );
+    CabanaPD::ThermalForceModel force_model( mechanics_model, thermal_model );
 
     // ====================================================
     //                   Create solver

--- a/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
@@ -133,8 +133,12 @@ void thermalDeformationHeatTransferPrenotchedExample(
     // ====================================================
     //                    Force model
     // ====================================================
-    CabanaPD::ForceModel force_model( model_type{}, horizon, K, G0, temp, kappa,
-                                      cp, alpha, temp0 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::ThermalModel thermal_model( fracture_model, temp, horizon, kappa,
+                                          cp, alpha, temp0 );
+    CabanaPD::Experimental::ThermalForceModel force_model( mechanics_model,
+                                                           thermal_model );
 
     // ====================================================
     //                   Create solver

--- a/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
@@ -135,10 +135,10 @@ void thermalDeformationHeatTransferPrenotchedExample(
     // ====================================================
     CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
     CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-    CabanaPD::ThermalModel thermal_model( fracture_model, temp, horizon, kappa,
-                                          cp, alpha, temp0 );
-    CabanaPD::Experimental::ThermalForceModel force_model( mechanics_model,
-                                                           thermal_model );
+    const double s0 = fracture_model.criticalStretch();
+    CabanaPD::ThermalModel thermal_model( horizon, s0, temp, alpha, kappa, cp,
+                                          temp0 );
+    CabanaPD::ThermalForceModel force_model( mechanics_model, thermal_model );
 
     // ====================================================
     //                   Create solver

--- a/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
+++ b/examples/thermomechanics/thermal_deformation_heat_transfer_prenotched.cpp
@@ -134,8 +134,7 @@ void thermalDeformationHeatTransferPrenotchedExample(
     //                    Force model
     // ====================================================
     CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
-    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-    const double s0 = fracture_model.criticalStretch();
+    const double s0 = CabanaPD::criticalStretch( horizon, K, G0 );
     CabanaPD::ThermalModel thermal_model( horizon, s0, temp, alpha, kappa, cp,
                                           temp0 );
     CabanaPD::ThermalForceModel force_model( mechanics_model, thermal_model );

--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -189,6 +189,17 @@ template <typename ThermalType, typename TemperatureType,
           typename FractureType = NoFracture>
 struct ThermalModel;
 
+template <>
+struct ThermalModel<TemperatureIndependent, TemperatureIndependent, NoFracture>
+{
+    KOKKOS_FUNCTION
+    double operator()( ThermalStretchTag, const int, const int,
+                       const double s ) const
+    {
+        return s;
+    }
+};
+
 template <typename TemperatureType>
 struct ThermalModel<TemperatureDependent, TemperatureType, NoFracture>
 {
@@ -426,21 +437,29 @@ struct is_force_model<ForceModel<MechanicsType, FractureType>>
 
 template <typename MechanicsType,
           typename FractureType = FractureModel<NoFracture>>
-struct ForceModel : public MechanicsType, FractureType
+struct ForceModel
+    : public MechanicsType,
+      FractureType,
+      ThermalModel<TemperatureIndependent, TemperatureIndependent, NoFracture>
 {
     using MechanicsType::operator();
     using FractureType::operator();
     using typename FractureType::fracture_tag;
+    using thermal_type = ThermalModel<TemperatureIndependent,
+                                      TemperatureIndependent, NoFracture>;
+    using thermal_type::operator();
 
     ForceModel( MechanicsType mechanics, FractureType thermal )
         : MechanicsType( mechanics )
         , FractureType( thermal )
+        , thermal_type()
     {
     }
 
     ForceModel( MechanicsType mechanics )
         : MechanicsType( mechanics )
         , FractureType()
+        , thermal_type()
     {
     }
 

--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -133,6 +133,14 @@ struct is_fracture_model<FractureModel<FractureType>> : public std::true_type
 {
 };
 
+KOKKOS_INLINE_FUNCTION
+auto averageCriticalStretch( const double s0_1, const double s0_2,
+                             const double K_1, const double K_2 )
+{
+    return Kokkos::sqrt( ( s0_1 * s0_1 * K_1 + s0_2 * s0_2 * K_2 ) /
+                         ( K_1 + K_2 ) );
+}
+
 template <>
 struct FractureModel<NoFracture>
 {
@@ -205,10 +213,9 @@ struct FractureModel<CriticalStretch>
                                   int>* = 0 )
     {
         G0 = ( model1.fractureEnergy() + model2.fractureEnergy() ) / 2.0;
-        const double s0_1 = model1.criticalStretch();
-        const double s0_2 = model2.criticalStretch();
-        s0 = Kokkos::sqrt( ( s0_1 * s0_1 * model1.K + s0_2 * s0_2 * model2.K ) /
-                           ( model1.K + model2.K ) );
+        s0 = averageCriticalStretch( model1.criticalStretch(),
+                                     model2.criticalStretch(), model1.K,
+                                     model2.K );
         bond_break_coeff = ( 1.0 + s0 ) * ( 1.0 + s0 );
     }
 
@@ -342,6 +349,9 @@ struct ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>
     template <typename ModelType1, typename ModelType2>
     ThermalModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
+        , s0( averageCriticalStretch( model1.criticalStretch(),
+                                      model2.criticalStretch(), model1.K,
+                                      model2.K ) )
     {
     }
 
@@ -354,6 +364,9 @@ struct ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>
             ( 1.0 + s0 + alpha * temp_avg ) * ( 1.0 + s0 + alpha * temp_avg );
         return r * r >= bond_break_coeff * xi * xi;
     }
+
+    KOKKOS_FUNCTION
+    auto criticalStretch() const { return s0; }
 };
 
 template <typename TemperatureType>

--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -134,6 +134,17 @@ struct is_fracture_model<FractureModel<FractureType>> : public std::true_type
 };
 
 KOKKOS_INLINE_FUNCTION
+auto criticalStretch( const double horizon, const double K, const double G0,
+                      const int influence = 1 )
+{
+    double s0 = Kokkos::sqrt( 5.0 * G0 / 9.0 / K / horizon ); // 1/xi
+    if ( influence == 0 )
+        s0 = Kokkos::sqrt( 8.0 * G0 / 15.0 / K / horizon ); // 1
+
+    return s0;
+}
+
+KOKKOS_INLINE_FUNCTION
 auto averageCriticalStretch( const double s0_1, const double s0_2,
                              const double K_1, const double K_2 )
 {
@@ -189,9 +200,7 @@ struct FractureModel<CriticalStretch>
         : G0( _G0 )
         , influence_type( influence )
     {
-        s0 = Kokkos::sqrt( 5.0 * G0 / 9.0 / _K / _force_horizon ); // 1/xi
-        if ( influence_type == 0 )
-            s0 = Kokkos::sqrt( 8.0 * G0 / 15.0 / _K / _force_horizon ); // 1
+        s0 = CabanaPD::criticalStretch( _force_horizon, _K, _G0, influence );
 
         bond_break_coeff = ( 1.0 + s0 ) * ( 1.0 + s0 );
     };

--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -558,6 +558,10 @@ struct ThermalForceModel : public MechanicsType, ThermalType
     using typename ThermalType::needs_update;
     using typename ThermalType::thermal_tag;
 
+    static_assert( !is_state_based<MechanicsType>::value ||
+                       !is_temperature_dependent<ThermalType>::value,
+                   "State-based models do not yet support thermomechanics!" );
+
     ThermalForceModel(
         MechanicsType mechanics, ThermalType thermal,
         typename std::enable_if_t<( is_mechanics_model<MechanicsType>::value &&

--- a/src/CabanaPD_ForceModels.hpp
+++ b/src/CabanaPD_ForceModels.hpp
@@ -39,6 +39,9 @@ struct InfluenceFunctionTag
 {
 };
 
+/******************************************************************************
+  Forward declarations.
+******************************************************************************/
 template <typename PDModelType, typename MechanicsType, typename... DataTypes>
 struct MechanicsModel;
 
@@ -53,12 +56,27 @@ struct is_mechanics_model<
 {
 };
 
+template <typename MechanicsType, typename FractureType>
+struct ForceModel;
+
+template <typename T>
+struct is_force_model : public std::false_type
+{
+};
+template <typename MechanicsType, typename FractureType>
+struct is_force_model<ForceModel<MechanicsType, FractureType>>
+    : public std::true_type
+{
+};
+
+/******************************************************************************
+  Base models.
+******************************************************************************/
 struct BaseForceModel
 {
     // Is there a field that needs to be updated later?
     using needs_update = std::false_type;
     using material_type = SingleMaterial;
-    using thermal_tag = TemperatureIndependent;
     double force_horizon;
     double K;
 
@@ -106,19 +124,46 @@ class BasePlasticity
 template <typename FractureType>
 struct FractureModel;
 
+template <typename T>
+struct is_fracture_model : public std::false_type
+{
+};
+template <typename FractureType>
+struct is_fracture_model<FractureModel<FractureType>> : public std::true_type
+{
+};
+
 template <>
 struct FractureModel<NoFracture>
 {
     using fracture_tag = NoFracture;
 
-    // This should only be used in multi-material models in which the current
-    // model does not support failure.
+    FractureModel() = default;
+
+    // Average from existing models.
+    template <typename ModelType1, typename ModelType2>
+    FractureModel(
+        const ModelType1&, const ModelType2&,
+        typename std::enable_if_t<( is_force_model<ModelType1>::value &&
+                                    is_force_model<ModelType2>::value ),
+                                  int>* = 0 )
+    {
+    }
+
+    // This should only be used in multi-material models in which the
+    // current model does not support failure.
     KOKKOS_INLINE_FUNCTION
     bool operator()( CriticalStretchTag, const int, const int, const double,
                      const double ) const
     {
         return false;
     }
+
+    KOKKOS_FUNCTION
+    auto criticalStretch() const { return DBL_MAX; }
+
+    KOKKOS_FUNCTION
+    auto fractureEnergy() const { return DBL_MAX; }
 };
 
 template <>
@@ -153,11 +198,16 @@ struct FractureModel<CriticalStretch>
 
     // Average from existing models.
     template <typename ModelType1, typename ModelType2>
-    FractureModel( const ModelType1& model1, const ModelType2& model2 )
+    FractureModel(
+        const ModelType1& model1, const ModelType2& model2,
+        typename std::enable_if_t<( is_force_model<ModelType1>::value &&
+                                    is_force_model<ModelType2>::value ),
+                                  int>* = 0 )
     {
-        G0 = ( model1.G0 + model2.G0 ) / 2.0;
-        s0 = Kokkos::sqrt( ( model1.s0 * model1.s0 * model1.K +
-                             model2.s0 * model2.s0 * model2.K ) /
+        G0 = ( model1.fractureEnergy() + model2.fractureEnergy() ) / 2.0;
+        const double s0_1 = model1.criticalStretch();
+        const double s0_2 = model2.criticalStretch();
+        s0 = Kokkos::sqrt( ( s0_1 * s0_1 * model1.K + s0_2 * s0_2 * model2.K ) /
                            ( model1.K + model2.K ) );
         bond_break_coeff = ( 1.0 + s0 ) * ( 1.0 + s0 );
     }
@@ -168,19 +218,20 @@ struct FractureModel<CriticalStretch>
     {
         return r * r >= bond_break_coeff * xi * xi;
     }
+
+    KOKKOS_FUNCTION
+    auto criticalStretch() const { return s0; }
+
+    KOKKOS_FUNCTION
+    auto fractureEnergy() const { return G0; }
+
+    KOKKOS_FUNCTION
+    auto influenceType() const { return influence_type; }
 };
 
 FractureModel( const double _force_horizon, const double _K, const double _G0,
                const int influence = 1 )
     ->FractureModel<CriticalStretch>;
-
-/******************************************************************************
-Force models forward declaration.
-******************************************************************************/
-template <typename PeridynamicsModelType, typename MechanicsModelType = Elastic,
-          typename DamageType = Fracture,
-          typename ThermalType = TemperatureIndependent, typename... DataTypes>
-struct ForceModel;
 
 /******************************************************************************
   Temperature-dependent models.
@@ -189,9 +240,22 @@ template <typename ThermalType, typename TemperatureType,
           typename FractureType = NoFracture>
 struct ThermalModel;
 
+template <typename T>
+struct is_thermal_model : public std::false_type
+{
+};
+template <typename ThermalType, typename TemperatureType, typename FractureType>
+struct is_thermal_model<
+    ThermalModel<ThermalType, TemperatureType, FractureType>>
+    : public std::true_type
+{
+};
+
 template <>
 struct ThermalModel<TemperatureIndependent, TemperatureIndependent, NoFracture>
 {
+    using thermal_tag = TemperatureIndependent;
+
     KOKKOS_FUNCTION
     double operator()( ThermalStretchTag, const int, const int,
                        const double s ) const
@@ -256,35 +320,28 @@ ThermalModel( const TemperatureType, const double, const double )
 
 template <typename TemperatureType>
 struct ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>
-    : public FractureModel<CriticalStretch>,
-      public ThermalModel<TemperatureDependent, TemperatureType, NoFracture>
+    : public ThermalModel<TemperatureDependent, TemperatureType, NoFracture>
 {
-    using base_fracture_type = FractureModel<CriticalStretch>;
-    using base_temperature_type =
+    using base_type =
         ThermalModel<TemperatureDependent, TemperatureType, NoFracture>;
-    using typename base_fracture_type::fracture_tag;
+    using base_type::operator();
+    using fracture_tag = Fracture;
 
-    // Does not use the base bond_break_coeff.
-    using base_fracture_type::s0;
-    using base_temperature_type::alpha;
-    using base_temperature_type::temp0;
-    using base_temperature_type::temperature;
+    double s0;
+    using base_type::alpha;
+    using base_type::temp0;
+    using base_type::temperature;
 
-    // Does not use the base critical stretch.
-    using base_temperature_type::operator();
-
-    ThermalModel( const base_fracture_type fracture,
-                  const TemperatureType _temp, const double _alpha,
-                  const double _temp0 )
-        : base_fracture_type( fracture )
-        , base_temperature_type( _temp, _alpha, _temp0 )
+    ThermalModel( const double _s0, const TemperatureType _temp,
+                  const double _alpha, const double _temp0 )
+        : base_type( _temp, _alpha, _temp0 )
+        , s0( _s0 )
     {
     }
 
     template <typename ModelType1, typename ModelType2>
     ThermalModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_fracture_type( model1, model2 )
-        , base_temperature_type( model1, model2 )
+        : base_type( model1, model2 )
     {
     }
 
@@ -299,9 +356,8 @@ struct ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>
     }
 };
 
-template <typename ForceModelType, typename TemperatureType>
-ThermalModel( ForceModelType, const TemperatureType, const double,
-              const double )
+template <typename TemperatureType>
+ThermalModel( const double, const TemperatureType, const double, const double )
     -> ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>;
 
 // This class stores temperature parameters needed for heat transfer, but not
@@ -356,32 +412,33 @@ struct ThermalModel<DynamicTemperature, TemperatureType, NoFracture>
     : public BaseDynamicTemperatureModel,
       ThermalModel<TemperatureDependent, TemperatureType, NoFracture>
 {
-    using thermal_tag = TemperatureDependent;
     using base_heattransfer_type = BaseDynamicTemperatureModel;
-    using base_temperature_type =
+    using typename base_heattransfer_type::thermal_tag;
+    using base_type =
         ThermalModel<TemperatureDependent, TemperatureType, NoFracture>;
-    using typename base_temperature_type::fracture_tag;
+    using typename base_type::fracture_tag;
+    using base_type::operator();
 
-    ThermalModel( const TemperatureType _temp, const double _thermal_horizon,
+    ThermalModel( const double _thermal_horizon, const TemperatureType _temp,
                   const double _alpha, const double _kappa, const double _cp,
                   const double _temp0,
                   const bool _constant_microconductivity = true )
         : base_heattransfer_type( _thermal_horizon, _kappa, _cp,
                                   _constant_microconductivity )
-        , base_temperature_type( _temp, _alpha, _temp0 )
+        , base_type( _temp, _alpha, _temp0 )
     {
     }
 
     template <typename ModelType1, typename ModelType2>
     ThermalModel( const ModelType1& model1, const ModelType2& model2 )
         : base_heattransfer_type( model1, model2 )
-        , base_temperature_type( model1, model2 )
+        , base_type( model1, model2 )
     {
     }
 };
 
 template <typename TemperatureType>
-ThermalModel( const TemperatureType, const double, const double, const double,
+ThermalModel( const double, const TemperatureType, const double, const double,
               const double, const double, const bool = true )
     -> ThermalModel<DynamicTemperature, TemperatureType, NoFracture>;
 
@@ -390,19 +447,19 @@ struct ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>
     : public BaseDynamicTemperatureModel,
       ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>
 {
-    using thermal_tag = TemperatureDependent;
     using base_heattransfer_type = BaseDynamicTemperatureModel;
-    using base_temperature_type =
+    using typename base_heattransfer_type::thermal_tag;
+    using base_type =
         ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>;
+    using base_type::operator();
 
-    template <typename ForceModelType>
-    ThermalModel( ForceModelType force_model, const TemperatureType _temp,
-                  const double _thermal_horizon, const double _alpha,
+    ThermalModel( const double _thermal_horizon, const double _s0,
+                  const TemperatureType _temp, const double _alpha,
                   const double _kappa, const double _cp, const double _temp0,
                   const bool _constant_microconductivity = true )
         : base_heattransfer_type( _thermal_horizon, _kappa, _cp,
                                   _constant_microconductivity )
-        , base_temperature_type( force_model, _temp, _alpha, _temp0 )
+        , base_type( _s0, _temp, _alpha, _temp0 )
 
     {
     }
@@ -410,31 +467,19 @@ struct ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>
     template <typename ModelType1, typename ModelType2>
     ThermalModel( const ModelType1& model1, const ModelType2& model2 )
         : base_heattransfer_type( model1, model2 )
-        , base_temperature_type( model1, model2 )
+        , base_type( model1, model2 )
     {
     }
 };
 
-template <typename ForceModelType, typename TemperatureType>
-ThermalModel( ForceModelType, const TemperatureType, const double, const double,
-              const double, const double, const double, const bool = true )
+template <typename TemperatureType>
+ThermalModel( const double, const double, const TemperatureType, const double,
+              const double, const double, const bool = true )
     -> ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>;
 
-namespace Experimental
-{
-template <typename MechanicsType, typename FractureType>
-struct ForceModel;
-
-template <typename T>
-struct is_force_model : public std::false_type
-{
-};
-template <typename MechanicsType, typename FractureType>
-struct is_force_model<ForceModel<MechanicsType, FractureType>>
-    : public std::true_type
-{
-};
-
+/******************************************************************************
+Force models.
+******************************************************************************/
 template <typename MechanicsType,
           typename FractureType = FractureModel<NoFracture>>
 struct ForceModel
@@ -443,37 +488,45 @@ struct ForceModel
       ThermalModel<TemperatureIndependent, TemperatureIndependent, NoFracture>
 {
     using MechanicsType::operator();
+    using MechanicsType::influenceType;
     using FractureType::operator();
+    using thermal_tag = TemperatureIndependent;
     using typename FractureType::fracture_tag;
     using thermal_type = ThermalModel<TemperatureIndependent,
                                       TemperatureIndependent, NoFracture>;
     using thermal_type::operator();
 
-    ForceModel( MechanicsType mechanics, FractureType thermal )
+    ForceModel(
+        MechanicsType mechanics, FractureType fracture,
+        typename std::enable_if_t<( is_mechanics_model<MechanicsType>::value &&
+                                    is_fracture_model<FractureType>::value ),
+                                  int>* = 0 )
         : MechanicsType( mechanics )
-        , FractureType( thermal )
+        , FractureType( fracture )
         , thermal_type()
     {
     }
 
     ForceModel( MechanicsType mechanics )
-        : MechanicsType( mechanics )
-        , FractureType()
-        , thermal_type()
+        : ForceModel( mechanics, FractureType() )
     {
     }
 
     // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
-    ForceModel(
-        const ModelType1& model1, const ModelType2& model2,
-        typename std::enable_if_t<is_force_model<ModelType1>::value &&
-                                  is_force_model<ModelType2>::value> = 0 )
+    ForceModel( const ModelType1& model1, const ModelType2& model2,
+                typename std::enable_if_t<( is_force_model<ModelType1>::value &&
+                                            is_force_model<ModelType2>::value ),
+                                          int>* = 0 )
         : MechanicsType( model1, model2 )
         , FractureType( model1, model2 )
     {
     }
 };
+
+template <typename MechanicsType, typename PhysicsType>
+ForceModel( MechanicsType mechanics, PhysicsType thermal )
+    -> ForceModel<MechanicsType, PhysicsType>;
 
 template <typename MechanicsType, typename ThermalType>
 struct ThermalForceModel;
@@ -492,7 +545,11 @@ struct ThermalForceModel : public MechanicsType, ThermalType
     using typename ThermalType::needs_update;
     using typename ThermalType::thermal_tag;
 
-    ThermalForceModel( MechanicsType mechanics, ThermalType thermal )
+    ThermalForceModel(
+        MechanicsType mechanics, ThermalType thermal,
+        typename std::enable_if_t<( is_mechanics_model<MechanicsType>::value &&
+                                    is_thermal_model<ThermalType>::value ),
+                                  int>* = 0 )
         : MechanicsType( mechanics )
         , ThermalType( thermal )
     {
@@ -502,19 +559,15 @@ struct ThermalForceModel : public MechanicsType, ThermalType
     template <typename ModelType1, typename ModelType2>
     ThermalForceModel(
         const ModelType1& model1, const ModelType2& model2,
-        typename std::enable_if_t<is_force_model<ModelType1>::value &&
-                                  is_force_model<ModelType2>::value> = 0 )
+        typename std::enable_if_t<( is_force_model<ModelType1>::value &&
+                                    is_force_model<ModelType2>::value ),
+                                  int>* = 0 )
         : MechanicsType( model1, model2 )
         , ThermalType( model1, model2 )
     {
     }
 };
 
-template <typename MechanicsType, typename PhysicsType>
-ForceModel( MechanicsType mechanics, PhysicsType thermal )
-    -> ForceModel<MechanicsType, PhysicsType>;
-
-} // namespace Experimental
 } // namespace CabanaPD
 
 #endif

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -109,7 +109,7 @@ struct CheckTemperatureDependence<ParameterPackType,
         typename IfElseType<TemperatureDependent, TemperatureIndependent,
                             std::disjunction_v<std::is_same<
                                 typename ParameterPackType::template value_type<
-                                    Indices>::thermal_type,
+                                    Indices>::thermal_tag,
                                 TemperatureDependent>...>>::type;
 };
 
@@ -127,7 +127,7 @@ struct CheckFractureModel<ParameterPackType, std::index_sequence<Indices...>>
         typename IfElseType<Fracture, NoFracture,
                             std::disjunction_v<std::is_same<
                                 typename ParameterPackType::template value_type<
-                                    Indices>::fracture_type,
+                                    Indices>::fracture_tag,
                                 Fracture>...>>::type;
 };
 
@@ -157,7 +157,7 @@ struct FirstModelWithFractureTypeImpl<FractureType, ParameterPackType, Index,
     using type = typename FirstModelWithFractureTypeImpl<
         FractureType, ParameterPackType, Index + 1,
         std::is_same_v<typename ParameterPackType::template value_type<
-                           Index + 1>::fracture_type,
+                           Index + 1>::fracture_tag,
                        FractureType>>::type;
 };
 
@@ -167,7 +167,7 @@ struct FirstModelWithFractureType
     using type = typename FirstModelWithFractureTypeImpl<
         FractureType, ParameterPackType, 0,
         std::is_same_v<
-            typename ParameterPackType::template value_type<0>::fracture_type,
+            typename ParameterPackType::template value_type<0>::fracture_tag,
             FractureType>>::type;
 };
 
@@ -212,15 +212,15 @@ struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
                        is_symmetric<Indexing>::value,
                    "Symmetry of model and indexing must match" );
 
-    using fracture_type = typename CheckFractureModel<
+    using fracture_tag = typename CheckFractureModel<
         ParameterPackType,
         std::make_index_sequence<ParameterPackType::size>>::type;
-    using thermal_type = typename CheckTemperatureDependence<
+    using thermal_tag = typename CheckTemperatureDependence<
         ParameterPackType,
         std::make_index_sequence<ParameterPackType::size>>::type;
 
     using force_tag =
-        typename FirstModelWithFractureType<fracture_type,
+        typename FirstModelWithFractureType<fracture_tag,
                                             ParameterPackType>::type::force_tag;
 
     ForceModelsImpl( MaterialType t, Indexing const& i,

--- a/src/CabanaPD_Input.hpp
+++ b/src/CabanaPD_Input.hpp
@@ -303,7 +303,7 @@ class Inputs
                             // Compute denominator for heat transfer.
                             if constexpr ( is_heat_transfer<
                                                typename ForceModel::
-                                                   thermal_type>::value )
+                                                   thermal_tag>::value )
                             {
                                 double coeff =
                                     model.microconductivity_function( xi );
@@ -322,7 +322,7 @@ class Inputs
 
         // Heat transfer timestep.
         if constexpr ( is_heat_transfer<
-                           typename ForceModel::thermal_type>::value )
+                           typename ForceModel::thermal_tag>::value )
         {
             double dt_ht = inputs.at( "thermal_subcycle_steps" )["value"];
             dt_ht *= dt;

--- a/src/CabanaPD_Types.hpp
+++ b/src/CabanaPD_Types.hpp
@@ -23,6 +23,11 @@ struct NoFracture
 struct Fracture
 {
 };
+struct CriticalStretch
+{
+    using base_type = Fracture;
+};
+
 template <class, class SFINAE = void>
 struct is_fracture : public std::false_type
 {
@@ -31,11 +36,14 @@ template <>
 struct is_fracture<Fracture> : public std::true_type
 {
 };
+template <>
+struct is_fracture<CriticalStretch> : public std::true_type
+{
+};
 template <typename ModelType>
-struct is_fracture<
-    ModelType,
-    typename std::enable_if<( std::is_same<typename ModelType::fracture_type,
-                                           Fracture>::value )>::type>
+struct is_fracture<ModelType, typename std::enable_if<(
+                                  std::is_same<typename ModelType::fracture_tag,
+                                               Fracture>::value )>::type>
     : public std::true_type
 {
 };
@@ -161,6 +169,19 @@ struct LinearLPS
 };
 
 template <typename T>
+struct is_model_tag : public std::false_type
+{
+};
+template <>
+struct is_model_tag<PMB> : public std::true_type
+{
+};
+template <>
+struct is_model_tag<LPS> : public std::true_type
+{
+};
+
+template <typename T>
 struct is_symmetric : public std::false_type
 {
 };
@@ -200,7 +221,7 @@ struct NoContact
     using model_tag = std::false_type;
     using force_tag = std::false_type;
     using thermal_type = TemperatureIndependent;
-    using fracture_type = NoFracture;
+    using fracture_tag = NoFracture;
 };
 template <class, class SFINAE = void>
 struct is_contact : public std::false_type

--- a/src/force/CabanaPD_PMB.hpp
+++ b/src/force/CabanaPD_PMB.hpp
@@ -106,10 +106,7 @@ class Force<MemorySpace, PMB, NoFracture> : public BaseForce<MemorySpace>
             double rx, ry, rz;
             getDistance( x, u, i, j, xi, r, s, rx, ry, rz );
 
-            if constexpr ( std::is_same_v<
-                               typename ModelType::thermal_tag::base_type,
-                               TemperatureDependent> )
-                s = model( ThermalStretchTag{}, i, j, s );
+            s = model( ThermalStretchTag{}, i, j, s );
 
             const double coeff = model( ForceCoeffTag{}, i, j, s, vol( j ) );
             fx_i = coeff * rx / r;
@@ -143,10 +140,7 @@ class Force<MemorySpace, PMB, NoFracture> : public BaseForce<MemorySpace>
             double xi, r, s;
             getDistance( x, u, i, j, xi, r, s );
 
-            if constexpr ( std::is_same_v<
-                               typename ModelType::thermal_tag::base_type,
-                               TemperatureDependent> )
-                s = model( ThermalStretchTag{}, i, j, s );
+            s = model( ThermalStretchTag{}, i, j, s );
 
             double w = model( EnergyTag{}, i, j, s, xi, vol( j ) );
             W( i ) += w;
@@ -179,10 +173,7 @@ class Force<MemorySpace, PMB, NoFracture> : public BaseForce<MemorySpace>
             double xi_x, xi_y, xi_z;
             getDistance( x, u, i, j, xi, r, s, rx, ry, rz, xi_x, xi_y, xi_z );
 
-            if constexpr ( std::is_same_v<
-                               typename ModelType::thermal_tag::base_type,
-                               TemperatureDependent> )
-                s = model( ThermalStretchTag{}, i, j, s );
+            s = model( ThermalStretchTag{}, i, j, s );
 
             const double coeff =
                 0.5 * model( ForceCoeffTag{}, i, j, s, vol( j ) );
@@ -263,10 +254,7 @@ class Force<MemorySpace, PMB, Fracture> : public BaseForce<MemorySpace>
                 double rx, ry, rz;
                 getDistance( x, u, i, j, xi, r, s, rx, ry, rz );
 
-                if constexpr ( std::is_same_v<
-                                   typename ModelType::thermal_tag::base_type,
-                                   TemperatureDependent> )
-                    s = model( ThermalStretchTag{}, i, j, s );
+                s = model( ThermalStretchTag{}, i, j, s );
 
                 // Break if beyond critical stretch unless in no-fail zone.
                 if ( model( CriticalStretchTag{}, i, j, r, xi ) &&
@@ -328,10 +316,7 @@ class Force<MemorySpace, PMB, Fracture> : public BaseForce<MemorySpace>
                 double xi, r, s;
                 getDistance( x, u, i, j, xi, r, s );
 
-                if constexpr ( std::is_same_v<
-                                   typename ModelType::thermal_tag::base_type,
-                                   TemperatureDependent> )
-                    s = model( ThermalStretchTag{}, i, j, s );
+                s = model( ThermalStretchTag{}, i, j, s );
 
                 double w =
                     mu( i, n ) * model( EnergyTag{}, i, j, s, xi, vol( j ), n );
@@ -385,10 +370,7 @@ class Force<MemorySpace, PMB, Fracture> : public BaseForce<MemorySpace>
                 getDistance( x, u, i, j, xi, r, s, rx, ry, rz, xi_x, xi_y,
                              xi_z );
 
-                if constexpr ( std::is_same_v<
-                                   typename ModelType::thermal_tag::base_type,
-                                   TemperatureDependent> )
-                    s = model( ThermalStretchTag{}, i, j, s );
+                s = model( ThermalStretchTag{}, i, j, s );
 
                 const double coeff =
                     0.5 * model( ForceCoeffTag{}, i, j, s, vol( j ), n );
@@ -457,10 +439,7 @@ class Force<MemorySpace, LinearPMB, NoFracture> : public BaseForce<MemorySpace>
             double xi_x, xi_y, xi_z;
             getLinearizedDistance( x, u, i, j, xi, linear_s, xi_x, xi_y, xi_z );
 
-            if constexpr ( std::is_same_v<
-                               typename ModelType::thermal_tag::base_type,
-                               TemperatureDependent> )
-                linear_s = model( ThermalStretchTag{}, i, j, linear_s );
+            linear_s = model( ThermalStretchTag{}, i, j, linear_s );
 
             const double coeff =
                 model( ForceCoeffTag{}, i, j, linear_s, vol( j ) );
@@ -496,10 +475,7 @@ class Force<MemorySpace, LinearPMB, NoFracture> : public BaseForce<MemorySpace>
             double xi, linear_s;
             getLinearizedDistance( x, u, i, j, xi, linear_s );
 
-            if constexpr ( std::is_same_v<
-                               typename ModelType::thermal_tag::base_type,
-                               TemperatureDependent> )
-                linear_s = model( ThermalStretchTag{}, i, j, linear_s );
+            linear_s = model( ThermalStretchTag{}, i, j, linear_s );
 
             double w = model( EnergyTag{}, i, j, linear_s, xi, vol( j ) );
             W( i ) += w;
@@ -531,10 +507,7 @@ class Force<MemorySpace, LinearPMB, NoFracture> : public BaseForce<MemorySpace>
             double xi_x, xi_y, xi_z;
             getLinearizedDistance( x, u, i, j, xi, linear_s, xi_x, xi_y, xi_z );
 
-            if constexpr ( std::is_same_v<
-                               typename ModelType::thermal_tag::base_type,
-                               TemperatureDependent> )
-                linear_s = model( ThermalStretchTag{}, i, j, linear_s );
+            linear_s = model( ThermalStretchTag{}, i, j, linear_s );
 
             const double coeff =
                 0.5 * model( ForceCoeffTag{}, i, j, linear_s, vol( j ) );

--- a/src/force/CabanaPD_PMB.hpp
+++ b/src/force/CabanaPD_PMB.hpp
@@ -106,7 +106,10 @@ class Force<MemorySpace, PMB, NoFracture> : public BaseForce<MemorySpace>
             double rx, ry, rz;
             getDistance( x, u, i, j, xi, r, s, rx, ry, rz );
 
-            s = model( ThermalStretchTag{}, i, j, s );
+            if constexpr ( std::is_same_v<
+                               typename ModelType::thermal_tag::base_type,
+                               TemperatureDependent> )
+                s = model( ThermalStretchTag{}, i, j, s );
 
             const double coeff = model( ForceCoeffTag{}, i, j, s, vol( j ) );
             fx_i = coeff * rx / r;
@@ -140,7 +143,10 @@ class Force<MemorySpace, PMB, NoFracture> : public BaseForce<MemorySpace>
             double xi, r, s;
             getDistance( x, u, i, j, xi, r, s );
 
-            s = model( ThermalStretchTag{}, i, j, s );
+            if constexpr ( std::is_same_v<
+                               typename ModelType::thermal_tag::base_type,
+                               TemperatureDependent> )
+                s = model( ThermalStretchTag{}, i, j, s );
 
             double w = model( EnergyTag{}, i, j, s, xi, vol( j ) );
             W( i ) += w;
@@ -173,7 +179,10 @@ class Force<MemorySpace, PMB, NoFracture> : public BaseForce<MemorySpace>
             double xi_x, xi_y, xi_z;
             getDistance( x, u, i, j, xi, r, s, rx, ry, rz, xi_x, xi_y, xi_z );
 
-            s = model( ThermalStretchTag{}, i, j, s );
+            if constexpr ( std::is_same_v<
+                               typename ModelType::thermal_tag::base_type,
+                               TemperatureDependent> )
+                s = model( ThermalStretchTag{}, i, j, s );
 
             const double coeff =
                 0.5 * model( ForceCoeffTag{}, i, j, s, vol( j ) );
@@ -254,7 +263,10 @@ class Force<MemorySpace, PMB, Fracture> : public BaseForce<MemorySpace>
                 double rx, ry, rz;
                 getDistance( x, u, i, j, xi, r, s, rx, ry, rz );
 
-                s = model( ThermalStretchTag{}, i, j, s );
+                if constexpr ( std::is_same_v<
+                                   typename ModelType::thermal_tag::base_type,
+                                   TemperatureDependent> )
+                    s = model( ThermalStretchTag{}, i, j, s );
 
                 // Break if beyond critical stretch unless in no-fail zone.
                 if ( model( CriticalStretchTag{}, i, j, r, xi ) &&
@@ -316,7 +328,10 @@ class Force<MemorySpace, PMB, Fracture> : public BaseForce<MemorySpace>
                 double xi, r, s;
                 getDistance( x, u, i, j, xi, r, s );
 
-                s = model( ThermalStretchTag{}, i, j, s );
+                if constexpr ( std::is_same_v<
+                                   typename ModelType::thermal_tag::base_type,
+                                   TemperatureDependent> )
+                    s = model( ThermalStretchTag{}, i, j, s );
 
                 double w =
                     mu( i, n ) * model( EnergyTag{}, i, j, s, xi, vol( j ), n );
@@ -370,7 +385,10 @@ class Force<MemorySpace, PMB, Fracture> : public BaseForce<MemorySpace>
                 getDistance( x, u, i, j, xi, r, s, rx, ry, rz, xi_x, xi_y,
                              xi_z );
 
-                s = model( ThermalStretchTag{}, i, j, s );
+                if constexpr ( std::is_same_v<
+                                   typename ModelType::thermal_tag::base_type,
+                                   TemperatureDependent> )
+                    s = model( ThermalStretchTag{}, i, j, s );
 
                 const double coeff =
                     0.5 * model( ForceCoeffTag{}, i, j, s, vol( j ), n );
@@ -439,7 +457,10 @@ class Force<MemorySpace, LinearPMB, NoFracture> : public BaseForce<MemorySpace>
             double xi_x, xi_y, xi_z;
             getLinearizedDistance( x, u, i, j, xi, linear_s, xi_x, xi_y, xi_z );
 
-            linear_s = model( ThermalStretchTag{}, i, j, linear_s );
+            if constexpr ( std::is_same_v<
+                               typename ModelType::thermal_tag::base_type,
+                               TemperatureDependent> )
+                linear_s = model( ThermalStretchTag{}, i, j, linear_s );
 
             const double coeff =
                 model( ForceCoeffTag{}, i, j, linear_s, vol( j ) );
@@ -475,7 +496,10 @@ class Force<MemorySpace, LinearPMB, NoFracture> : public BaseForce<MemorySpace>
             double xi, linear_s;
             getLinearizedDistance( x, u, i, j, xi, linear_s );
 
-            linear_s = model( ThermalStretchTag{}, i, j, linear_s );
+            if constexpr ( std::is_same_v<
+                               typename ModelType::thermal_tag::base_type,
+                               TemperatureDependent> )
+                linear_s = model( ThermalStretchTag{}, i, j, linear_s );
 
             double w = model( EnergyTag{}, i, j, linear_s, xi, vol( j ) );
             W( i ) += w;
@@ -507,7 +531,10 @@ class Force<MemorySpace, LinearPMB, NoFracture> : public BaseForce<MemorySpace>
             double xi_x, xi_y, xi_z;
             getLinearizedDistance( x, u, i, j, xi, linear_s, xi_x, xi_y, xi_z );
 
-            linear_s = model( ThermalStretchTag{}, i, j, linear_s );
+            if constexpr ( std::is_same_v<
+                               typename ModelType::thermal_tag::base_type,
+                               TemperatureDependent> )
+                linear_s = model( ThermalStretchTag{}, i, j, linear_s );
 
             const double coeff =
                 0.5 * model( ForceCoeffTag{}, i, j, linear_s, vol( j ) );

--- a/src/force_models/CabanaPD_Contact.hpp
+++ b/src/force_models/CabanaPD_Contact.hpp
@@ -54,8 +54,8 @@ struct ContactModel
 struct NormalRepulsionModel : public ContactModel
 {
     using base_type = ContactModel;
-    using fracture_type = NoFracture;
-    using thermal_type = TemperatureIndependent;
+    using fracture_tag = NoFracture;
+    using thermal_tag = TemperatureIndependent;
     // Tag to dispatch to force iteration.
     using force_tag = NormalRepulsionModel;
 

--- a/src/force_models/CabanaPD_Hertzian.hpp
+++ b/src/force_models/CabanaPD_Hertzian.hpp
@@ -23,8 +23,8 @@ namespace CabanaPD
 struct HertzianModel : public ContactModel
 {
     using base_type = ContactModel;
-    using fracture_type = NoFracture;
-    using thermal_type = TemperatureIndependent;
+    using fracture_tag = NoFracture;
+    using thermal_tag = TemperatureIndependent;
     // Tag to dispatch to force iteration.
     using force_tag = HertzianModel;
 

--- a/src/force_models/CabanaPD_HertzianJKR.hpp
+++ b/src/force_models/CabanaPD_HertzianJKR.hpp
@@ -23,8 +23,8 @@ namespace CabanaPD
 struct HertzianJKRModel : public ContactModel
 {
     using base_type = ContactModel;
-    using fracture_type = NoFracture;
-    using thermal_type = TemperatureIndependent;
+    using fracture_tag = NoFracture;
+    using thermal_tag = TemperatureIndependent;
     // Tag to dispatch to force iteration.
     using force_tag = HertzianModel;
 

--- a/src/force_models/CabanaPD_LPS.hpp
+++ b/src/force_models/CabanaPD_LPS.hpp
@@ -41,6 +41,12 @@ struct MechanicsModel<LPS, Elastic> : public BaseForceModel
     Kokkos::Array<double, 2> theta_coeff;
     Kokkos::Array<double, 2> s_coeff;
 
+    MechanicsModel( LPS tag, Elastic, const double _force_horizon,
+                    const double _K, const double _G, const int _influence = 0 )
+        : MechanicsModel( tag, _force_horizon, _K, _G, _influence )
+    {
+    }
+
     MechanicsModel( LPS, const double _force_horizon, const double _K,
                     const double _G, const int _influence = 0 )
         : base_type( _force_horizon, _K )
@@ -52,10 +58,7 @@ struct MechanicsModel<LPS, Elastic> : public BaseForceModel
 
     // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
-    MechanicsModel(
-        const ModelType1& model1, const ModelType2& model2,
-        typename std::enable_if_t<is_mechanics_model<ModelType1>::value &&
-                                  is_mechanics_model<ModelType2>::value> = 0 )
+    MechanicsModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
     {
         G = ( model1.G + model2.G ) / 2.0;
@@ -64,8 +67,8 @@ struct MechanicsModel<LPS, Elastic> : public BaseForceModel
         theta_coeff[1] = 3.0 * model2.K - 5.0 * model2.G;
         s_coeff[1] = 15.0 * model2.G;
 
-        influence_type = model1.influence_type;
-        if ( model2.influence_type != model1.influence_type )
+        influence_type = model1.influenceType();
+        if ( model2.influenceType() != model1.influenceType() )
             log_err( std::cout,
                      "Influence function type for each model must match for "
                      "multi-material systems" );
@@ -82,6 +85,9 @@ struct MechanicsModel<LPS, Elastic> : public BaseForceModel
         if ( influence_type > 1 || influence_type < 0 )
             log_err( std::cout, "Influence function type must be 0 or 1." );
     }
+
+    KOKKOS_FUNCTION
+    auto influenceType() const { return influence_type; }
 
     KOKKOS_INLINE_FUNCTION auto operator()( InfluenceFunctionTag,
                                             double xi ) const
@@ -167,143 +173,14 @@ struct MechanicsModel<LinearLPS, Elastic> : public MechanicsModel<LPS, Elastic>
     }
 };
 
-// Backwards compatibility wrapper.
-template <>
-struct ForceModel<LPS, Elastic, NoFracture>
-    : public Experimental::ForceModel<MechanicsModel<LPS, Elastic>,
-                                      FractureModel<NoFracture>>
-{
-    using base_type = Experimental::ForceModel<MechanicsModel<LPS, Elastic>,
-                                               FractureModel<NoFracture>>;
-    using base_type::operator();
-
-    ForceModel( LPS tag, const double _force_horizon, const double _K,
-                const double _G, const int _influence = 0 )
-        : base_type( MechanicsModel( tag, _force_horizon, _K, _G, _influence ),
-                     FractureModel() )
-    {
-    }
-
-    ForceModel( LPS tag, NoFracture, const double _force_horizon,
-                const double _K, const double _G, const int _influence = 0 )
-        : ForceModel( tag, _force_horizon, _K, _G, _influence )
-    {
-    }
-
-    ForceModel( LPS tag, Elastic, NoFracture, const double _force_horizon,
-                const double _K, const double _G, const int _influence = 0 )
-        : ForceModel( tag, _force_horizon, _K, _G, _influence )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <>
-struct ForceModel<LPS, Elastic, Fracture>
-    : public Experimental::ForceModel<MechanicsModel<LPS, Elastic>,
-                                      FractureModel<CriticalStretch>>
-
-{
-    using base_type = Experimental::ForceModel<MechanicsModel<LPS, Elastic>,
-                                               FractureModel<CriticalStretch>>;
-    using base_type::operator();
-    ForceModel( LPS tag, const double _force_horizon, const double _K,
-                const double _G, const double _G0, const int _influence = 0 )
-        : base_type( MechanicsModel( tag, _force_horizon, _K, _G, _influence ),
-                     FractureModel( _force_horizon, _K, _G0, _influence ) )
-    {
-    }
-
-    ForceModel( LPS model, Fracture, const double _force_horizon,
-                const double _K, const double _G, const double _G0,
-                const int _influence = 0 )
-        : ForceModel( model, _force_horizon, _K, _G, _G0, _influence )
-    {
-    }
-
-    ForceModel( LPS model, Elastic, const double _force_horizon,
-                const double _K, const double _G, const double _G0,
-                const int _influence = 0 )
-        : ForceModel( model, _force_horizon, _K, _G, _G0, _influence )
-    {
-    }
-
-    ForceModel( LPS model, Elastic, Fracture, const double _force_horizon,
-                const double _K, const double _G, const double _G0,
-                const int _influence = 0 )
-        : ForceModel( model, _force_horizon, _K, _G, _G0, _influence )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <typename MechanicsType, typename FractureType, typename ThermalType,
-          typename... FieldTypes>
-struct ForceModel<LinearLPS, MechanicsType, FractureType, ThermalType,
-                  FieldTypes...>
-    : public ForceModel<LPS, MechanicsType, FractureType, ThermalType,
-                        FieldTypes...>
-{
-    using base_type = ForceModel<LPS, MechanicsType, FractureType, ThermalType,
-                                 FieldTypes...>;
-    // Tag to dispatch to force iteration.
-    using force_tag = LinearLPS;
-
-    using base_type::base_type;
-    using base_type::operator();
-
-    template <typename... Args>
-    ForceModel( LinearLPS, Args&&... args )
-        : base_type( typename base_type::model_tag{},
-                     std::forward<Args>( args )... )
-    {
-    }
-};
-
 template <typename ModelType>
 MechanicsModel( ModelType, const double force_horizon, const double K,
-                const double G, const int influence = 0 )
+                const double G, const int _influence = 0 )
     -> MechanicsModel<ModelType, Elastic>;
-
 template <typename ModelType>
-ForceModel( ModelType, Elastic, NoFracture, const double force_horizon,
-            const double K, const double G, const int influence = 0 )
-    -> ForceModel<ModelType, Elastic, NoFracture>;
-
-template <typename ModelType>
-ForceModel( ModelType, NoFracture, const double force_horizon, const double K,
-            const double G, const int influence = 0 )
-    -> ForceModel<ModelType, Elastic, NoFracture>;
-
-template <typename ModelType>
-ForceModel( ModelType, Elastic, const double force_horizon, const double K,
-            const double G, const double _G0, const int influence = 0,
-            typename std::enable_if<( is_state_based<ModelType>::value ),
-                                    int>::type* = 0 )
-    -> ForceModel<ModelType, Elastic>;
-
-template <typename ModelType>
-ForceModel(
-    ModelType, Elastic, Fracture, const double force_horizon, const double K,
-    const double G, const double _G0, const int influence = 0,
-    typename std::enable_if<( is_state_based<ModelType>::value ), int>::type* =
-        0 ) -> ForceModel<ModelType, Elastic>;
-
-template <typename ModelType>
-ForceModel( ModelType, const double _force_horizon, const double _K,
-            const double _G, const double _G0, const int _influence = 0,
-            typename std::enable_if<( is_state_based<ModelType>::value ),
-                                    int>::type* = 0 ) -> ForceModel<ModelType>;
+MechanicsModel( ModelType, Elastic, const double force_horizon, const double K,
+                const double G, const int _influence = 0 )
+    -> MechanicsModel<ModelType, Elastic>;
 
 } // namespace CabanaPD
 

--- a/src/force_models/CabanaPD_PMB.hpp
+++ b/src/force_models/CabanaPD_PMB.hpp
@@ -21,11 +21,8 @@
 namespace CabanaPD
 {
 
-template <typename MechanicsModelType, typename... DataTypes>
-struct BaseForceModelPMB;
-
 template <>
-struct BaseForceModelPMB<Elastic> : public BaseForceModel
+struct MechanicsModel<PMB, Elastic> : public BaseForceModel
 {
     using base_type = BaseForceModel;
     using mechanics_type = Elastic;
@@ -38,7 +35,7 @@ struct BaseForceModelPMB<Elastic> : public BaseForceModel
     using base_type::K;
     double c;
 
-    BaseForceModelPMB( const double force_horizon, const double _K )
+    MechanicsModel( PMB, const double force_horizon, const double _K )
         : base_type( force_horizon, _K )
     {
         c = 18.0 * K /
@@ -48,7 +45,10 @@ struct BaseForceModelPMB<Elastic> : public BaseForceModel
 
     // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
-    BaseForceModelPMB( const ModelType1& model1, const ModelType2& model2 )
+    MechanicsModel(
+        const ModelType1& model1, const ModelType2& model2,
+        typename std::enable_if_t<is_mechanics_model<ModelType1>::value &&
+                                  is_mechanics_model<ModelType2>::value> = 0 )
         : base_type( model1, model2 )
     {
         c = ( model1.c + model2.c ) / 2.0;
@@ -71,11 +71,15 @@ struct BaseForceModelPMB<Elastic> : public BaseForceModel
     }
 };
 
+template <typename ModelType>
+MechanicsModel( ModelType, const double force_horizon, const double K )
+    -> MechanicsModel<ModelType, Elastic>;
+
 template <typename MemorySpace>
-struct BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>
-    : public BaseForceModelPMB<Elastic>, public BasePlasticity<MemorySpace>
+struct MechanicsModel<PMB, ElasticPerfectlyPlastic, MemorySpace>
+    : public MechanicsModel<PMB, Elastic>, public BasePlasticity<MemorySpace>
 {
-    using base_type = BaseForceModelPMB<Elastic>;
+    using base_type = MechanicsModel<PMB, Elastic>;
     using base_plasticity_type = BasePlasticity<MemorySpace>;
 
     using mechanics_type = ElasticPerfectlyPlastic;
@@ -86,9 +90,10 @@ struct BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>
 
     using base_plasticity_type::updateBonds;
 
-    BaseForceModelPMB( MemorySpace, const double force_horizon, const double K,
-                       const double sigma_y )
-        : base_type( force_horizon, K )
+    MechanicsModel( PMB tag, ElasticPerfectlyPlastic, MemorySpace,
+                    const double force_horizon, const double K,
+                    const double sigma_y )
+        : base_type( tag, force_horizon, K )
         , base_plasticity_type()
         , s_Y( sigma_y / 3.0 / K )
     {
@@ -96,7 +101,7 @@ struct BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>
 
     // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
-    BaseForceModelPMB( const ModelType1& model1, const ModelType2& model2 )
+    MechanicsModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
         , base_plasticity_type()
     {
@@ -147,51 +152,71 @@ struct BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>
 };
 
 template <>
-struct ForceModel<PMB, Elastic, NoFracture, TemperatureIndependent>
-    : public BaseForceModelPMB<Elastic>,
-      BaseNoFractureModel,
-      BaseTemperatureModel<TemperatureIndependent>
+struct MechanicsModel<LinearPMB, Elastic> : public MechanicsModel<LPS, Elastic>
 {
-    using base_type = BaseForceModelPMB<Elastic>;
-    using base_fracture_type = BaseNoFractureModel;
-    using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
+    using base_type = MechanicsModel<LPS, Elastic>;
+    // Tag to dispatch to force iteration.
+    using force_tag = LinearPMB;
 
     using base_type::base_type;
-    using base_type::force_horizon;
     using base_type::operator();
-    using base_fracture_type::operator();
-    using base_temperature_type::operator();
 
-    ForceModel( PMB, NoFracture, const double force_horizon, const double K )
-        : base_type( force_horizon, K )
+    template <typename... Args>
+    MechanicsModel( LinearPMB, Args&&... args )
+        : base_type( typename base_type::model_tag{},
+                     std::forward<Args>( args )... )
+    {
+    }
+};
+
+template <typename ModelType, typename MemorySpace>
+MechanicsModel( ModelType, ElasticPerfectlyPlastic, MemorySpace,
+                const double force_horizon, const double K,
+                const double sigma_y )
+    -> MechanicsModel<ModelType, ElasticPerfectlyPlastic, MemorySpace>;
+
+// Backwards compatibility wrappers.
+template <>
+struct ForceModel<PMB, Elastic, NoFracture>
+    : public Experimental::ForceModel<MechanicsModel<PMB, Elastic>,
+                                      FractureModel<NoFracture>>
+{
+    using base_type = Experimental::ForceModel<MechanicsModel<PMB, Elastic>,
+                                               FractureModel<NoFracture>>;
+    using base_type::operator();
+
+    ForceModel( PMB tag, NoFracture, const double force_horizon,
+                const double K )
+        : base_type( MechanicsModel( tag, force_horizon, K ), FractureModel() )
     {
     }
 
-    ForceModel( PMB, Elastic, NoFracture, const double force_horizon,
-                const double K )
-        : base_type( force_horizon, K )
+    ForceModel( PMB tag, Elastic, NoFracture fracture,
+                const double force_horizon, const double K )
+        : ForceModel( tag, fracture, force_horizon, K )
+    {
+    }
+
+    template <typename ModelType1, typename ModelType2>
+    ForceModel( const ModelType1& model1, const ModelType2& model2 )
+        : base_type( model1, model2 )
     {
     }
 };
 
 template <>
-struct ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
-    : public BaseForceModelPMB<Elastic>,
-      BaseFractureModel,
-      BaseTemperatureModel<TemperatureIndependent>
+struct ForceModel<PMB, Elastic, Fracture>
+    : public Experimental::ForceModel<MechanicsModel<PMB, Elastic>,
+                                      FractureModel<CriticalStretch>>
 {
-    using base_type = BaseForceModelPMB<Elastic>;
-    using base_fracture_type = BaseFractureModel;
-    using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
-
+    using base_type = Experimental::ForceModel<MechanicsModel<PMB, Elastic>,
+                                               FractureModel<CriticalStretch>>;
     using base_type::operator();
-    using base_fracture_type::operator();
-    using base_temperature_type::operator();
 
-    ForceModel( PMB, const double force_horizon, const double K,
+    ForceModel( PMB tag, const double force_horizon, const double K,
                 const double G0, const int influence_type = 1 )
-        : base_type( force_horizon, K )
-        , base_fracture_type( force_horizon, K, G0, influence_type )
+        : base_type( MechanicsModel( tag, force_horizon, K ),
+                     FractureModel( force_horizon, K, G0, influence_type ) )
     {
     }
 
@@ -214,47 +239,40 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureIndependent>
     }
 
     // Constructor to work with plasticity.
-    ForceModel( PMB, Elastic, const double force_horizon, const double K,
+    ForceModel( PMB tag, Elastic, const double force_horizon, const double K,
                 const double G0, const double s0 )
-        : base_type( force_horizon, K )
-        , base_fracture_type( G0, s0 )
+        : base_type( MechanicsModel( tag, force_horizon, K ),
+                     FractureModel( G0, s0 ) )
     {
     }
 
-    // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
     ForceModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
-        , base_fracture_type( model1, model2 )
     {
     }
 };
 
 template <typename MemorySpace>
-struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
-                  TemperatureIndependent, MemorySpace>
-    : public BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>,
-      public BaseFractureModel,
-      public BaseTemperatureModel<TemperatureIndependent>
+struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, MemorySpace>
+    : public Experimental::ForceModel<
+          MechanicsModel<PMB, ElasticPerfectlyPlastic, MemorySpace>,
+          FractureModel<CriticalStretch>>
 {
-    using base_type = BaseForceModelPMB<ElasticPerfectlyPlastic, MemorySpace>;
-    using base_fracture_type = BaseFractureModel;
-    using base_temperature_type = BaseTemperatureModel<TemperatureIndependent>;
-
+    using mechanics_type =
+        MechanicsModel<PMB, ElasticPerfectlyPlastic, MemorySpace>;
+    using fracture_type = FractureModel<CriticalStretch>;
+    using base_type = Experimental::ForceModel<mechanics_type, fracture_type>;
     using base_type::operator();
-    using base_fracture_type::operator();
-    using base_temperature_type::operator();
-    using base_type::updateBonds;
 
-    ForceModel( PMB, ElasticPerfectlyPlastic, MemorySpace space,
+    ForceModel( PMB tag, ElasticPerfectlyPlastic epp, MemorySpace space,
                 const double force_horizon, const double K, const double G0,
                 const double sigma_y )
-        : base_type( space, force_horizon, K, sigma_y )
-        , base_fracture_type(
-              G0,
-              // s0
-              ( 5.0 * G0 / sigma_y / force_horizon + sigma_y / K ) / 6.0 )
-        , base_temperature_type()
+        : base_type(
+              mechanics_type( tag, epp, space, force_horizon, K, sigma_y ),
+              fracture_type(
+                  G0, // G0, s0
+                  ( 5.0 * G0 / sigma_y / force_horizon + sigma_y / K ) / 6.0 ) )
     {
     }
 
@@ -265,11 +283,9 @@ struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture,
     {
     }
 
-    // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
     ForceModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
-        , base_fracture_type( model1, model2 )
     {
     }
 };
@@ -300,65 +316,64 @@ template <typename ModelType, typename MemorySpace>
 ForceModel( ModelType, ElasticPerfectlyPlastic, MemorySpace,
             const double force_horizon, const double K, const double G0,
             const double sigma_y )
-    -> ForceModel<ModelType, ElasticPerfectlyPlastic, Fracture,
-                  TemperatureIndependent, MemorySpace>;
+    -> ForceModel<ModelType, ElasticPerfectlyPlastic, Fracture, MemorySpace>;
 
+/******************************************************************************
+ Temperature-dependent backwards compatibility wrappers.
+******************************************************************************/
 template <typename TemperatureType>
 struct ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
                   TemperatureType>
-    : public BaseForceModelPMB<Elastic>,
-      BaseNoFractureModel,
-      BaseTemperatureModel<TemperatureDependent, TemperatureType>
+    : public Experimental::ThermalForceModel<
+          MechanicsModel<PMB, Elastic>,
+          ThermalModel<TemperatureDependent, TemperatureType>>
 {
-    using base_type = BaseForceModelPMB<Elastic>;
-    using base_temperature_type =
-        BaseTemperatureModel<TemperatureDependent, TemperatureType>;
+    using mechanics_type = MechanicsModel<PMB, Elastic>;
+    using thermal_type = ThermalModel<TemperatureDependent, TemperatureType>;
+    using base_type =
+        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
+    using typename thermal_type::thermal_tag;
 
-    using base_type::operator();
-    using base_temperature_type::operator();
-    using typename base_temperature_type::needs_update;
-
-    ForceModel( PMB, NoFracture, const double _force_horizon, const double _K,
-                const TemperatureType _temp, const double _alpha,
-                const double _temp0 = 0.0 )
-        : base_type( _force_horizon, _K )
-        , base_temperature_type( _temp, _alpha, _temp0 )
+    ForceModel( PMB tag, NoFracture, const double _force_horizon,
+                const double _K, const TemperatureType _temp,
+                const double _alpha, const double _temp0 = 0.0 )
+        : base_type( mechanics_type( tag, _force_horizon, _K ),
+                     thermal_type( _temp, _alpha, _temp0 ) )
     {
     }
 
-    // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
     ForceModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
-        , base_temperature_type( model1, model2 )
     {
     }
 };
 
 template <typename TemperatureType>
 struct ForceModel<PMB, Elastic, Fracture, TemperatureDependent, TemperatureType>
-    : public BaseForceModelPMB<Elastic>, ThermalFractureModel<TemperatureType>
+    : public Experimental::ThermalForceModel<
+          MechanicsModel<PMB, Elastic>,
+          ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>>
 {
-    using base_type = BaseForceModelPMB<Elastic>;
-    using base_temperature_type = ThermalFractureModel<TemperatureType>;
+    using mechanics_type = MechanicsModel<PMB, Elastic>;
+    using thermal_type =
+        ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>;
+    using fracture_type = FractureModel<CriticalStretch>;
+    using base_type =
+        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
 
-    using base_type::operator();
-    using base_temperature_type::operator();
-    using typename base_temperature_type::needs_update;
-
-    ForceModel( PMB, const double _horizon, const double _K, const double _G0,
-                const TemperatureType _temp, const double _alpha,
-                const double _temp0 = 0.0 )
-        : base_type( _horizon, _K )
-        , base_temperature_type( _horizon, _K, _G0, _temp, _alpha, _temp0 )
+    ForceModel( PMB tag, const double _horizon, const double _K,
+                const double _G0, const TemperatureType _temp,
+                const double _alpha, const double _temp0 = 0.0 )
+        : base_type( mechanics_type( tag, _horizon, _K ),
+                     thermal_type( fracture_type( _horizon, _K, _G0 ), _temp,
+                                   _alpha, _temp0 ) )
     {
     }
 
-    // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
     ForceModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
-        , base_temperature_type( model1, model2 )
     {
     }
 };
@@ -366,33 +381,34 @@ struct ForceModel<PMB, Elastic, Fracture, TemperatureDependent, TemperatureType>
 template <typename TemperatureType>
 struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, TemperatureDependent,
                   TemperatureType>
-    : public BaseForceModelPMB<ElasticPerfectlyPlastic,
-                               typename TemperatureType::memory_space>,
-      public ThermalFractureModel<TemperatureType>
+    : public Experimental::ThermalForceModel<
+          MechanicsModel<PMB, ElasticPerfectlyPlastic,
+                         typename TemperatureType::memory_space>,
+          ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>>
 {
-    using base_type = BaseForceModelPMB<ElasticPerfectlyPlastic,
-                                        typename TemperatureType::memory_space>;
-    using base_temperature_type = ThermalFractureModel<TemperatureType>;
+    using mechanics_type =
+        MechanicsModel<PMB, ElasticPerfectlyPlastic,
+                       typename TemperatureType::memory_space>;
+    using thermal_type =
+        ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>;
+    using base_type =
+        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
 
-    using base_type::operator();
-    using base_temperature_type::operator();
-    using typename base_temperature_type::needs_update;
-
-    ForceModel( PMB, ElasticPerfectlyPlastic, const double _horizon,
+    ForceModel( PMB tag, ElasticPerfectlyPlastic epp, const double _horizon,
                 const double _K, const double _G0, const double sigma_y,
                 const TemperatureType _temp, const double _alpha,
                 const double _temp0 = 0.0 )
-        : base_type( typename TemperatureType::memory_space{}, _horizon, _K,
-                     sigma_y )
-        , base_temperature_type( _horizon, _K, _G0, _temp, _alpha, _temp0 )
+        : base_type( mechanics_type( tag, epp,
+                                     typename TemperatureType::memory_space{},
+                                     _horizon, _K, sigma_y ),
+                     thermal_type( FractureModel( _horizon, _K, _G0 ), _temp,
+                                   _alpha, _temp0 ) )
     {
     }
 
-    // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
     ForceModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
-        , base_temperature_type( model1, model2 )
     {
     }
 };
@@ -421,40 +437,101 @@ ForceModel( ModelType, ElasticPerfectlyPlastic, const double horizon,
 
 template <typename TemperatureType>
 struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>
-    : public BaseForceModelPMB<Elastic>,
-      BaseNoFractureModel,
-      BaseTemperatureModel<TemperatureDependent, TemperatureType>,
-      BaseDynamicTemperatureModel
+    : public Experimental::ThermalForceModel<
+          MechanicsModel<PMB, Elastic>,
+          ThermalModel<DynamicTemperature, TemperatureType, NoFracture>>
 {
-    using base_type = BaseForceModelPMB<Elastic>;
-    using base_temperature_type =
-        BaseTemperatureModel<TemperatureDependent, TemperatureType>;
-    using base_heat_transfer_type = BaseDynamicTemperatureModel;
+    using mechanics_type = MechanicsModel<PMB, Elastic>;
+    using thermal_type =
+        ThermalModel<DynamicTemperature, TemperatureType, NoFracture>;
+    using base_type =
+        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
 
-    // Necessary to distinguish between TemperatureDependent
-    using thermal_type = DynamicTemperature;
-
-    using base_type::operator();
-    using base_temperature_type::operator();
-    using typename base_temperature_type::needs_update;
-
-    ForceModel( PMB, NoFracture, const double _horizon, const double _K,
+    ForceModel( PMB tag, NoFracture, const double _horizon, const double _K,
                 const TemperatureType& _temp, const double _kappa,
                 const double _cp, const double _alpha,
                 const double _temp0 = 0.0,
                 const bool _constant_microconductivity = true )
-        : base_type( _horizon, _K )
-        , base_temperature_type( _temp, _alpha, _temp0 )
-        , base_heat_transfer_type( _horizon, _kappa, _cp,
-                                   _constant_microconductivity )
+        : base_type( mechanics_type( tag, _horizon, _K ),
+                     thermal_type( _temp, _kappa, _cp, _alpha, _temp0,
+                                   _constant_microconductivity ) )
     {
     }
 
-    // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
     ForceModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
-        , base_temperature_type( model1, model2 )
+    {
+    }
+};
+
+template <typename ModelType, typename TemperatureType>
+struct ForceModel<ModelType, Elastic, Fracture, DynamicTemperature,
+                  TemperatureType>
+    : public Experimental::ThermalForceModel<
+          MechanicsModel<PMB, Elastic>,
+          ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>>
+{
+    using mechanics_type = MechanicsModel<PMB, Elastic>;
+    using thermal_type =
+        ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>;
+    using base_type =
+        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
+
+    ForceModel( PMB tag, const double _horizon, const double _K,
+                const double _G0, const TemperatureType _temp,
+                const double _kappa, const double _cp, const double _alpha,
+                const double _temp0 = 0.0,
+                const bool _constant_microconductivity = true )
+        : base_type( mechanics_type( tag, _horizon, _K ),
+                     thermal_type( FractureModel( _horizon, _K, _G0 ), _temp,
+                                   _kappa, _cp, _alpha, _temp0,
+                                   _constant_microconductivity ) )
+    {
+    }
+
+    template <typename ModelType1, typename ModelType2>
+    ForceModel( const ModelType1& model1, const ModelType2& model2 )
+        : base_type( model1, model2 )
+    {
+    }
+};
+
+template <typename TemperatureType>
+struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, DynamicTemperature,
+                  TemperatureType>
+    : public Experimental::ThermalForceModel<
+          MechanicsModel<PMB, ElasticPerfectlyPlastic,
+                         typename TemperatureType::memory_space>,
+          ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>>
+
+{
+    using mechanics_type =
+        MechanicsModel<PMB, ElasticPerfectlyPlastic,
+                       typename TemperatureType::memory_space>;
+    using thermal_type =
+        ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>;
+    using base_type =
+        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
+
+    ForceModel( PMB tag, ElasticPerfectlyPlastic epp, const double _horizon,
+                const double _K, const double _G0, const double sigma_y,
+                const TemperatureType _temp, const double _kappa,
+                const double _cp, const double _alpha,
+                const double _temp0 = 0.0,
+                const bool _constant_microconductivity = true )
+        : base_type( mechanics_type( tag, epp,
+                                     typename TemperatureType::memory_space{},
+                                     _horizon, _K, sigma_y ),
+                     thermal_type( FractureModel( _horizon, _K, _G0 ), _temp,
+                                   _kappa, _cp, _alpha, _temp0,
+                                   _constant_microconductivity ) )
+    {
+    }
+
+    template <typename ModelType1, typename ModelType2>
+    ForceModel( const ModelType1& model1, const ModelType2& model2 )
+        : base_type( model1, model2 )
     {
     }
 };
@@ -468,95 +545,12 @@ ForceModel( ModelType, NoFracture, const double horizon, const double K,
                   TemperatureType>;
 
 template <typename ModelType, typename TemperatureType>
-struct ForceModel<ModelType, Elastic, Fracture, DynamicTemperature,
-                  TemperatureType> : public BaseForceModelPMB<Elastic>,
-                                     ThermalFractureModel<TemperatureType>,
-                                     BaseDynamicTemperatureModel
-{
-    using base_type = BaseForceModelPMB<Elastic>;
-    using base_temperature_type = ThermalFractureModel<TemperatureType>;
-    using base_heat_transfer_type = BaseDynamicTemperatureModel;
-
-    // Necessary to distinguish between TemperatureDependent
-    using thermal_type = DynamicTemperature;
-
-    using base_type::operator();
-    using base_temperature_type::operator();
-    using typename base_temperature_type::needs_update;
-
-    ForceModel( PMB, const double _horizon, const double _K, const double _G0,
-                const TemperatureType _temp, const double _kappa,
-                const double _cp, const double _alpha,
-                const double _temp0 = 0.0,
-                const bool _constant_microconductivity = true )
-        : base_type( _horizon, _K )
-        , base_temperature_type( _horizon, _K, _G0, _temp, _alpha, _temp0 )
-        , base_heat_transfer_type( _horizon, _kappa, _cp,
-                                   _constant_microconductivity )
-    {
-    }
-
-    // Constructor to average from existing models.
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-        , base_temperature_type( model1, model2 )
-        , base_heat_transfer_type( model1, model2 )
-    {
-    }
-};
-
-template <typename ModelType, typename TemperatureType>
 ForceModel( ModelType, const double horizon, const double K, const double G0,
             const TemperatureType& temp, const double kappa, const double cp,
             const double alpha, const double temp0 = 0.0,
             const bool constant_microconductivity = true )
     -> ForceModel<ModelType, Elastic, Fracture, DynamicTemperature,
                   TemperatureType>;
-
-template <typename TemperatureType>
-struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, DynamicTemperature,
-                  TemperatureType>
-    : public BaseForceModelPMB<ElasticPerfectlyPlastic,
-                               typename TemperatureType::memory_space>,
-      public ThermalFractureModel<TemperatureType>,
-      BaseDynamicTemperatureModel
-{
-    using base_type = BaseForceModelPMB<ElasticPerfectlyPlastic,
-                                        typename TemperatureType::memory_space>;
-    using base_temperature_type = ThermalFractureModel<TemperatureType>;
-    using base_heat_transfer_type = BaseDynamicTemperatureModel;
-
-    // Necessary to distinguish between TemperatureDependent
-    using thermal_type = DynamicTemperature;
-
-    using base_type::operator();
-    using base_temperature_type::operator();
-    using typename base_temperature_type::needs_update;
-
-    ForceModel( PMB, ElasticPerfectlyPlastic, const double _horizon,
-                const double _K, const double _G0, const double sigma_y,
-                const TemperatureType _temp, const double _kappa,
-                const double _cp, const double _alpha,
-                const double _temp0 = 0.0,
-                const bool _constant_microconductivity = true )
-        : base_type( typename TemperatureType::memory_space{}, _horizon, _K,
-                     sigma_y )
-        , base_temperature_type( _horizon, _K, _G0, _temp, _alpha, _temp0 )
-        , base_heat_transfer_type( _horizon, _kappa, _cp,
-                                   _constant_microconductivity )
-    {
-    }
-
-    // Constructor to average from existing models.
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-        , base_temperature_type( model1, model2 )
-        , base_heat_transfer_type( model1, model2 )
-    {
-    }
-};
 
 template <typename ModelType, typename TemperatureType>
 ForceModel( ModelType, ElasticPerfectlyPlastic, const double horizon,
@@ -579,16 +573,15 @@ struct ForceModel<LinearPMB, MechanicsType, FractureType, ThermalType,
 {
     using base_type = ForceModel<PMB, MechanicsType, FractureType, ThermalType,
                                  FieldTypes...>;
-
     // Tag to dispatch to force iteration.
     using force_tag = LinearPMB;
 
+    using base_type::base_type;
     using base_type::operator();
 
     template <typename... Args>
     ForceModel( LinearPMB, Args... args )
-        : base_type( typename base_type::model_tag{},
-                     std::forward<Args>( args )... )
+        : base_type( typename base_type::model_tag{}, args... )
     {
     }
 };

--- a/src/force_models/CabanaPD_PMB.hpp
+++ b/src/force_models/CabanaPD_PMB.hpp
@@ -35,6 +35,12 @@ struct MechanicsModel<PMB, Elastic> : public BaseForceModel
     using base_type::K;
     double c;
 
+    MechanicsModel( PMB tag, Elastic, const double force_horizon,
+                    const double _K )
+        : MechanicsModel( tag, force_horizon, _K )
+    {
+    }
+
     MechanicsModel( PMB, const double force_horizon, const double _K )
         : base_type( force_horizon, _K )
     {
@@ -45,14 +51,14 @@ struct MechanicsModel<PMB, Elastic> : public BaseForceModel
 
     // Constructor to average from existing models.
     template <typename ModelType1, typename ModelType2>
-    MechanicsModel(
-        const ModelType1& model1, const ModelType2& model2,
-        typename std::enable_if_t<is_mechanics_model<ModelType1>::value &&
-                                  is_mechanics_model<ModelType2>::value> = 0 )
+    MechanicsModel( const ModelType1& model1, const ModelType2& model2 )
         : base_type( model1, model2 )
     {
         c = ( model1.c + model2.c ) / 2.0;
     }
+
+    KOKKOS_FUNCTION
+    int influenceType() const { return 1; }
 
     KOKKOS_INLINE_FUNCTION
     auto operator()( ForceCoeffTag, const int, const int, const double s,
@@ -70,6 +76,10 @@ struct MechanicsModel<PMB, Elastic> : public BaseForceModel
         return 0.25 * c * s * s * xi * vol;
     }
 };
+
+template <typename ModelType>
+MechanicsModel( ModelType, Elastic, const double force_horizon, const double K )
+    -> MechanicsModel<ModelType, Elastic>;
 
 template <typename ModelType>
 MechanicsModel( ModelType, const double force_horizon, const double K )
@@ -152,9 +162,9 @@ struct MechanicsModel<PMB, ElasticPerfectlyPlastic, MemorySpace>
 };
 
 template <>
-struct MechanicsModel<LinearPMB, Elastic> : public MechanicsModel<LPS, Elastic>
+struct MechanicsModel<LinearPMB, Elastic> : public MechanicsModel<PMB, Elastic>
 {
-    using base_type = MechanicsModel<LPS, Elastic>;
+    using base_type = MechanicsModel<PMB, Elastic>;
     // Tag to dispatch to force iteration.
     using force_tag = LinearPMB;
 
@@ -174,417 +184,6 @@ MechanicsModel( ModelType, ElasticPerfectlyPlastic, MemorySpace,
                 const double force_horizon, const double K,
                 const double sigma_y )
     -> MechanicsModel<ModelType, ElasticPerfectlyPlastic, MemorySpace>;
-
-// Backwards compatibility wrappers.
-template <>
-struct ForceModel<PMB, Elastic, NoFracture>
-    : public Experimental::ForceModel<MechanicsModel<PMB, Elastic>,
-                                      FractureModel<NoFracture>>
-{
-    using base_type = Experimental::ForceModel<MechanicsModel<PMB, Elastic>,
-                                               FractureModel<NoFracture>>;
-    using base_type::operator();
-
-    ForceModel( PMB tag, NoFracture, const double force_horizon,
-                const double K )
-        : base_type( MechanicsModel( tag, force_horizon, K ), FractureModel() )
-    {
-    }
-
-    ForceModel( PMB tag, Elastic, NoFracture fracture,
-                const double force_horizon, const double K )
-        : ForceModel( tag, fracture, force_horizon, K )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <>
-struct ForceModel<PMB, Elastic, Fracture>
-    : public Experimental::ForceModel<MechanicsModel<PMB, Elastic>,
-                                      FractureModel<CriticalStretch>>
-{
-    using base_type = Experimental::ForceModel<MechanicsModel<PMB, Elastic>,
-                                               FractureModel<CriticalStretch>>;
-    using base_type::operator();
-
-    ForceModel( PMB tag, const double force_horizon, const double K,
-                const double G0, const int influence_type = 1 )
-        : base_type( MechanicsModel( tag, force_horizon, K ),
-                     FractureModel( force_horizon, K, G0, influence_type ) )
-    {
-    }
-
-    ForceModel( PMB model, Elastic, const double force_horizon, const double K,
-                const double G0, const int influence_type = 1 )
-        : ForceModel( model, force_horizon, K, G0, influence_type )
-    {
-    }
-
-    ForceModel( PMB model, Fracture, const double force_horizon, const double K,
-                const double G0, const int influence_type = 1 )
-        : ForceModel( model, force_horizon, K, G0, influence_type )
-    {
-    }
-
-    ForceModel( PMB model, Elastic, Fracture, const double force_horizon,
-                const double K, const double G0, const int influence_type = 1 )
-        : ForceModel( model, force_horizon, K, G0, influence_type )
-    {
-    }
-
-    // Constructor to work with plasticity.
-    ForceModel( PMB tag, Elastic, const double force_horizon, const double K,
-                const double G0, const double s0 )
-        : base_type( MechanicsModel( tag, force_horizon, K ),
-                     FractureModel( G0, s0 ) )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <typename MemorySpace>
-struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, MemorySpace>
-    : public Experimental::ForceModel<
-          MechanicsModel<PMB, ElasticPerfectlyPlastic, MemorySpace>,
-          FractureModel<CriticalStretch>>
-{
-    using mechanics_type =
-        MechanicsModel<PMB, ElasticPerfectlyPlastic, MemorySpace>;
-    using fracture_type = FractureModel<CriticalStretch>;
-    using base_type = Experimental::ForceModel<mechanics_type, fracture_type>;
-    using base_type::operator();
-
-    ForceModel( PMB tag, ElasticPerfectlyPlastic epp, MemorySpace space,
-                const double force_horizon, const double K, const double G0,
-                const double sigma_y )
-        : base_type(
-              mechanics_type( tag, epp, space, force_horizon, K, sigma_y ),
-              fracture_type(
-                  G0, // G0, s0
-                  ( 5.0 * G0 / sigma_y / force_horizon + sigma_y / K ) / 6.0 ) )
-    {
-    }
-
-    ForceModel( PMB model, ElasticPerfectlyPlastic mechanics, Fracture,
-                MemorySpace space, const double force_horizon, const double K,
-                const double G0, const double sigma_y )
-        : ForceModel( model, mechanics, space, force_horizon, K, G0, sigma_y )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <typename ModelType>
-ForceModel( ModelType, Elastic, NoFracture, const double force_horizon,
-            const double K ) -> ForceModel<ModelType, Elastic, NoFracture>;
-
-template <typename ModelType>
-ForceModel( ModelType, Elastic, Fracture, const double force_horizon,
-            const double K, const double G0 ) -> ForceModel<ModelType, Elastic>;
-
-// Default to fracture.
-template <typename ModelType>
-ForceModel( ModelType, Elastic, const double force_horizon, const double K,
-            const double G0 ) -> ForceModel<ModelType, Elastic>;
-
-template <typename ModelType>
-ForceModel( ModelType, NoFracture, const double force_horizon, const double K )
-    -> ForceModel<ModelType, Elastic, NoFracture>;
-
-// Default to elastic.
-template <typename ModelType>
-ForceModel( ModelType, const double force_horizon, const double K,
-            const double G0 ) -> ForceModel<ModelType>;
-
-template <typename ModelType, typename MemorySpace>
-ForceModel( ModelType, ElasticPerfectlyPlastic, MemorySpace,
-            const double force_horizon, const double K, const double G0,
-            const double sigma_y )
-    -> ForceModel<ModelType, ElasticPerfectlyPlastic, Fracture, MemorySpace>;
-
-/******************************************************************************
- Temperature-dependent backwards compatibility wrappers.
-******************************************************************************/
-template <typename TemperatureType>
-struct ForceModel<PMB, Elastic, NoFracture, TemperatureDependent,
-                  TemperatureType>
-    : public Experimental::ThermalForceModel<
-          MechanicsModel<PMB, Elastic>,
-          ThermalModel<TemperatureDependent, TemperatureType>>
-{
-    using mechanics_type = MechanicsModel<PMB, Elastic>;
-    using thermal_type = ThermalModel<TemperatureDependent, TemperatureType>;
-    using base_type =
-        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
-    using typename thermal_type::thermal_tag;
-
-    ForceModel( PMB tag, NoFracture, const double _force_horizon,
-                const double _K, const TemperatureType _temp,
-                const double _alpha, const double _temp0 = 0.0 )
-        : base_type( mechanics_type( tag, _force_horizon, _K ),
-                     thermal_type( _temp, _alpha, _temp0 ) )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <typename TemperatureType>
-struct ForceModel<PMB, Elastic, Fracture, TemperatureDependent, TemperatureType>
-    : public Experimental::ThermalForceModel<
-          MechanicsModel<PMB, Elastic>,
-          ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>>
-{
-    using mechanics_type = MechanicsModel<PMB, Elastic>;
-    using thermal_type =
-        ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>;
-    using fracture_type = FractureModel<CriticalStretch>;
-    using base_type =
-        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
-
-    ForceModel( PMB tag, const double _horizon, const double _K,
-                const double _G0, const TemperatureType _temp,
-                const double _alpha, const double _temp0 = 0.0 )
-        : base_type( mechanics_type( tag, _horizon, _K ),
-                     thermal_type( fracture_type( _horizon, _K, _G0 ), _temp,
-                                   _alpha, _temp0 ) )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <typename TemperatureType>
-struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, TemperatureDependent,
-                  TemperatureType>
-    : public Experimental::ThermalForceModel<
-          MechanicsModel<PMB, ElasticPerfectlyPlastic,
-                         typename TemperatureType::memory_space>,
-          ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>>
-{
-    using mechanics_type =
-        MechanicsModel<PMB, ElasticPerfectlyPlastic,
-                       typename TemperatureType::memory_space>;
-    using thermal_type =
-        ThermalModel<TemperatureDependent, TemperatureType, CriticalStretch>;
-    using base_type =
-        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
-
-    ForceModel( PMB tag, ElasticPerfectlyPlastic epp, const double _horizon,
-                const double _K, const double _G0, const double sigma_y,
-                const TemperatureType _temp, const double _alpha,
-                const double _temp0 = 0.0 )
-        : base_type( mechanics_type( tag, epp,
-                                     typename TemperatureType::memory_space{},
-                                     _horizon, _K, sigma_y ),
-                     thermal_type( FractureModel( _horizon, _K, _G0 ), _temp,
-                                   _alpha, _temp0 ) )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <typename ModelType, typename TemperatureType>
-ForceModel( ModelType, NoFracture, const double horizon, const double K,
-            const TemperatureType& temp, const double alpha,
-            const double temp0 = 0.0 )
-    -> ForceModel<ModelType, Elastic, NoFracture, TemperatureDependent,
-                  TemperatureType>;
-
-template <typename ModelType, typename TemperatureType>
-ForceModel( ModelType, const double horizon, const double K, const double _G0,
-            const TemperatureType& temp, const double alpha,
-            const double temp0 = 0.0 )
-    -> ForceModel<ModelType, Elastic, Fracture, TemperatureDependent,
-                  TemperatureType>;
-
-template <typename ModelType, typename TemperatureType>
-ForceModel( ModelType, ElasticPerfectlyPlastic, const double horizon,
-            const double K, const double _G0, const double sigma_y,
-            const TemperatureType& temp, const double alpha,
-            const double temp0 = 0.0 )
-    -> ForceModel<ModelType, ElasticPerfectlyPlastic, Fracture,
-                  TemperatureDependent, TemperatureType>;
-
-template <typename TemperatureType>
-struct ForceModel<PMB, Elastic, NoFracture, DynamicTemperature, TemperatureType>
-    : public Experimental::ThermalForceModel<
-          MechanicsModel<PMB, Elastic>,
-          ThermalModel<DynamicTemperature, TemperatureType, NoFracture>>
-{
-    using mechanics_type = MechanicsModel<PMB, Elastic>;
-    using thermal_type =
-        ThermalModel<DynamicTemperature, TemperatureType, NoFracture>;
-    using base_type =
-        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
-
-    ForceModel( PMB tag, NoFracture, const double _horizon, const double _K,
-                const TemperatureType& _temp, const double _kappa,
-                const double _cp, const double _alpha,
-                const double _temp0 = 0.0,
-                const bool _constant_microconductivity = true )
-        : base_type( mechanics_type( tag, _horizon, _K ),
-                     thermal_type( _temp, _kappa, _cp, _alpha, _temp0,
-                                   _constant_microconductivity ) )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <typename ModelType, typename TemperatureType>
-struct ForceModel<ModelType, Elastic, Fracture, DynamicTemperature,
-                  TemperatureType>
-    : public Experimental::ThermalForceModel<
-          MechanicsModel<PMB, Elastic>,
-          ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>>
-{
-    using mechanics_type = MechanicsModel<PMB, Elastic>;
-    using thermal_type =
-        ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>;
-    using base_type =
-        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
-
-    ForceModel( PMB tag, const double _horizon, const double _K,
-                const double _G0, const TemperatureType _temp,
-                const double _kappa, const double _cp, const double _alpha,
-                const double _temp0 = 0.0,
-                const bool _constant_microconductivity = true )
-        : base_type( mechanics_type( tag, _horizon, _K ),
-                     thermal_type( FractureModel( _horizon, _K, _G0 ), _temp,
-                                   _kappa, _cp, _alpha, _temp0,
-                                   _constant_microconductivity ) )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <typename TemperatureType>
-struct ForceModel<PMB, ElasticPerfectlyPlastic, Fracture, DynamicTemperature,
-                  TemperatureType>
-    : public Experimental::ThermalForceModel<
-          MechanicsModel<PMB, ElasticPerfectlyPlastic,
-                         typename TemperatureType::memory_space>,
-          ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>>
-
-{
-    using mechanics_type =
-        MechanicsModel<PMB, ElasticPerfectlyPlastic,
-                       typename TemperatureType::memory_space>;
-    using thermal_type =
-        ThermalModel<DynamicTemperature, TemperatureType, CriticalStretch>;
-    using base_type =
-        Experimental::ThermalForceModel<mechanics_type, thermal_type>;
-
-    ForceModel( PMB tag, ElasticPerfectlyPlastic epp, const double _horizon,
-                const double _K, const double _G0, const double sigma_y,
-                const TemperatureType _temp, const double _kappa,
-                const double _cp, const double _alpha,
-                const double _temp0 = 0.0,
-                const bool _constant_microconductivity = true )
-        : base_type( mechanics_type( tag, epp,
-                                     typename TemperatureType::memory_space{},
-                                     _horizon, _K, sigma_y ),
-                     thermal_type( FractureModel( _horizon, _K, _G0 ), _temp,
-                                   _kappa, _cp, _alpha, _temp0,
-                                   _constant_microconductivity ) )
-    {
-    }
-
-    template <typename ModelType1, typename ModelType2>
-    ForceModel( const ModelType1& model1, const ModelType2& model2 )
-        : base_type( model1, model2 )
-    {
-    }
-};
-
-template <typename ModelType, typename TemperatureType>
-ForceModel( ModelType, NoFracture, const double horizon, const double K,
-            const TemperatureType& temp, const double kappa, const double cp,
-            const double alpha, const double temp0 = 0.0,
-            const bool constant_microconductivity = true )
-    -> ForceModel<ModelType, Elastic, NoFracture, DynamicTemperature,
-                  TemperatureType>;
-
-template <typename ModelType, typename TemperatureType>
-ForceModel( ModelType, const double horizon, const double K, const double G0,
-            const TemperatureType& temp, const double kappa, const double cp,
-            const double alpha, const double temp0 = 0.0,
-            const bool constant_microconductivity = true )
-    -> ForceModel<ModelType, Elastic, Fracture, DynamicTemperature,
-                  TemperatureType>;
-
-template <typename ModelType, typename TemperatureType>
-ForceModel( ModelType, ElasticPerfectlyPlastic, const double horizon,
-            const double K, const double G0, const double sigma_y,
-            const TemperatureType& temp, const double kappa, const double cp,
-            const double alpha, const double temp0 = 0.0,
-            const bool constant_microconductivity = true )
-    -> ForceModel<ModelType, ElasticPerfectlyPlastic, Fracture,
-                  DynamicTemperature, TemperatureType>;
-
-/******************************************************************************
- Linear PMB.
-******************************************************************************/
-template <typename MechanicsType, typename FractureType, typename ThermalType,
-          typename... FieldTypes>
-struct ForceModel<LinearPMB, MechanicsType, FractureType, ThermalType,
-                  FieldTypes...>
-    : public ForceModel<PMB, MechanicsType, FractureType, ThermalType,
-                        FieldTypes...>
-{
-    using base_type = ForceModel<PMB, MechanicsType, FractureType, ThermalType,
-                                 FieldTypes...>;
-    // Tag to dispatch to force iteration.
-    using force_tag = LinearPMB;
-
-    using base_type::base_type;
-    using base_type::operator();
-
-    template <typename... Args>
-    ForceModel( LinearPMB, Args... args )
-        : base_type( typename base_type::model_tag{}, args... )
-    {
-    }
-};
 
 } // namespace CabanaPD
 

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -926,7 +926,7 @@ void testForce( ModelType model, const double dx, const double m,
 {
     using force_tag = typename ModelType::force_tag;
     using model_tag = typename ModelType::model_tag;
-    using fracture_tag = typename ModelType::fracture_type;
+    using fracture_tag = typename ModelType::fracture_tag;
     auto particles = createParticles( model_tag{}, test_tag, dx, inputs.coeff );
 
     // This needs to exactly match the mesh spacing to compare with the single
@@ -1064,6 +1064,7 @@ TEST( TEST_CATEGORY, test_force_pmb_construct )
     particles.domain( box_min, box_max, num_cells, 0 );
     particles.create( TEST_EXECSPACE{} );
     auto temp = particles.sliceTemperature();
+    CabanaPD::ThermalModel thermal_model( temp, alpha, temp0 );
     {
         //  With elastic, without fracture.
         CabanaPD::ForceModel force_model( CabanaPD::PMB{},
@@ -1252,9 +1253,9 @@ TEST( TEST_CATEGORY, test_force_pmb_binary )
     static_assert( std::is_same_v<typename model_type::model_tag,
                                   typename decltype( models )::model_tag> );
     static_assert( std::is_same_v<CabanaPD::NoFracture,
-                                  typename decltype( models )::fracture_type> );
+                                  typename decltype( models )::fracture_tag> );
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
-                                  typename decltype( models )::thermal_type> );
+                                  typename decltype( models )::thermal_tag> );
 
     Inputs<model_type> inputs{ force_horizon, K, 0.1, 1.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
@@ -1284,9 +1285,9 @@ TEST( TEST_CATEGORY, test_force_lps_binary )
     static_assert( std::is_same_v<typename model_type::model_tag,
                                   typename decltype( models )::model_tag> );
     static_assert( std::is_same_v<CabanaPD::Fracture,
-                                  typename decltype( models )::fracture_type> );
+                                  typename decltype( models )::fracture_tag> );
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
-                                  typename decltype( models )::thermal_type> );
+                                  typename decltype( models )::thermal_tag> );
 
     Inputs<model_type> inputs{ force_horizon, K, G, 0.1, 2.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
@@ -1316,9 +1317,9 @@ TEST( TEST_CATEGORY, test_force_pmb_ternary )
     static_assert( std::is_same_v<typename model_type::model_tag,
                                   typename decltype( models )::model_tag> );
     static_assert( std::is_same_v<CabanaPD::NoFracture,
-                                  typename decltype( models )::fracture_type> );
+                                  typename decltype( models )::fracture_tag> );
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
-                                  typename decltype( models )::thermal_type> );
+                                  typename decltype( models )::thermal_tag> );
 
     Inputs<model_type> inputs{ force_horizon, K, 0.1, 1.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
@@ -1349,9 +1350,9 @@ TEST( TEST_CATEGORY, test_force_lps_ternary )
     static_assert( std::is_same_v<typename model_type::model_tag,
                                   typename decltype( models )::model_tag> );
     static_assert( std::is_same_v<CabanaPD::Fracture,
-                                  typename decltype( models )::fracture_type> );
+                                  typename decltype( models )::fracture_tag> );
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
-                                  typename decltype( models )::thermal_type> );
+                                  typename decltype( models )::thermal_tag> );
 
     Inputs<model_type> inputs{ force_horizon, K, G, 0.1, 2.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
@@ -1370,16 +1371,17 @@ TEST( TEST_CATEGORY, test_force_thermal_pmb_multi )
     double alpha = 1.0;
     double temp0 = 1.0;
     using model_type = CabanaPD::PMB;
-    using thermal_type = CabanaPD::DynamicTemperature;
+    using thermal_tag = CabanaPD::DynamicTemperature;
 
     auto particles =
         createParticles( model_type{}, LinearTag{}, dx, 0.1,
-                         CabanaPD::MultiMaterial{}, 2, thermal_type{}, temp0 );
+                         CabanaPD::MultiMaterial{}, 2, thermal_tag{}, temp0 );
     auto temp = particles.sliceTemperature();
 
-    CabanaPD::ForceModel model1( CabanaPD::PMB{}, horizon, K, G0, temp, kappa,
-                                 cp, alpha, temp0 );
-    CabanaPD::ForceModel model2( model1 );
+    CabanaPD::ForceModel model1( CabanaPD::PMB{}, horizon, K, G0, temp, horizon,
+                                 kappa, cp, alpha, temp0 );
+
+    auto model2( model1 );
     auto models = CabanaPD::createMultiForceModel(
         particles, CabanaPD::AverageTag{}, model1, model2 );
 
@@ -1413,9 +1415,9 @@ TEST( TEST_CATEGORY, test_force_pmb_quaternary )
     static_assert( std::is_same_v<typename model_type::model_tag,
                                   typename decltype( models )::model_tag> );
     static_assert( std::is_same_v<CabanaPD::NoFracture,
-                                  typename decltype( models )::fracture_type> );
+                                  typename decltype( models )::fracture_tag> );
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
-                                  typename decltype( models )::thermal_type> );
+                                  typename decltype( models )::thermal_tag> );
 
     Inputs<model_type> inputs{ force_horizon, K, 0.1, 1.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
@@ -1447,9 +1449,9 @@ TEST( TEST_CATEGORY, test_force_lps_quaternary )
     static_assert( std::is_same_v<typename model_type::model_tag,
                                   typename decltype( models )::model_tag> );
     static_assert( std::is_same_v<CabanaPD::Fracture,
-                                  typename decltype( models )::fracture_type> );
+                                  typename decltype( models )::fracture_tag> );
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
-                                  typename decltype( models )::thermal_type> );
+                                  typename decltype( models )::thermal_tag> );
 
     Inputs<model_type> inputs{ force_horizon, K, G, 0.1, 2.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
@@ -1484,8 +1486,8 @@ struct TestModel
 {
     using force_tag = ForceType;
     using model_tag = ModelType;
-    using fracture_type = FractureType;
-    using thermal_type = ThermalType;
+    using fracture_tag = FractureType;
+    using thermal_tag = ThermalType;
 
     int expectedTypeI;
     int expectedTypeJ;
@@ -1538,9 +1540,9 @@ TEST( TEST_CATEGORY, test_forceModelsMulti_binary )
         Cabana::makeParameterPack( model1, model12, model21, model2 ) );
 
     static_assert( std::is_same_v<CabanaPD::Fracture,
-                                  typename decltype( models )::fracture_type> );
+                                  typename decltype( models )::fracture_tag> );
     static_assert( std::is_same_v<CabanaPD::TemperatureDependent,
-                                  typename decltype( models )::thermal_type> );
+                                  typename decltype( models )::thermal_tag> );
 
     models( FirstTestTag{}, 0, 0, parameter[0] );
     models( FirstTestTag{}, 1, 1, parameter[1] );

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -983,8 +983,8 @@ void testForce( ModelType model, const double dx, const double m,
 void testNeighbor( const double dx, const double m, const double force_horizon )
 {
     CabanaPD::PMB model_tag;
-    CabanaPD::ForceModel model( model_tag, CabanaPD::Elastic{},
-                                CabanaPD::NoFracture{}, force_horizon, 1.0 );
+    CabanaPD::MechanicsModel mechanics_model( model_tag, force_horizon, 1.0 );
+    CabanaPD::ForceModel model( mechanics_model );
 
     auto particles = createParticles( model_tag, LinearTag{}, dx, 0.0 );
 
@@ -1005,52 +1005,48 @@ TEST( TEST_CATEGORY, test_neighbor )
     // dx needs to be decreased for increased m: boundary particles are ignored.
     double m = 3;
     double dx = 2.0 / 11.0;
-    double force_horizon = dx * m;
-    testNeighbor( dx, m, force_horizon );
+    double horizon = dx * m;
+    testNeighbor( dx, m, horizon );
 
     m = 6;
     dx = 2.0 / 15.0;
-    force_horizon = dx * m;
-    testNeighbor( dx, m, force_horizon );
+    horizon = dx * m;
+    testNeighbor( dx, m, horizon );
 }
 
 // Test construction of all PMB models.
 TEST( TEST_CATEGORY, test_force_pmb_construct )
 {
-    double force_horizon = 5.0;
+    double horizon = 5.0;
     double K = 1.0;
     double G0 = 100.0;
 
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
     {
-        // With defaults.
-        CabanaPD::ForceModel model( CabanaPD::PMB{}, force_horizon, K, G0 );
+        // With fracture.
+        CabanaPD::MechanicsModel mechanics_model( CabanaPD::PMB{}, horizon, K );
+        CabanaPD::ForceModel model( mechanics_model, fracture_model );
     }
     {
         // With mechanics input.
-        CabanaPD::ForceModel model( CabanaPD::PMB{}, CabanaPD::Elastic{},
-                                    force_horizon, K, G0 );
-    }
-    {
-        // With all inputs.
-        CabanaPD::ForceModel model( CabanaPD::PMB{}, CabanaPD::Elastic{},
-                                    CabanaPD::Fracture{}, force_horizon, K,
-                                    G0 );
+        CabanaPD::MechanicsModel mechanics_model(
+            CabanaPD::PMB{}, CabanaPD::Elastic{}, horizon, K );
+        CabanaPD::ForceModel model( mechanics_model, fracture_model );
     }
     // Without fracture.
     {
-        CabanaPD::ForceModel model( CabanaPD::PMB{}, CabanaPD::Elastic{},
-                                    CabanaPD::NoFracture{}, force_horizon, K );
+        CabanaPD::MechanicsModel mechanics_model( CabanaPD::PMB{}, horizon, K );
+
+        CabanaPD::ForceModel model( mechanics_model );
     }
-    {
-        CabanaPD::ForceModel model( CabanaPD::PMB{}, CabanaPD::NoFracture{},
-                                    force_horizon, K );
-    }
+
     // With EPP (cannot be run without fracture).
     double sigma_y = 10.0;
     {
-        CabanaPD::ForceModel force_model(
+        CabanaPD::MechanicsModel mechanics_model(
             CabanaPD::PMB{}, CabanaPD::ElasticPerfectlyPlastic{},
-            TEST_MEMSPACE{}, force_horizon, K, G0, sigma_y );
+            TEST_MEMSPACE{}, horizon, K, sigma_y );
+        CabanaPD::ForceModel model( mechanics_model, fracture_model );
     }
 
     // With thermomechanics.
@@ -1064,78 +1060,70 @@ TEST( TEST_CATEGORY, test_force_pmb_construct )
     particles.domain( box_min, box_max, num_cells, 0 );
     particles.create( TEST_EXECSPACE{} );
     auto temp = particles.sliceTemperature();
-    CabanaPD::ThermalModel thermal_model( temp, alpha, temp0 );
+
+    CabanaPD::MechanicsModel mechanics_model( CabanaPD::PMB{}, horizon, K );
     {
-        //  With elastic, without fracture.
-        CabanaPD::ForceModel force_model( CabanaPD::PMB{},
-                                          CabanaPD::NoFracture{}, force_horizon,
-                                          K, temp, alpha, temp0 );
+        //  Without fracture.
+        CabanaPD::ThermalModel thermal_model( temp, alpha, temp0 );
+        CabanaPD::ThermalForceModel force_model( mechanics_model,
+                                                 thermal_model );
     }
     {
-        //  With elastic.
-        CabanaPD::ForceModel force_model( CabanaPD::PMB{}, force_horizon, K, G0,
-                                          temp, alpha, temp0 );
-    }
-    {
-        //  With EPP.
-        CabanaPD::ForceModel force_model(
-            CabanaPD::PMB{}, CabanaPD::ElasticPerfectlyPlastic{}, force_horizon,
-            K, G0, sigma_y, temp, alpha, temp0 );
+        //  With fracture.
+        CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+        CabanaPD::ThermalModel thermal_model( fracture_model.criticalStretch(),
+                                              temp, alpha, temp0 );
+        CabanaPD::ThermalForceModel force_model( mechanics_model,
+                                                 thermal_model );
     }
 
     // With heat transfer.
     double kappa = 1.0;
     double cp = 1.0;
     {
-        CabanaPD::ForceModel force_model( CabanaPD::PMB{},
-                                          CabanaPD::NoFracture{}, force_horizon,
-                                          K, temp, kappa, cp, alpha, temp0 );
+        //  Without fracture.
+        CabanaPD::ThermalModel thermal_model( horizon, temp, alpha, kappa, cp,
+                                              temp0 );
+        CabanaPD::ThermalForceModel force_model( mechanics_model,
+                                                 thermal_model );
     }
     {
-        CabanaPD::ForceModel force_model( CabanaPD::PMB{}, force_horizon, K, G0,
-                                          temp, kappa, cp, alpha, temp0 );
-    }
-    {
-        //  With EPP.
-        CabanaPD::ForceModel force_model(
-            CabanaPD::PMB{}, CabanaPD::ElasticPerfectlyPlastic{}, force_horizon,
-            K, G0, sigma_y, temp, kappa, cp, alpha, temp0 );
+        //  With fracture.
+        CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+        CabanaPD::ThermalModel thermal_model( horizon,
+                                              fracture_model.criticalStretch(),
+                                              temp, alpha, kappa, cp, temp0 );
+        CabanaPD::ThermalForceModel force_model( mechanics_model,
+                                                 thermal_model );
     }
 }
 
 // Test construction of all LPS models.
 TEST( TEST_CATEGORY, test_force_lps_construct )
 {
-    double force_horizon = 5.0;
+    double horizon = 5.0;
     double K = 1.0;
     double G = 2.0;
     double G0 = 100.0;
 
     {
-        // LPS with defaults.
-        CabanaPD::ForceModel model( CabanaPD::LPS{}, force_horizon, K, G, G0,
-                                    1 );
+        // LPS without fracture.
+        CabanaPD::MechanicsModel mechanics_model( CabanaPD::LPS{}, horizon, K,
+                                                  G, 1 );
+        CabanaPD::ForceModel model( mechanics_model );
     }
     {
         // LPS with mechanics input.
-        CabanaPD::ForceModel model( CabanaPD::LPS{}, CabanaPD::Elastic{},
-                                    force_horizon, K, G, G0, 1 );
+        CabanaPD::MechanicsModel mechanics_model(
+            CabanaPD::LPS{}, CabanaPD::Elastic{}, horizon, K, G, 1 );
+        CabanaPD::ForceModel model( mechanics_model );
     }
     {
-        // LPS with all inputs.
-        CabanaPD::ForceModel model( CabanaPD::LPS{}, CabanaPD::Elastic{},
-                                    CabanaPD::Fracture{}, force_horizon, K, G,
-                                    G0, 1 );
-    }
-    // LPS without fracture.
-    {
-        CabanaPD::ForceModel model( CabanaPD::LPS{}, CabanaPD::Elastic{},
-                                    CabanaPD::NoFracture{}, force_horizon, K, G,
-                                    1 );
-    }
-    {
-        CabanaPD::ForceModel model( CabanaPD::LPS{}, CabanaPD::NoFracture{},
-                                    force_horizon, K, G, 1 );
+        // LPS with fracture.
+        CabanaPD::MechanicsModel mechanics_model( CabanaPD::LPS{}, horizon, K,
+                                                  G, 1 );
+        CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+        CabanaPD::ForceModel model( mechanics_model, fracture_model );
     }
 }
 
@@ -1144,13 +1132,13 @@ TEST( TEST_CATEGORY, test_force_pmb )
     // dx needs to be decreased for increased m: boundary particles are ignored.
     double m = 3;
     double dx = 2.0 / 11.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel model( model_type{}, CabanaPD::Elastic{},
-                                CabanaPD::NoFracture{}, force_horizon, K );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::ForceModel model( mechanics_model );
 
-    Inputs<model_type> inputs{ force_horizon, K, 0.1, 1.1 };
+    Inputs<model_type> inputs{ horizon, K, 0.1, 1.1 };
     testForce( model, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( model, dx, m, QuadraticTag{}, inputs );
@@ -1159,12 +1147,13 @@ TEST( TEST_CATEGORY, test_force_linear_pmb )
 {
     double m = 3;
     double dx = 2.0 / 11.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
-    CabanaPD::ForceModel model( CabanaPD::LinearPMB{}, CabanaPD::Elastic{},
-                                CabanaPD::NoFracture{}, force_horizon, K );
+    CabanaPD::MechanicsModel mechanics_model( CabanaPD::LinearPMB{},
+                                              CabanaPD::Elastic{}, horizon, K );
+    CabanaPD::ForceModel model( mechanics_model );
 
-    Inputs<CabanaPD::PMB> inputs{ force_horizon, K, 0.1, 1.1 };
+    Inputs<CabanaPD::PMB> inputs{ horizon, K, 0.1, 1.1 };
     testForce( model, dx, m, LinearTag{}, inputs );
 }
 TEST( TEST_CATEGORY, test_force_lps )
@@ -1172,15 +1161,15 @@ TEST( TEST_CATEGORY, test_force_lps )
     double m = 3;
     // Need a larger system than PMB because the boundary region is larger.
     double dx = 2.0 / 15.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     double G = 0.5;
     using model_type = CabanaPD::LPS;
-    CabanaPD::ForceModel model( model_type{}, CabanaPD::Elastic{},
-                                CabanaPD::NoFracture{}, force_horizon, K, G,
-                                1 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, CabanaPD::Elastic{},
+                                              horizon, K, G, 1 );
+    CabanaPD::ForceModel model( mechanics_model );
 
-    Inputs<model_type> inputs{ force_horizon, K, G, 0.1, 2.1 };
+    Inputs<model_type> inputs{ horizon, K, G, 0.1, 2.1 };
     testForce( model, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( model, dx, m, QuadraticTag{}, inputs );
@@ -1189,12 +1178,14 @@ TEST( TEST_CATEGORY, test_force_linear_lps )
 {
     double m = 3;
     double dx = 2.0 / 15.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     double G = 0.5;
-    CabanaPD::ForceModel model( CabanaPD::LinearLPS{}, CabanaPD::NoFracture{},
-                                force_horizon, K, G, 1 );
-    Inputs<CabanaPD::LPS> inputs{ force_horizon, K, G, 0.1, 2.1 };
+    CabanaPD::MechanicsModel mechanics_model( CabanaPD::LinearLPS{}, horizon, K,
+                                              G, 1 );
+    CabanaPD::ForceModel model( mechanics_model );
+
+    Inputs<CabanaPD::LPS> inputs{ horizon, K, G, 0.1, 2.1 };
     testForce( model, dx, m, LinearTag{}, inputs );
 }
 
@@ -1203,14 +1194,16 @@ TEST( TEST_CATEGORY, test_force_pmb_damage )
 {
     double m = 3;
     double dx = 2.0 / 11.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     // Large value to make sure no bonds break.
     double G0 = 1000.0;
     using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel model( model_type{}, force_horizon, K, G0 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::ForceModel model( mechanics_model, fracture_model );
 
-    Inputs<model_type> inputs{ force_horizon, K, 0.1, 1.1 };
+    Inputs<model_type> inputs{ horizon, K, 0.1, 1.1 };
     testForce( model, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( model, dx, m, QuadraticTag{}, inputs );
@@ -1219,14 +1212,16 @@ TEST( TEST_CATEGORY, test_force_lps_damage )
 {
     double m = 3;
     double dx = 2.0 / 15.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     double G = 0.5;
     double G0 = 1000.0;
     using model_type = CabanaPD::LPS;
-    CabanaPD::ForceModel model( model_type{}, force_horizon, K, G, G0, 1 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K, G, 1 );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::ForceModel model( mechanics_model, fracture_model );
 
-    Inputs<model_type> inputs{ force_horizon, K, G, 0.1, 2.1 };
+    Inputs<model_type> inputs{ horizon, K, G, 0.1, 2.1 };
     testForce( model, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( model, dx, m, QuadraticTag{}, inputs );
@@ -1236,11 +1231,11 @@ TEST( TEST_CATEGORY, test_force_pmb_binary )
     // dx needs to be decreased for increased m: boundary particles are ignored.
     double m = 3;
     double dx = 2.0 / 11.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel model1( model_type{}, CabanaPD::Elastic{},
-                                 CabanaPD::NoFracture{}, force_horizon, K );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::ForceModel model1( mechanics_model );
     CabanaPD::ForceModel model2( model1 );
 
     auto particles = createParticles( model_type{}, LinearTag{}, dx, 0.1,
@@ -1257,7 +1252,7 @@ TEST( TEST_CATEGORY, test_force_pmb_binary )
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
                                   typename decltype( models )::thermal_tag> );
 
-    Inputs<model_type> inputs{ force_horizon, K, 0.1, 1.1 };
+    Inputs<model_type> inputs{ horizon, K, 0.1, 1.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( models, dx, m, QuadraticTag{}, inputs );
@@ -1267,13 +1262,15 @@ TEST( TEST_CATEGORY, test_force_lps_binary )
     double m = 3;
     // Need a larger system than PMB because the boundary region is larger.
     double dx = 2.0 / 15.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     double G = 0.5;
     double G0 = 1000.0;
     using model_type = CabanaPD::LPS;
-    CabanaPD::ForceModel model1( model_type{}, force_horizon, K, G, G0, 1 );
-    CabanaPD::ForceModel model2( model_type{}, force_horizon, K, G, G0, 1 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K, G, 1 );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::ForceModel model1( mechanics_model, fracture_model );
+    CabanaPD::ForceModel model2( mechanics_model );
 
     auto particles = createParticles( model_type{}, LinearTag{}, dx, 0.1,
                                       CabanaPD::MultiMaterial{}, 2 );
@@ -1289,7 +1286,7 @@ TEST( TEST_CATEGORY, test_force_lps_binary )
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
                                   typename decltype( models )::thermal_tag> );
 
-    Inputs<model_type> inputs{ force_horizon, K, G, 0.1, 2.1 };
+    Inputs<model_type> inputs{ horizon, K, G, 0.1, 2.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( models, dx, m, QuadraticTag{}, inputs );
@@ -1299,11 +1296,11 @@ TEST( TEST_CATEGORY, test_force_pmb_ternary )
     // dx needs to be decreased for increased m: boundary particles are ignored.
     double m = 3;
     double dx = 2.0 / 11.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel model1( model_type{}, CabanaPD::Elastic{},
-                                 CabanaPD::NoFracture{}, force_horizon, K );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::ForceModel model1( mechanics_model );
     CabanaPD::ForceModel model2( model1 );
     CabanaPD::ForceModel model3( model1 );
 
@@ -1321,7 +1318,7 @@ TEST( TEST_CATEGORY, test_force_pmb_ternary )
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
                                   typename decltype( models )::thermal_tag> );
 
-    Inputs<model_type> inputs{ force_horizon, K, 0.1, 1.1 };
+    Inputs<model_type> inputs{ horizon, K, 0.1, 1.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( models, dx, m, QuadraticTag{}, inputs );
@@ -1331,14 +1328,16 @@ TEST( TEST_CATEGORY, test_force_lps_ternary )
     double m = 3;
     // Need a larger system than PMB because the boundary region is larger.
     double dx = 2.0 / 15.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     double G = 0.5;
     double G0 = 1000.0;
     using model_type = CabanaPD::LPS;
-    CabanaPD::ForceModel model1( model_type{}, force_horizon, K, G, G0, 1 );
-    CabanaPD::ForceModel model2( model_type{}, force_horizon, K, G, G0, 1 );
-    CabanaPD::ForceModel model3( model_type{}, force_horizon, K, G, G0, 1 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K, G, 1 );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::ForceModel model1( mechanics_model, fracture_model );
+    CabanaPD::ForceModel model2( mechanics_model );
+    CabanaPD::ForceModel model3( mechanics_model );
 
     auto particles = createParticles( model_type{}, LinearTag{}, dx, 0.1,
                                       CabanaPD::MultiMaterial{}, 3 );
@@ -1354,7 +1353,7 @@ TEST( TEST_CATEGORY, test_force_lps_ternary )
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
                                   typename decltype( models )::thermal_tag> );
 
-    Inputs<model_type> inputs{ force_horizon, K, G, 0.1, 2.1 };
+    Inputs<model_type> inputs{ horizon, K, G, 0.1, 2.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( models, dx, m, QuadraticTag{}, inputs );
@@ -1365,7 +1364,6 @@ TEST( TEST_CATEGORY, test_force_thermal_pmb_multi )
     double dx = 2.0 / 11.0;
     double horizon = dx * m;
     double K = 1.0;
-    double G0 = 1000.0;
     double kappa = 1.0;
     double cp = 1.0;
     double alpha = 1.0;
@@ -1378,8 +1376,10 @@ TEST( TEST_CATEGORY, test_force_thermal_pmb_multi )
                          CabanaPD::MultiMaterial{}, 2, thermal_tag{}, temp0 );
     auto temp = particles.sliceTemperature();
 
-    CabanaPD::ForceModel model1( CabanaPD::PMB{}, horizon, K, G0, temp, horizon,
-                                 kappa, cp, alpha, temp0 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K );
+    CabanaPD::ThermalModel thermal_model( horizon, temp, alpha, kappa, cp,
+                                          temp0 );
+    CabanaPD::ThermalForceModel model1( mechanics_model, thermal_model );
 
     auto model2( model1 );
     auto models = CabanaPD::createMultiForceModel(
@@ -1396,11 +1396,12 @@ TEST( TEST_CATEGORY, test_force_pmb_quaternary )
     // dx needs to be decreased for increased m: boundary particles are ignored.
     double m = 3;
     double dx = 2.0 / 11.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     using model_type = CabanaPD::PMB;
-    CabanaPD::ForceModel model1( model_type{}, CabanaPD::Elastic{},
-                                 CabanaPD::NoFracture{}, force_horizon, K );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, CabanaPD::Elastic{},
+                                              horizon, K );
+    CabanaPD::ForceModel model1( mechanics_model );
     CabanaPD::ForceModel model2( model1 );
     CabanaPD::ForceModel model3( model1 );
     CabanaPD::ForceModel model4( model1 );
@@ -1419,7 +1420,7 @@ TEST( TEST_CATEGORY, test_force_pmb_quaternary )
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
                                   typename decltype( models )::thermal_tag> );
 
-    Inputs<model_type> inputs{ force_horizon, K, 0.1, 1.1 };
+    Inputs<model_type> inputs{ horizon, K, 0.1, 1.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( models, dx, m, QuadraticTag{}, inputs );
@@ -1429,15 +1430,17 @@ TEST( TEST_CATEGORY, test_force_lps_quaternary )
     double m = 3;
     // Need a larger system than PMB because the boundary region is larger.
     double dx = 2.0 / 15.0;
-    double force_horizon = dx * m;
+    double horizon = dx * m;
     double K = 1.0;
     double G = 0.5;
     double G0 = 1000.0;
     using model_type = CabanaPD::LPS;
-    CabanaPD::ForceModel model1( model_type{}, force_horizon, K, G, G0, 1 );
-    CabanaPD::ForceModel model2( model_type{}, force_horizon, K, G, G0, 1 );
-    CabanaPD::ForceModel model3( model_type{}, force_horizon, K, G, G0, 1 );
-    CabanaPD::ForceModel model4( model_type{}, force_horizon, K, G, G0, 1 );
+    CabanaPD::MechanicsModel mechanics_model( model_type{}, horizon, K, G, 1 );
+    CabanaPD::FractureModel fracture_model( horizon, K, G0 );
+    CabanaPD::ForceModel model1( mechanics_model, fracture_model );
+    CabanaPD::ForceModel model2( mechanics_model, fracture_model );
+    CabanaPD::ForceModel model3( mechanics_model, fracture_model );
+    CabanaPD::ForceModel model4( mechanics_model, fracture_model );
 
     auto particles = createParticles( model_type{}, LinearTag{}, dx, 0.1,
                                       CabanaPD::MultiMaterial{}, 4 );
@@ -1453,7 +1456,7 @@ TEST( TEST_CATEGORY, test_force_lps_quaternary )
     static_assert( std::is_same_v<CabanaPD::TemperatureIndependent,
                                   typename decltype( models )::thermal_tag> );
 
-    Inputs<model_type> inputs{ force_horizon, K, G, 0.1, 2.1 };
+    Inputs<model_type> inputs{ horizon, K, G, 0.1, 2.1 };
     testForce( models, dx, m, LinearTag{}, inputs );
     inputs.update( 0.01 );
     testForce( models, dx, m, QuadraticTag{}, inputs );

--- a/unit_test/tstForce.hpp
+++ b/unit_test/tstForce.hpp
@@ -1070,9 +1070,8 @@ TEST( TEST_CATEGORY, test_force_pmb_construct )
     }
     {
         //  With fracture.
-        CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-        CabanaPD::ThermalModel thermal_model( fracture_model.criticalStretch(),
-                                              temp, alpha, temp0 );
+        const double s0 = CabanaPD::criticalStretch( horizon, K, G0 );
+        CabanaPD::ThermalModel thermal_model( s0, temp, alpha, temp0 );
         CabanaPD::ThermalForceModel force_model( mechanics_model,
                                                  thermal_model );
     }
@@ -1089,10 +1088,9 @@ TEST( TEST_CATEGORY, test_force_pmb_construct )
     }
     {
         //  With fracture.
-        CabanaPD::FractureModel fracture_model( horizon, K, G0 );
-        CabanaPD::ThermalModel thermal_model( horizon,
-                                              fracture_model.criticalStretch(),
-                                              temp, alpha, kappa, cp, temp0 );
+        const double s0 = CabanaPD::criticalStretch( horizon, K, G0 );
+        CabanaPD::ThermalModel thermal_model( horizon, s0, temp, alpha, kappa,
+                                              cp, temp0 );
         CabanaPD::ThermalForceModel force_model( mechanics_model,
                                                  thermal_model );
     }


### PR DESCRIPTION
Separate mechanics, fracture, and thermal models

`ForceModel` uses combinations of `MechanicsModel` and `FractureModel` to run dynamics. `ThermalForceModel` uses combinations of `MechanicsModel`, `FractureModel`, and `ThermalModel`. It is likely not obvious why only certain options are available

- Retain the original models as wrappers around these better separated components
- Renames generic reuse of the `Fracture` tag with `CriticalStretch` since that's actually how we model bond failure

TODO: agree on naming. In particular, I'm not sure I want `Experimental` namespace, but it was a quick easy choice. May be time for a discussion on deprecation timelines of the old models as well