### PR TITLE
Separate output from particle output frequency

### DIFF
--- a/examples/mechanics/dogbone_tensile_test.cpp
+++ b/examples/mechanics/dogbone_tensile_test.cpp
@@ -261,6 +261,8 @@ void dogboneTensileTestExample( const std::string filename )
     //                   Simulation run
     // ====================================================
     solver.init( bc );
+    solver.updateRegion( output_fx, output_fy, output_fz, output_yl,
+                         output_yr );
     solver.run( bc, output_fx, output_fy, output_fz, output_yl, output_yr );
 }
 

--- a/examples/mechanics/inputs/dogbone_tensile_test.json
+++ b/examples/mechanics/inputs/dogbone_tensile_test.json
@@ -15,5 +15,6 @@
     "timestep"               : {"value": 3.0e-7, "unit": "s"},
     "timestep_safety_factor" : {"value": 0.85},
     "output_frequency"       : {"value": 200},
+    "particle_output_frequency"       : {"value": 400},
     "output_reference"       : {"value": false}
 }

--- a/src/CabanaPD_Input.hpp
+++ b/src/CabanaPD_Input.hpp
@@ -99,6 +99,7 @@ class Inputs
         // Number of time steps.
         int num_steps = tf / dt;
         inputs["num_steps"]["value"] = num_steps;
+        setupOutput();
 
         // Output files.
         if ( !inputs.contains( "output_file" ) )
@@ -203,6 +204,15 @@ class Inputs
                      "Units for low_corner and high_corner do not match." );
         if ( inputs["dx"]["unit"] != inputs["high_corner"]["unit"] )
             log_err( std::cout, "Units for dx do not match system units." );
+    }
+
+    void setupOutput()
+    {
+        if ( !inputs.contains( "output_frequency" ) )
+            inputs["output_frequency"]["value"] = inputs["num_steps"]["value"];
+        if ( !inputs.contains( "particle_output_frequency" ) )
+            inputs["particle_output_frequency"]["value"] =
+                inputs["output_frequency"]["value"];
     }
 
     template <class ForceModel>

--- a/src/CabanaPD_OutputProfiles.hpp
+++ b/src/CabanaPD_OutputProfiles.hpp
@@ -120,7 +120,8 @@ class OutputTimeSeries
         double time = inputs["final_time"];
         double dt = inputs["timestep"];
         double freq = inputs["output_frequency"];
-        int output_steps = static_cast<int>( time / dt / freq );
+        // May or may not need an extra index for the initial state.
+        int output_steps = static_cast<int>( time / dt / freq ) + 1;
         // Purposely using zero-init here.
         _profile = profile_type( "time_output", output_steps );
     }

--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -158,6 +158,7 @@ class Solver
 
         num_steps = inputs["num_steps"];
         output_frequency = inputs["output_frequency"];
+        particle_output_frequency = inputs["particle_output_frequency"];
         output_reference = inputs["output_reference"];
 
         // Create integrator.
@@ -484,7 +485,7 @@ class Solver
             computeEnergy( force_model, *force, particles, *neighbor );
             computeStress( force_model, *force, particles, *neighbor );
 
-            particles.output( step / output_frequency, step * dt,
+            particles.output( step / particle_output_frequency, step * dt,
                               output_reference );
 
             // Timer has to be stopped before printing output.
@@ -609,6 +610,7 @@ class Solver
 
     int num_steps;
     int output_frequency;
+    int particle_output_frequency;
     bool output_reference;
     double dt;
     int thermal_subcycle_steps;


### PR DESCRIPTION
Particle output frequency defaults to the main output frequency, but is now separable with a new input. 

Also add indexing fix to enable initial region output - could also be done inside `solver.init()`