### PR TITLE
Initial regression tests for the core library 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,6 +92,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Build CabanaPD
         run: |
+          cmake_opts=( -DCabanaPD_ENABLE_TESTING=ON -DCabanaPD_ENABLE_EXAMPLES=ON )
+          if [[ ${{ matrix.cmake_build_type }} == 'Release' ]]; then
+            cmake_opts+=( -DCabanaPD_ENABLE_REGRESSION_TESTING=ON )
+          fi
           cmake -B build \
             -D CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} \
@@ -100,8 +104,7 @@ jobs:
             -D CMAKE_PREFIX_PATH="$HOME/Cabana" \
             -D MPIEXEC_MAX_NUMPROCS=2 \
             -D MPIEXEC_PREFLAGS="--oversubscribe" \
-            -D CabanaPD_ENABLE_TESTING=ON \
-            -D CabanaPD_ENABLE_EXAMPLES=ON
+            ${cmake_opts[@]}
           cmake --build build --parallel 2
           cmake --install build
       - name: Test CabanaPD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,8 @@ endif()
 ## Unit tests
 ##---------------------------------------------------------------------------##
 option(CabanaPD_ENABLE_TESTING "Build tests" OFF)
-if(CabanaPD_ENABLE_TESTING)
+option(CabanaPD_ENABLE_REGRESSION_TESTING "Build tests" OFF)
+if(CabanaPD_ENABLE_TESTING OR CabanaPD_ENABLE_REGRESSION_TESTING)
   find_package(GTest 1.10 REQUIRED)
   # Workaround for FindGTest module in CMake older than 3.20
   if(TARGET GTest::gtest)
@@ -95,7 +96,11 @@ if(CabanaPD_ENABLE_TESTING)
     message(FATAL_ERROR "bug in GTest find module workaround")
   endif()
   enable_testing()
+endif()
+if(CabanaPD_ENABLE_TESTING)
   add_subdirectory(unit_test)
+endif()
+if(CabanaPD_ENABLE_REGRESSION_TESTING)
   add_subdirectory(regression_test)
 endif()
 

--- a/examples/mechanics/crack_inclusion.cpp
+++ b/examples/mechanics/crack_inclusion.cpp
@@ -170,10 +170,28 @@ void crackInclusionExample( const std::string filename )
                                        true, plane1, plane2 );
 
     // ====================================================
+    //                      Outputs
+    // ====================================================
+    // Output maximum y-extent of the crack.
+    CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
+    auto d = solver.particles.sliceDamage();
+    auto crack_y_func = KOKKOS_LAMBDA( const int p )
+    {
+        // Use a threshold of damage to only output damaged particles.
+        if ( d( p ) > 0.3 )
+            return x( p, 1 );
+        else
+            return 0.0;
+    };
+    auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
+        "output_crack_y.txt", inputs, exec_space{}, solver.particles,
+        crack_y_func, box );
+
+    // ====================================================
     //                   Simulation run
     // ====================================================
     solver.init( bc, prenotch );
-    solver.run( bc );
+    solver.run( bc, output_yl );
 }
 
 // Initialize MPI+Kokkos.

--- a/examples/mechanics/crack_inclusion.cpp
+++ b/examples/mechanics/crack_inclusion.cpp
@@ -184,7 +184,7 @@ void crackInclusionExample( const std::string filename )
             return 0.0;
     };
     auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
-        "output_crack_y.txt", inputs, exec_space{}, solver.particles,
+        "output_incl_crack_y.txt", inputs, exec_space{}, solver.particles,
         crack_y_func, box );
 
     // ====================================================

--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -127,10 +127,28 @@ void kalthoffWinklerExample( const std::string filename )
                                        exec_space{}, solver.particles, plane );
 
     // ====================================================
+    //                      Outputs
+    // ====================================================
+    // Output maximum y-extent of the crack.
+    CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
+    auto d = solver.particles.sliceDamage();
+    auto crack_y_func = KOKKOS_LAMBDA( const int p )
+    {
+        // Use a threshold of damage to only output damaged particles.
+        if ( d( p ) > 0.3 )
+            return x( p, 1 );
+        else
+            return 0.0;
+    };
+    auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
+        "output_kw_crack_y.txt", inputs, exec_space{}, solver.particles,
+        crack_y_func, box );
+
+    // ====================================================
     //                   Simulation run
     // ====================================================
     solver.init( bc, prenotch );
-    solver.run( bc );
+    solver.run( bc, output_yl );
 }
 
 // Initialize MPI+Kokkos.

--- a/regression_test/CMakeLists.txt
+++ b/regression_test/CMakeLists.txt
@@ -5,6 +5,7 @@ include(${PROJECT_SOURCE_DIR}/test_harness/CabanaPD_testing_macros.cmake)
 
 CabanaPD_add_tests(PREFIX RegressionTest NAMES Hertz HertzJKR)
 
+configure_file(inputs/kalthoff_winkler.json kalthoff_winkler.json COPYONLY )
 configure_file(inputs/crack_inclusion.json crack_inclusion.json COPYONLY )
 
-CabanaPD_add_tests(MPI PREFIX RegressionTest NAMES CrackInclusion)
+CabanaPD_add_tests(MPI PREFIX RegressionTest NAMES KalthoffWinkler CrackInclusion)

--- a/regression_test/CMakeLists.txt
+++ b/regression_test/CMakeLists.txt
@@ -5,7 +5,8 @@ include(${PROJECT_SOURCE_DIR}/test_harness/CabanaPD_testing_macros.cmake)
 
 CabanaPD_add_tests(PREFIX RegressionTest NAMES Hertz HertzJKR)
 
+configure_file(inputs/elastic_wave.json elastic_wave.json COPYONLY )
 configure_file(inputs/kalthoff_winkler.json kalthoff_winkler.json COPYONLY )
 configure_file(inputs/crack_inclusion.json crack_inclusion.json COPYONLY )
 
-CabanaPD_add_tests(MPI PREFIX RegressionTest NAMES KalthoffWinkler CrackInclusion)
+CabanaPD_add_tests(MPI PREFIX RegressionTest NAMES ElasticWave KalthoffWinkler CrackInclusion)

--- a/regression_test/CMakeLists.txt
+++ b/regression_test/CMakeLists.txt
@@ -1,14 +1,10 @@
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/inputs/hertzian_contact.json
-  ${CMAKE_CURRENT_BINARY_DIR}/hertzian_contact.json
-  COPYONLY
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/inputs/hertzian_jkr_contact.json
-  ${CMAKE_CURRENT_BINARY_DIR}/hertzian_jkr_contact.json
-  COPYONLY
-)
+configure_file(inputs/hertzian_contact.json hertzian_contact.json COPYONLY)
+configure_file(inputs/hertzian_jkr_contact.json hertzian_jkr_contact.json COPYONLY)
 
 include(${PROJECT_SOURCE_DIR}/test_harness/CabanaPD_testing_macros.cmake)
 
 CabanaPD_add_tests(PREFIX RegressionTest NAMES Hertz HertzJKR)
+
+configure_file(inputs/crack_inclusion.json crack_inclusion.json COPYONLY )
+
+CabanaPD_add_tests(MPI PREFIX RegressionTest NAMES CrackInclusion)

--- a/regression_test/inputs/crack_inclusion.json
+++ b/regression_test/inputs/crack_inclusion.json
@@ -1,0 +1,18 @@
+{
+    "num_cells"              : {"value": [80, 40, 4]},
+    "system_size"            : {"value": [0.04, 0.02, 0.001], "unit": "m"},
+    "inclusion_center"       : {"value": [0.015, 0.0], "unit": "m"},
+    "inclusion_radius"       : {"value": 0.005, "unit": "m"},
+    "density"                : {"value": [2440, 2440], "unit": "kg/m^3"},
+    "elastic_modulus"        : {"value": [72e+9, 144e+9], "unit": "Pa"},
+    "Poisson's_ratio"        : {"value": [0.22, 0.22]},
+    "fracture_energy"        : {"value": [3.8, 38.0], "unit": "J/m^2"},
+    "horizon"                : {"value": 0.001, "unit": "m"},
+    "traction"               : {"value": 2e6, "unit": "Pa"},
+    "final_time"             : {"value": 22.5e-6, "unit": "s"},
+    "timestep"               : {"value": 3.4e-8, "unit": "s"},
+    "timestep_safety_factor" : {"value": 0.85},
+    "output_frequency"       : {"value": 50},
+    "output_reference"       : {"value": true},
+    "output_file"            : {"value": "regression_crack_inclusion.out"}
+}

--- a/regression_test/inputs/elastic_wave.json
+++ b/regression_test/inputs/elastic_wave.json
@@ -1,0 +1,13 @@
+{
+    "num_cells"              : {"value": [41, 41, 41]},
+    "system_size"            : {"value": [1.0, 1.0, 1.0], "unit": ""},
+    "density"                : {"value": 100.0,  "unit": ""},
+    "bulk_modulus"           : {"value": 1.0, "unit": ""},
+    "shear_modulus"          : {"value": 0.5, "unit": ""},
+    "horizon"                : {"value": 0.075, "unit": ""},
+    "final_time"             : {"value": 0.6, "unit": ""},
+    "timestep"               : {"value": 0.01,  "unit": ""},
+    "timestep_safety_factor" : {"value": 0.85},
+    "output_frequency"       : {"value": 20},
+    "output_reference"       : {"value": true}
+}

--- a/regression_test/inputs/kalthoff_winkler.json
+++ b/regression_test/inputs/kalthoff_winkler.json
@@ -1,0 +1,14 @@
+{
+    "num_cells"              : {"value": [75, 151, 7]},
+    "system_size"            : {"value": [0.1, 0.2, 0.009], "unit": "m"},
+    "density"                : {"value": 8000, "unit": "kg/m^3"},
+    "elastic_modulus"        : {"value": 191e+9, "unit": "Pa"},
+    "fracture_energy"        : {"value": 42408, "unit": "J/m^2"},
+    "horizon"                : {"value": 0.002, "unit": "m"},
+    "impactor_velocity"      : {"value": 16, "unit": "m/s"},
+    "final_time"             : {"value": 70e-6, "unit": "s"},
+    "timestep"               : {"value": 1e-7, "unit": "s"},
+    "timestep_safety_factor" : {"value": 0.85},
+    "output_frequency"       : {"value": 50},
+    "output_reference"       : {"value": true}
+}

--- a/regression_test/tstCrackInclusion.hpp
+++ b/regression_test/tstCrackInclusion.hpp
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * Copyright (c) 2022 by Oak Ridge National Laboratory                      *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This outfile is part of CabanaPD. CabanaPD is distributed under a           *
+ * BSD 3-clause license. For the licensing terms see the LICENSE outfile in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <CabanaPD.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace Test
+{
+
+TEST( TEST_CATEGORY, CrackInclusion )
+{
+    std::string outname = "output_incl_crack_y.txt";
+    std::filesystem::remove( outname );
+
+    // Run with smaller system than example/ for regression testing.
+    std::system( "../examples/mechanics/CrackInclusion crack_inclusion.json" );
+
+    // This test is based on checking that the crack actually branches:
+    // If the crack does not correctly branch around the inclusion, then the
+    // final extent is mostly likely to be near 0.0
+    // (This indicates a bug in the multi-material interface)
+    std::ifstream outfile( outname );
+    std::string line;
+    double max_crack_y;
+    while ( std::getline( outfile, line ) )
+    {
+        if ( !line.empty() )
+            max_crack_y = std::stod( line );
+    }
+    outfile.close();
+
+    // Check the maximum crack extent, with a tolerance of dy/10.
+    // This expected result comes from running this case with exactly these
+    // settings: it only tests that new changes do not alter the behavior.
+    EXPECT_NEAR( max_crack_y, 5.75e-3, 5e-5 );
+}
+
+} // end namespace Test

--- a/regression_test/tstCrackInclusion.hpp
+++ b/regression_test/tstCrackInclusion.hpp
@@ -14,6 +14,7 @@
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 
@@ -26,7 +27,9 @@ TEST( TEST_CATEGORY, CrackInclusion )
     std::filesystem::remove( outname );
 
     // Run with smaller system than example/ for regression testing.
-    std::system( "../examples/mechanics/CrackInclusion crack_inclusion.json" );
+    auto sysreturn = std::system(
+        "../examples/mechanics/CrackInclusion crack_inclusion.json" );
+    EXPECT_EQ( sysreturn, 0 );
 
     // This test is based on checking that the crack actually branches:
     // If the crack does not correctly branch around the inclusion, then the

--- a/regression_test/tstCrackInclusion.hpp
+++ b/regression_test/tstCrackInclusion.hpp
@@ -31,6 +31,10 @@ TEST( TEST_CATEGORY, CrackInclusion )
         "../examples/mechanics/CrackInclusion crack_inclusion.json" );
     EXPECT_EQ( sysreturn, 0 );
 
+    // Only need to check on rank zero.
+    if ( !CabanaPD::print_rank() )
+        return;
+
     // This test is based on checking that the crack actually branches:
     // If the crack does not correctly branch around the inclusion, then the
     // final extent is mostly likely to be near 0.0

--- a/regression_test/tstElasticWave.hpp
+++ b/regression_test/tstElasticWave.hpp
@@ -1,0 +1,92 @@
+/****************************************************************************
+ * Copyright (c) 2022 by Oak Ridge National Laboratory                      *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This outfile is part of CabanaPD. CabanaPD is distributed under a           *
+ * BSD 3-clause license. For the licensing terms see the LICENSE outfile in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <CabanaPD.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace Test
+{
+
+auto polyfit( const std::vector<double> c, const double x )
+{
+    double result = 0.0;
+    for ( double i = 0; i < c.size(); ++i )
+    {
+        result = result * x + c[i];
+    }
+    return result;
+}
+
+TEST( TEST_CATEGORY, ElasticWave )
+{
+    // Remove any existing file first.
+    std::string outname = "displacement_profile.txt";
+    std::filesystem::remove( outname );
+
+    // Run with smaller system than example/ for regression testing.
+    std::system( "../examples/mechanics/ElasticWave elastic_wave.json" );
+
+    // Coefficients in descending order.
+    std::vector<double> coeff{
+        1.61854683e+03, 9.92564555e+07, -2.04437979e+03, -1.25377266e+08,
+        1.11872348e+03, 6.80635175e+07, -3.47671366e+02, -2.07030221e+07,
+        6.75838697e+01, 3.85014862e+06, -8.53079823e+00, -4.46939102e+05,
+        7.02713121e-01, 3.15089992e+04, -3.69859638e-02, -1.22783300e+03,
+        1.18185545e-03, 2.00620375e+01, -2.07937472e-05, 4.57208084e-03,
+        1.66083591e-07, 1.32149495e-03, -3.73328058e-10 };
+
+    // This test compares the final state with an externally fit polynomial
+    // using a higher resolution (81 points per dim). The order was chosen to
+    // represent the curve well, except the boundary points. This is extremely
+    // specific to the initial state and the final time.
+    std::ifstream outfile( outname );
+    std::string line;
+    double total_err = 0.0;
+    while ( std::getline( outfile, line ) )
+    {
+        if ( !line.empty() )
+        {
+            // Check the displacement profile in x.
+            std::istringstream ss( line );
+            std::vector<double> values( ( std::istream_iterator<double>( ss ) ),
+                                        std::istream_iterator<double>() );
+
+            const double x = values[1];
+            // Polynomial fit is bad near the ends and near zero there are large
+            // relative errors.
+            if ( x > 0.425 || x < -0.425 || ( x < 0.025 && x > -0.025 ) )
+                continue;
+
+            const double u = values[2];
+            const double u_fit = polyfit( coeff, x );
+            const double diff_err = ( u - u_fit );
+            const double rel_err = std::abs( diff_err / u_fit );
+            // This is a relatively low accuracy check because the polynomial
+            // was fit with a higher resolution run.
+            EXPECT_LT( rel_err, 0.035 );
+            total_err += diff_err * diff_err;
+        }
+    }
+    outfile.close();
+
+    EXPECT_LT( std::sqrt( total_err ), 3e-5 );
+}
+
+} // end namespace Test

--- a/regression_test/tstElasticWave.hpp
+++ b/regression_test/tstElasticWave.hpp
@@ -14,6 +14,7 @@
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -41,7 +42,9 @@ TEST( TEST_CATEGORY, ElasticWave )
     std::filesystem::remove( outname );
 
     // Run with smaller system than example/ for regression testing.
-    std::system( "../examples/mechanics/ElasticWave elastic_wave.json" );
+    auto sysreturn =
+        std::system( "../examples/mechanics/ElasticWave elastic_wave.json" );
+    EXPECT_EQ( sysreturn, 0 );
 
     // Coefficients in descending order.
     std::vector<double> coeff{

--- a/regression_test/tstElasticWave.hpp
+++ b/regression_test/tstElasticWave.hpp
@@ -46,6 +46,10 @@ TEST( TEST_CATEGORY, ElasticWave )
         std::system( "../examples/mechanics/ElasticWave elastic_wave.json" );
     EXPECT_EQ( sysreturn, 0 );
 
+    // Only need to check on rank zero.
+    if ( !CabanaPD::print_rank() )
+        return;
+
     // Coefficients in descending order.
     std::vector<double> coeff{
         1.61854683e+03, 9.92564555e+07, -2.04437979e+03, -1.25377266e+08,

--- a/regression_test/tstKalthoffWinkler.hpp
+++ b/regression_test/tstKalthoffWinkler.hpp
@@ -14,6 +14,7 @@
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 
@@ -27,8 +28,9 @@ TEST( TEST_CATEGORY, KalthoffWinkler )
     std::filesystem::remove( outname );
 
     // Run with smaller system than example/ for regression testing.
-    std::system(
+    auto sysreturn = std::system(
         "../examples/mechanics/KalthoffWinkler kalthoff_winkler.json" );
+    EXPECT_EQ( sysreturn, 0 );
 
     // This test is based on checking that the crack grows at the correct angle.
     std::ifstream outfile( outname );

--- a/regression_test/tstKalthoffWinkler.hpp
+++ b/regression_test/tstKalthoffWinkler.hpp
@@ -32,6 +32,10 @@ TEST( TEST_CATEGORY, KalthoffWinkler )
         "../examples/mechanics/KalthoffWinkler kalthoff_winkler.json" );
     EXPECT_EQ( sysreturn, 0 );
 
+    // Only need to check on rank zero.
+    if ( !CabanaPD::print_rank() )
+        return;
+
     // This test is based on checking that the crack grows at the correct angle.
     std::ifstream outfile( outname );
     std::string line;

--- a/regression_test/tstKalthoffWinkler.hpp
+++ b/regression_test/tstKalthoffWinkler.hpp
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * Copyright (c) 2022 by Oak Ridge National Laboratory                      *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This outfile is part of CabanaPD. CabanaPD is distributed under a           *
+ * BSD 3-clause license. For the licensing terms see the LICENSE outfile in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <CabanaPD.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace Test
+{
+
+TEST( TEST_CATEGORY, KalthoffWinkler )
+{
+    // Remove any existing file first.
+    std::string outname = "output_kw_crack_y.txt";
+    std::filesystem::remove( outname );
+
+    // Run with smaller system than example/ for regression testing.
+    std::system(
+        "../examples/mechanics/KalthoffWinkler kalthoff_winkler.json" );
+
+    // This test is based on checking that the crack grows at the correct angle.
+    std::ifstream outfile( outname );
+    std::string line;
+    double max_crack_y;
+    while ( std::getline( outfile, line ) )
+    {
+        if ( !line.empty() )
+            max_crack_y = std::stod( line );
+    }
+    outfile.close();
+
+    // Check the maximum crack extent, with a tolerance of dy/10.
+    // This expected result comes from running this case with exactly these
+    // settings: it only tests that new changes do not alter the behavior.
+    EXPECT_NEAR( max_crack_y, 7.42e-2, 1.1e-4 );
+}
+
+} // end namespace Test

--- a/src/CabanaPD_OutputProfiles.hpp
+++ b/src/CabanaPD_OutputProfiles.hpp
@@ -12,6 +12,8 @@
 #ifndef DISPLACEMENTPROFILE_H
 #define DISPLACEMENTPROFILE_H
 
+#include <mpi.h>
+
 #include <Kokkos_Core.hpp>
 
 #include <Cabana_Core.hpp>
@@ -92,10 +94,25 @@ void createDisplacementMagnitudeProfile( std::string file_name,
     createOutputProfile( file_name, particles, profile_dim, magnitude );
 }
 
+template <typename T>
+struct MpiReduce;
+
+template <typename Scalar>
+struct MpiReduce<Kokkos::Sum<Scalar>>
+{
+    static MPI_Op type() { return MPI_SUM; }
+};
+
+template <typename Scalar>
+struct MpiReduce<Kokkos::Max<Scalar>>
+{
+    static MPI_Op type() { return MPI_MAX; }
+};
+
 /******************************************************************************
   Scalar time series
 ******************************************************************************/
-template <typename MemorySpace, typename FunctorType>
+template <typename ReduceType, typename MemorySpace, typename FunctorType>
 class OutputTimeSeries
 {
     using memory_space = MemorySpace;
@@ -108,6 +125,8 @@ class OutputTimeSeries
     profile_type _profile;
     FunctorType _output;
     std::size_t index;
+
+    MpiReduce<ReduceType> mpi_op;
 
   public:
     OutputTimeSeries( std::string name, Inputs inputs,
@@ -133,13 +152,14 @@ class OutputTimeSeries
         auto indices = _indices;
         auto output = _output;
         // Reduce into host view.
+        ReduceType reducer( _profile( index ) );
         Kokkos::parallel_reduce(
             "time_series", policy,
             KOKKOS_LAMBDA( const int b, double& px ) {
                 auto p = indices._view( b );
-                px += output( p );
+                reducer.join( px, output( p ) );
             },
-            _profile( index ) );
+            reducer );
         Kokkos::fence();
         index++;
     }
@@ -148,8 +168,9 @@ class OutputTimeSeries
     {
         auto profile_host = Kokkos::create_mirror_view_and_copy(
             Kokkos::HostSpace{}, _profile );
+
         MPI_Allreduce( MPI_IN_PLACE, profile_host.data(), profile_host.size(),
-                       MPI_DOUBLE, MPI_SUM, comm );
+                       MPI_DOUBLE, mpi_op.type(), comm );
         auto num_particles = static_cast<int>( _indices.size() );
         MPI_Allreduce( MPI_IN_PLACE, &num_particles, 1, MPI_INT, MPI_SUM,
                        comm );
@@ -176,7 +197,21 @@ auto createOutputTimeSeries( std::string name, const Inputs inputs,
                              const GeometryType geom )
 {
     ParticleSteeringVector indices( exec_space, particles, geom );
-    return OutputTimeSeries( name, inputs, indices, user );
+    return OutputTimeSeries<Kokkos::Sum<double>,
+                            typename ParticleType::memory_space, FunctorType>(
+        name, inputs, indices, user );
+}
+
+template <typename ReducerType, typename FunctorType, typename ExecSpace,
+          typename ParticleType, typename GeometryType>
+auto createOutputTimeSeries( std::string name, const Inputs inputs,
+                             ExecSpace exec_space,
+                             const ParticleType& particles, FunctorType user,
+                             const GeometryType geom )
+{
+    ParticleSteeringVector indices( exec_space, particles, geom );
+    return OutputTimeSeries<ReducerType, typename ParticleType::memory_space,
+                            FunctorType>( name, inputs, indices, user );
 }
 
 } // namespace CabanaPD


### PR DESCRIPTION
An attempt at simple enough regression tests that they run quickly and easily. This is a difficult balance of system size and accepted error so I would expect to need some iteration here. These problems were chosen as relatively insensitive to discretization (very relative); crack branching for example is extremely sensitive 

- Elastic wave, testing the final displacement profile
- Kalthoff Winkler, testing the final position of the crack tip in y
- Crack inclusion, testing the final position of the crack tip in y
