### PR TITLE
Add time to region output kernels

### DIFF
--- a/examples/mechanics/crack_inclusion.cpp
+++ b/examples/mechanics/crack_inclusion.cpp
@@ -175,7 +175,7 @@ void crackInclusionExample( const std::string filename )
     // Output maximum y-extent of the crack.
     CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
     auto d = solver.particles.sliceDamage();
-    auto crack_y_func = KOKKOS_LAMBDA( const int p )
+    auto crack_y_func = KOKKOS_LAMBDA( const int p, const double )
     {
         // Use a threshold of damage to only output damaged particles.
         if ( d( p ) > 0.3 )

--- a/examples/mechanics/dogbone_tensile_test.cpp
+++ b/examples/mechanics/dogbone_tensile_test.cpp
@@ -264,6 +264,8 @@ void dogboneTensileTestExample( const std::string filename )
     //                   Simulation run
     // ====================================================
     solver.init( bc );
+    solver.updateRegion( 0.0, output_fx, output_fy, output_fz, output_yl,
+                         output_yr );
     solver.run( bc, output_fx, output_fy, output_fz, output_yl, output_yr );
 }
 

--- a/examples/mechanics/dogbone_tensile_test.cpp
+++ b/examples/mechanics/dogbone_tensile_test.cpp
@@ -208,7 +208,7 @@ void dogboneTensileTestExample( const std::string filename )
 
     // Generate force outputs for right grip to compute stress.
     // Output force on right grip in x-direction.
-    auto force_func_x = KOKKOS_LAMBDA( const int p )
+    auto force_func_x = KOKKOS_LAMBDA( const int p, const double )
     {
         return f( p, 0 ) * dx * dy * dz;
     };
@@ -217,7 +217,7 @@ void dogboneTensileTestExample( const std::string filename )
         force_func_x, right_grip );
 
     // Output force on right grip in y-direction.
-    auto force_func_y = KOKKOS_LAMBDA( const int p )
+    auto force_func_y = KOKKOS_LAMBDA( const int p, const double )
     {
         return f( p, 1 ) * dx * dy * dz;
     };
@@ -226,7 +226,7 @@ void dogboneTensileTestExample( const std::string filename )
         force_func_y, right_grip );
 
     // Output force on right grip in z-direction.
-    auto force_func_z = KOKKOS_LAMBDA( const int p )
+    auto force_func_z = KOKKOS_LAMBDA( const int p, const double )
     {
         return f( p, 2 ) * dx * dy * dz;
     };
@@ -236,7 +236,10 @@ void dogboneTensileTestExample( const std::string filename )
 
     // Generate position outputs for gage to compute strain.
     auto y = solver.particles.sliceCurrentPosition();
-    auto pos_func = KOKKOS_LAMBDA( const int p ) { return y( p, 0 ); };
+    auto pos_func = KOKKOS_LAMBDA( const int p, const double )
+    {
+        return y( p, 0 );
+    };
     double dG = 0.1 * G;
 
     // Output x-position of left side of gage.

--- a/examples/mechanics/kalthoff_winkler.cpp
+++ b/examples/mechanics/kalthoff_winkler.cpp
@@ -132,7 +132,7 @@ void kalthoffWinklerExample( const std::string filename )
     // Output maximum y-extent of the crack.
     CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
     auto d = solver.particles.sliceDamage();
-    auto crack_y_func = KOKKOS_LAMBDA( const int p )
+    auto crack_y_func = KOKKOS_LAMBDA( const int p, const double )
     {
         // Use a threshold of damage to only output damaged particles.
         if ( d( p ) > 0.3 )

--- a/src/CabanaPD_OutputProfiles.hpp
+++ b/src/CabanaPD_OutputProfiles.hpp
@@ -144,7 +144,7 @@ class OutputTimeSeries
         _profile = profile_type( "time_output", output_steps );
     }
 
-    void update()
+    void update( const double time )
     {
         Kokkos::RangePolicy<typename memory_space::execution_space> policy(
             0, _indices.size() );
@@ -157,7 +157,7 @@ class OutputTimeSeries
             "time_series", policy,
             KOKKOS_LAMBDA( const int b, double& px ) {
                 auto p = indices._view( b );
-                reducer.join( px, output( p ) );
+                reducer.join( px, output( p, time ) );
             },
             reducer );
         Kokkos::fence();

--- a/src/CabanaPD_OutputProfiles.hpp
+++ b/src/CabanaPD_OutputProfiles.hpp
@@ -140,8 +140,8 @@ class OutputTimeSeries
         double dt = inputs["timestep"];
         double freq = inputs["output_frequency"];
         int output_steps = static_cast<int>( time / dt / freq );
-        // Purposely using zero-init here.
-        _profile = profile_type( "time_output", output_steps );
+        // Purposely using zero-init here. Add space for initial output as well.
+        _profile = profile_type( "time_output", output_steps + 1 );
     }
 
     void update( const double time )

--- a/src/CabanaPD_Solver.hpp
+++ b/src/CabanaPD_Solver.hpp
@@ -415,7 +415,7 @@ class Solver
             runStep( step );
             // FIXME: not included in timing
             if ( step % output_frequency == 0 )
-                updateRegion( region_output... );
+                updateRegion( step * dt, region_output... );
         }
 
         // Final output and timings.
@@ -436,7 +436,7 @@ class Solver
             runStep( step, boundary_condition );
             // FIXME: not included in timing
             if ( step % output_frequency == 0 )
-                updateRegion( region_output... );
+                updateRegion( step * dt, region_output... );
         }
 
         // Final output and timings.
@@ -446,14 +446,15 @@ class Solver
 
     // Iterate over all regions.
     template <typename... RegionType>
-    void updateRegion( RegionType&... region )
+    void updateRegion( [[maybe_unused]] const double time,
+                       RegionType&... region )
     {
-        ( updateRegion( region ), ... );
+        ( updateRegion( time, region ), ... );
     }
     template <typename RegionType>
-    void updateRegion( RegionType& region )
+    void updateRegion( const double time, RegionType& region )
     {
-        region.update();
+        region.update( time );
     }
 
     // Compute and communicate fields needed for force computation and update


### PR DESCRIPTION
This breaks any previous case without time in the functor signature. Not sure if it's worth trying to support backwards compatibility on this (especially since this is for `OutputTimeSeries`)

Closes #294 

Also enables initial output (requires +1 for the size of the output sizes) and demonstrates for the tensile test