### PR TITLE
Add polycrystal example

### DIFF
--- a/examples/mechanics/CMakeLists.txt
+++ b/examples/mechanics/CMakeLists.txt
@@ -22,4 +22,7 @@ target_link_libraries(PlateWithHole LINK_PUBLIC CabanaPD)
 add_executable(CrackInclusion crack_inclusion.cpp)
 target_link_libraries(CrackInclusion LINK_PUBLIC CabanaPD)
 
-install(TARGETS ElasticWave KalthoffWinkler CrackBranching FragmentingCylinder RandomCracks DogboneTensileTest PlateWithHole CrackInclusion DESTINATION ${CMAKE_INSTALL_BINDIR})
+add_executable(Polycrystal polycrystal.cpp)
+target_link_libraries(Polycrystal LINK_PUBLIC CabanaPD)
+
+install(TARGETS ElasticWave KalthoffWinkler CrackBranching FragmentingCylinder RandomCracks DogboneTensileTest PlateWithHole CrackInclusion Polycrystal DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/examples/mechanics/inputs/polycrystal.json
+++ b/examples/mechanics/inputs/polycrystal.json
@@ -10,7 +10,12 @@
     "output_reference"       : {"value": true},
     
     "density"                : {"value": [2440, 2440, 2440, 2440], "unit": "kg/m^3"},
-    "elastic_modulus"        : {"value": [72e+9, 144e+9, 72e+9, 72e+9], "unit": "Pa"},
-    "Poisson's_ratio"        : {"value": [0.22, 0.22, 0.22, 0.22]},
-    "fracture_energy"        : {"value": [3.8, 38.0, 3.8, 3.8], "unit": "J/m^2"}
+
+    "elastic_modulus_within"        : {"value": 72e+9, "unit": "Pa"},
+    "Poisson's_ratio_within"        : {"value": 0.22},
+    "fracture_energy_within"        : {"value": 38.0, "unit": "J/m^2"},
+    
+    "elastic_modulus_between"       : {"value": 72e+9, "unit": "Pa"},
+    "Poisson's_ratio_between"       : {"value": 0.22},
+    "fracture_energy_between"       : {"value": 3.8, "unit": "J/m^2"}
 }

--- a/examples/mechanics/inputs/polycrystal.json
+++ b/examples/mechanics/inputs/polycrystal.json
@@ -1,0 +1,16 @@
+{
+    "num_cells"              : {"value": [400, 160, 8]},
+    "system_size"            : {"value": [0.1, 0.04, 0.002], "unit": "m"},
+    "horizon"                : {"value": 0.001, "unit": "m"},
+    "traction"               : {"value": 2e6, "unit": "Pa"},
+    "final_time"             : {"value": 43e-6, "unit": "s"},
+    "timestep"               : {"value": 4.5e-8, "unit": "s"},
+    "timestep_safety_factor" : {"value": 0.85},
+    "output_frequency"       : {"value": 5},
+    "output_reference"       : {"value": true},
+    
+    "density"                : {"value": [2440, 2440, 2440, 2440], "unit": "kg/m^3"},
+    "elastic_modulus"        : {"value": [72e+9, 144e+9, 72e+9, 72e+9], "unit": "Pa"},
+    "Poisson's_ratio"        : {"value": [0.22, 0.22, 0.22, 0.22]},
+    "fracture_energy"        : {"value": [3.8, 38.0, 3.8, 3.8], "unit": "J/m^2"}
+}

--- a/examples/mechanics/inputs/polycrystal.json
+++ b/examples/mechanics/inputs/polycrystal.json
@@ -2,7 +2,7 @@
     "num_cells"              : {"value": [400, 160, 8]},
     "system_size"            : {"value": [0.1, 0.04, 0.002], "unit": "m"},
     "horizon"                : {"value": 0.001, "unit": "m"},
-    "traction"               : {"value": 2e6, "unit": "Pa"},
+    "traction"               : {"value": 4e6, "unit": "Pa"},
     "final_time"             : {"value": 43e-6, "unit": "s"},
     "timestep"               : {"value": 4.5e-8, "unit": "s"},
     "timestep_safety_factor" : {"value": 0.85},

--- a/examples/mechanics/inputs/polycrystal.json
+++ b/examples/mechanics/inputs/polycrystal.json
@@ -12,5 +12,5 @@
     "density"                : {"value": [2440, 2440, 2440, 2440], "unit": "kg/m^3"},
     "elastic_modulus"        : {"value": [72e+9, 72e+9], "unit": "Pa"},
     "Poisson's_ratio"        : {"value": [0.22, 0.22]},
-    "fracture_energy"        : {"value": [38.0, 3.8], "unit": "J/m^2"},
+    "fracture_energy"        : {"value": [38.0, 3.8], "unit": "J/m^2"}
 }

--- a/examples/mechanics/inputs/polycrystal.json
+++ b/examples/mechanics/inputs/polycrystal.json
@@ -10,12 +10,7 @@
     "output_reference"       : {"value": true},
     
     "density"                : {"value": [2440, 2440, 2440, 2440], "unit": "kg/m^3"},
-
-    "elastic_modulus_within"        : {"value": 72e+9, "unit": "Pa"},
-    "Poisson's_ratio_within"        : {"value": 0.22},
-    "fracture_energy_within"        : {"value": 38.0, "unit": "J/m^2"},
-    
-    "elastic_modulus_between"       : {"value": 72e+9, "unit": "Pa"},
-    "Poisson's_ratio_between"       : {"value": 0.22},
-    "fracture_energy_between"       : {"value": 3.8, "unit": "J/m^2"}
+    "elastic_modulus"        : {"value": [72e+9, 72e+9], "unit": "Pa"},
+    "Poisson's_ratio"        : {"value": [0.22, 0.22]},
+    "fracture_energy"        : {"value": [38.0, 3.8], "unit": "J/m^2"},
 }

--- a/examples/mechanics/inputs/polycrystal.json
+++ b/examples/mechanics/inputs/polycrystal.json
@@ -2,7 +2,7 @@
     "num_cells"              : {"value": [400, 160, 8]},
     "system_size"            : {"value": [0.1, 0.04, 0.002], "unit": "m"},
     "horizon"                : {"value": 0.001, "unit": "m"},
-    "traction"               : {"value": 4e6, "unit": "Pa"},
+    "traction"               : {"value": 8e6, "unit": "Pa"},
     "final_time"             : {"value": 43e-6, "unit": "s"},
     "timestep"               : {"value": 4.5e-8, "unit": "s"},
     "timestep_safety_factor" : {"value": 0.85},

--- a/examples/mechanics/inputs/polycrystal.json
+++ b/examples/mechanics/inputs/polycrystal.json
@@ -1,15 +1,15 @@
 {
-    "num_cells"              : {"value": [400, 160, 8]},
-    "system_size"            : {"value": [0.1, 0.04, 0.002], "unit": "m"},
+    "num_cells"              : {"value": [160, 160, 160]},
+    "system_size"            : {"value": [0.04, 0.04, 0.04], "unit": "m"},
     "horizon"                : {"value": 0.001, "unit": "m"},
     "traction"               : {"value": 8e6, "unit": "Pa"},
     "final_time"             : {"value": 43e-6, "unit": "s"},
     "timestep"               : {"value": 4.5e-8, "unit": "s"},
     "timestep_safety_factor" : {"value": 0.85},
-    "output_frequency"       : {"value": 5},
+    "output_frequency"       : {"value": 30},
     "output_reference"       : {"value": true},
     
-    "density"                : {"value": [2440, 2440, 2440, 2440], "unit": "kg/m^3"},
+    "density"                : {"value": [2440, 2440, 2440, 2440, 2440, 2440, 2440, 2440, 2440, 2440, 2440, 2440, 2440, 2440, 2440, 2440], "unit": "kg/m^3"},
     "elastic_modulus"        : {"value": [72e+9, 72e+9], "unit": "Pa"},
     "Poisson's_ratio"        : {"value": [0.22, 0.22]},
     "fracture_energy"        : {"value": [38.0, 3.8], "unit": "J/m^2"}

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -460,8 +460,8 @@ void polycrystalExample( const std::string filename )
     // ====================================================
     //                   Simulation run
     // ====================================================
-    solver.init( bc, prenotch );
-    solver.run( bc, output_yl );
+    solver.init( bc );
+    solver.run( bc );
 }
 
 // Initialize MPI+Kokkos.

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -291,22 +291,25 @@ void polycrystalExample( const std::string filename )
     // ====================================================
     //                Material parameters
     // ====================================================
-    std::array<double, NUM_GRAINS> grainRho;
-    std::array<double, NUM_GRAINS> E;
-    std::array<double, NUM_GRAINS> nu;
-    std::array<double, NUM_GRAINS> G0;
-    std::array<double, NUM_GRAINS> K;
-    std::array<double, NUM_GRAINS> G;
-
+    Kokkos::Array<double, NUM_GRAINS> grainRho;
     for ( int i = 0; i < NUM_GRAINS; ++i )
     {
         grainRho[i] = inputs["density"][i];
-        E[i] = inputs["elastic_modulus"][i];
-        nu[i] = inputs["Poisson's_ratio"][i];
-        G0[i] = inputs["fracture_energy"][i];
-        K[i] = E[i] / ( 3 * ( 1 - 2 * nu[i] ) );
-        G[i] = E[i] / ( 2 * ( 1 + nu[i] ) );
     }
+
+    // Within-grain parameters
+    double E_within = inputs["elastic_modulus_within"];
+    double nu_within = inputs["Poisson's_ratio_within"];
+    double G0_within = inputs["fracture_energy_within"];
+    double K_within = E_within / ( 3 * ( 1 - 2 * nu_within ) );
+    double G_within = E_within / ( 2 * ( 1 + nu_within ) );
+
+    // Between-grain parameters
+    double E_between = inputs["elastic_modulus_between"];
+    double nu_between = inputs["Poisson's_ratio_between"];
+    double G0_between = inputs["fracture_energy_between"];
+    double K_between = E_between / ( 3 * ( 1 - 2 * nu_between ) );
+    double G_between = E_between / ( 2 * ( 1 + nu_between ) );
 
     double horizon = inputs["horizon"];
     horizon += 1e-10;
@@ -315,15 +318,16 @@ void polycrystalExample( const std::string filename )
     //                Polycrystal grains
     // ====================================================
     std::array<double, 3> extent = inputs["system_size"];
-    std::array<std::array<double, 3>, NUM_GRAINS> grainPos;
-    getPolycrystalGrains( extent, grainPos );
+    std::array<std::array<double, 3>, NUM_GRAINS> grainPosStd;
+    getPolycrystalGrains( extent, grainPosStd );
 
-    // Shift grains relative to low_corner
+    // Shift grains relative to low_corner and copy to Kokkos::Array
+    Kokkos::Array<Kokkos::Array<double, 3>, NUM_GRAINS> grainPos;
     for ( int i = 0; i < NUM_GRAINS; ++i )
     {
-        grainPos[i] = { grainPos[i][0] + low_corner[0],
-                        grainPos[i][1] + low_corner[1],
-                        grainPos[i][2] + low_corner[2] };
+        grainPos[i] = { grainPosStd[i][0] + low_corner[0],
+                        grainPosStd[i][1] + low_corner[1],
+                        grainPosStd[i][2] + low_corner[2] };
     }
 
     // ====================================================
@@ -345,14 +349,10 @@ void polycrystalExample( const std::string filename )
     using model_type = CabanaPD::LPS;
 
     // Grain materials
-    CabanaPD::ForceModel force_models0( model_type{}, horizon, K[0], G[0],
-                                        G0[0] );
-    CabanaPD::ForceModel force_models1( model_type{}, horizon, K[1], G[1],
-                                        G0[1] );
-    CabanaPD::ForceModel force_models2( model_type{}, horizon, K[2], G[2],
-                                        G0[2] );
-    CabanaPD::ForceModel force_models3( model_type{}, horizon, K[3], G[3],
-                                        G0[3] );
+    CabanaPD::ForceModel force_model_within( model_type{}, horizon, K_within, G_within,
+                                             G0_within );
+    CabanaPD::ForceModel force_model_between( model_type{}, horizon, K_between, G_between,
+                                              G0_between );
 
     // ====================================================
     //                 Particle generation
@@ -395,7 +395,7 @@ void polycrystalExample( const std::string filename )
         int grainIndex = 0;
         for ( int i = 0; i < NUM_GRAINS; ++i )
         {
-            const std::array<double, 3>& pos = grainPos[i];
+            const Kokkos::Array<double, 3>& pos = grainPos[i];
             double dx = x( pid, 0 ) - pos[0];
             double dy = x( pid, 1 ) - pos[1];
             double dz = x( pid, 2 ) - pos[2];
@@ -417,8 +417,7 @@ void polycrystalExample( const std::string filename )
     //                   Create solver
     // ====================================================
     auto models = CabanaPD::createMultiForceModel(
-        particles, CabanaPD::AverageTag{}, force_models0, force_models1,
-        force_models2, force_models3 );
+        particles, CabanaPD::AverageTag{}, force_model_within, force_model_between );
     CabanaPD::Solver solver( inputs, particles, models );
 
     // ====================================================

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -325,7 +325,7 @@ void crackPolycrystalExample( const std::string filename )
         grainPos[i] = { grainPos[i][0] + low_corner[0],
                         grainPos[i][1] + low_corner[1],
                         grainPos[i][2] + low_corner[2] };
-        std::cout << grainPos[i][0] << ", " << grainPos[i][1] << ", " grainPos[i][2] << std::endl;
+        std::cout << grainPos[i][0] << ", " << grainPos[i][1] << ", " << grainPos[i][2] << std::endl;
     }
 
     // ====================================================

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -350,9 +350,9 @@ void polycrystalExample( const std::string filename )
     using model_type = CabanaPD::PMB;
 
     // Grain materials
-    CabanaPD::ForceModel force_model_within( model_type{}, horizon, K_within, G_within,
+    CabanaPD::ForceModel force_model_within( model_type{}, horizon, K_within,
                                              G0_within );
-    CabanaPD::ForceModel force_model_between( model_type{}, horizon, K_between, G_between,
+    CabanaPD::ForceModel force_model_between( model_type{}, horizon, K_between,
                                               G0_between );
 
     // ====================================================

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -15,7 +15,7 @@ constexpr double PI = 3.141592653589793238462643383;
 
 // Get flat index into ND array
 template <std::size_t n>
-int indexND( const std::array<int, n>& index, const std::array<int, n>& shape )
+int indexND( const Kokkos::Array<int, n>& index, const Kokkos::Array<int, n>& shape )
 {
     int outIndex = 0;
     int stride = 1;
@@ -31,7 +31,7 @@ int indexND( const std::array<int, n>& index, const std::array<int, n>& shape )
 
 // Check if ND array multi-index is valid
 template <std::size_t n>
-bool isValid( const std::array<int, n>& idx, const std::array<int, n>& shape )
+bool isValid( const Kokkos::Array<int, n>& idx, const Kokkos::Array<int, n>& shape )
 {
     for ( int i = 0; i < n; ++i )
     {
@@ -46,8 +46,8 @@ bool isValid( const std::array<int, n>& idx, const std::array<int, n>& shape )
 // Recursive helper function for makeNeighborRelativeIndices
 template <std::size_t n>
 void makeRelativeIndicesRecursive(
-    int axis, std::array<int, n>& curIndex,
-    std::vector<std::array<int, n>>& outRelativeIndices )
+    int axis, Kokkos::Array<int, n>& curIndex,
+    std::vector<Kokkos::Array<int, n>>& outRelativeIndices )
 {
     int maxDist = std::ceil( std::sqrt( static_cast<double>( n ) ) );
     for ( int i = -maxDist; i <= maxDist; ++i )
@@ -68,15 +68,15 @@ void makeRelativeIndicesRecursive(
 // Get ND array neighbor relative multi-indices
 template <std::size_t n>
 void makeNeighborRelativeIndices(
-    std::vector<std::array<int, n>>& outRelativeIndices )
+    std::vector<Kokkos::Array<int, n>>& outRelativeIndices )
 {
-    std::array<int, n> curIndex = {};
+    Kokkos::Array<int, n> curIndex = {};
     makeRelativeIndicesRecursive( 0, curIndex, outRelativeIndices );
 }
 
 template <std::size_t n>
-double distSquared( const std::array<double, n>& a,
-                    const std::array<double, n>& b )
+double distSquared( const Kokkos::Array<double, n>& a,
+                    const Kokkos::Array<double, n>& b )
 {
     double r2 = 0.0;
     for ( int axis = 0; axis < n; ++axis )
@@ -88,8 +88,8 @@ double distSquared( const std::array<double, n>& a,
 
 // n-dimensional Poisson disc sampling in a rectangular prism domain
 template <std::size_t n, class RNGType>
-void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
-                          std::vector<std::array<double, n>>& outPoints,
+void poissonDiscSampling( const Kokkos::Array<double, n>& extent, double r, int k,
+                          std::vector<Kokkos::Array<double, n>>& outPoints,
                           RNGType& gen )
 {
     // Precompute reused values for sampling
@@ -98,7 +98,7 @@ void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
 
     // Calculate shape of grid
     double cellSize = r / std::sqrt( static_cast<double>( n ) );
-    std::array<int, n> gridShape = {};
+    Kokkos::Array<int, n> gridShape = {};
     int totalCells = 1;
     for ( int axis = 0; axis < n; ++axis )
     {
@@ -113,15 +113,15 @@ void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
     std::vector<int> grid( totalCells, -1 );
 
     // Calculate grid search relative indices
-    std::vector<std::array<int, n>> nbrIndicesRel;
+    std::vector<Kokkos::Array<int, n>> nbrIndicesRel;
     makeNeighborRelativeIndices( nbrIndicesRel );
 
     // Choose first point
     std::uniform_real_distribution<double> coordDist( 0.0, 1.0 );
     auto coordGen = std::bind( coordDist, gen );
 
-    std::array<double, n> x0 = {};
-    std::array<int, n> idx0 = {};
+    Kokkos::Array<double, n> x0 = {};
+    Kokkos::Array<int, n> idx0 = {};
     for ( int axis = 0; axis < n; ++axis )
     {
         x0[axis] = coordGen() * extent[axis];
@@ -139,14 +139,14 @@ void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
         std::uniform_int_distribution<int> pointDist( 0, activeSet.size() - 1 );
         int seedIndexInActive = pointDist( gen );
         int seedIndex = activeSet[seedIndexInActive];
-        std::array<double, n> seedX = outPoints[seedIndex];
+        Kokkos::Array<double, n> seedX = outPoints[seedIndex];
 
         bool addedPoint = false;
 
         for ( int i = 0; i < k; ++i )
         {
-            std::array<double, n> x = {};
-            std::array<int, n> idx = {};
+            Kokkos::Array<double, n> x = {};
+            Kokkos::Array<int, n> idx = {};
 
             // Use inverse method to sample distance from seed
             double xR = std::pow( rn + coordGen() * ( rn2 - rn ),
@@ -172,10 +172,10 @@ void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
             }
 
             // Check if point is too close to any existing points
-            std::array<int, n> checkIdx = idx;
+            Kokkos::Array<int, n> checkIdx = idx;
             bool isClose = false;
 
-            for ( const std::array<int, n>& relIdx : nbrIndicesRel )
+            for ( const Kokkos::Array<int, n>& relIdx : nbrIndicesRel )
             {
                 for ( int axis = 0; axis < n; ++axis )
                 {
@@ -193,7 +193,7 @@ void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
                     continue;
                 }
 
-                const std::array<double, n>& checkX = outPoints[checkPoint];
+                const Kokkos::Array<double, n>& checkX = outPoints[checkPoint];
 
                 if ( distSquared( checkX, x ) > r * r )
                 {
@@ -227,8 +227,8 @@ void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
 // Poisson disc sampling
 template <std::size_t numGrains>
 void getPolycrystalGrains(
-    const std::array<double, 3>& extent,
-    std::array<std::array<double, 3>, numGrains>& outLocations )
+    const Kokkos::Array<double, 3>& extent,
+    Kokkos::Array<Kokkos::Array<double, 3>, numGrains>& outLocations )
 {
     // Initialize RNG
     std::random_device trueRng;
@@ -241,7 +241,7 @@ void getPolycrystalGrains(
     double radius =
         2.0 * std::pow( 0.75 * volume / PI / static_cast<double>( numGrains ),
                         1.0 / 3.0 );
-    std::vector<std::array<double, 3>> testPoints;
+    std::vector<Kokkos::Array<double, 3>> testPoints;
     do
     {
         testPoints.clear();
@@ -276,18 +276,18 @@ void crackPolycrystalExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    std::array<double, 3> low_corner = inputs["low_corner"];
-    std::array<double, 3> high_corner = inputs["high_corner"];
+    Kokkos::Array<double, 3> low_corner = inputs["low_corner"];
+    Kokkos::Array<double, 3> high_corner = inputs["high_corner"];
 
     // ====================================================
     //                Material parameters
     // ====================================================
-    std::array<double, NUM_GRAINS> grainRho;
-    std::array<double, NUM_GRAINS> E;
-    std::array<double, NUM_GRAINS> nu;
-    std::array<double, NUM_GRAINS> G0;
-    std::array<double, NUM_GRAINS> K;
-    std::array<double, NUM_GRAINS> G;
+    Kokkos::Array<double, NUM_GRAINS> grainRho;
+    Kokkos::Array<double, NUM_GRAINS> E;
+    Kokkos::Array<double, NUM_GRAINS> nu;
+    Kokkos::Array<double, NUM_GRAINS> G0;
+    Kokkos::Array<double, NUM_GRAINS> K;
+    Kokkos::Array<double, NUM_GRAINS> G;
 
     for ( int i = 0; i < NUM_GRAINS; ++i )
     {
@@ -305,8 +305,8 @@ void crackPolycrystalExample( const std::string filename )
     // ====================================================
     //                Polycrystal grains
     // ====================================================
-    std::array<double, 3> extent = inputs["system_size"];
-    std::array<std::array<double, 3>, NUM_GRAINS> grainPos;
+    Kokkos::Array<double, 3> extent = inputs["system_size"];
+    Kokkos::Array<Kokkos::Array<double, 3>, NUM_GRAINS> grainPos;
     getPolycrystalGrains( extent, grainPos );
 
     // Shift grains relative to low_corner
@@ -386,7 +386,7 @@ void crackPolycrystalExample( const std::string filename )
         int grainIndex = 0;
         for ( int i = 0; i < NUM_GRAINS; ++i )
         {
-            const std::array<double, 3>& pos = grainPos[i];
+            const Kokkos::Array<double, 3>& pos = grainPos[i];
             double dx = x( pid, 0 ) - pos[0];
             double dy = x( pid, 1 ) - pos[1];
             double dz = x( pid, 2 ) - pos[2];

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -15,7 +15,7 @@ constexpr double PI = 3.141592653589793238462643383;
 
 // Get flat index into ND array
 template <std::size_t n>
-int indexND( const Kokkos::Array<int, n>& index, const Kokkos::Array<int, n>& shape )
+int indexND( const std::array<int, n>& index, const std::array<int, n>& shape )
 {
     int outIndex = 0;
     int stride = 1;
@@ -31,7 +31,7 @@ int indexND( const Kokkos::Array<int, n>& index, const Kokkos::Array<int, n>& sh
 
 // Check if ND array multi-index is valid
 template <std::size_t n>
-bool isValid( const Kokkos::Array<int, n>& idx, const Kokkos::Array<int, n>& shape )
+bool isValid( const std::array<int, n>& idx, const std::array<int, n>& shape )
 {
     for ( int i = 0; i < n; ++i )
     {
@@ -46,8 +46,8 @@ bool isValid( const Kokkos::Array<int, n>& idx, const Kokkos::Array<int, n>& sha
 // Recursive helper function for makeNeighborRelativeIndices
 template <std::size_t n>
 void makeRelativeIndicesRecursive(
-    int axis, Kokkos::Array<int, n>& curIndex,
-    std::vector<Kokkos::Array<int, n>>& outRelativeIndices )
+    int axis, std::array<int, n>& curIndex,
+    std::vector<std::array<int, n>>& outRelativeIndices )
 {
     int maxDist = std::ceil( std::sqrt( static_cast<double>( n ) ) );
     for ( int i = -maxDist; i <= maxDist; ++i )
@@ -68,15 +68,15 @@ void makeRelativeIndicesRecursive(
 // Get ND array neighbor relative multi-indices
 template <std::size_t n>
 void makeNeighborRelativeIndices(
-    std::vector<Kokkos::Array<int, n>>& outRelativeIndices )
+    std::vector<std::array<int, n>>& outRelativeIndices )
 {
-    Kokkos::Array<int, n> curIndex = {};
+    std::array<int, n> curIndex = {};
     makeRelativeIndicesRecursive( 0, curIndex, outRelativeIndices );
 }
 
 template <std::size_t n>
-double distSquared( const Kokkos::Array<double, n>& a,
-                    const Kokkos::Array<double, n>& b )
+double distSquared( const std::array<double, n>& a,
+                    const std::array<double, n>& b )
 {
     double r2 = 0.0;
     for ( int axis = 0; axis < n; ++axis )
@@ -88,8 +88,8 @@ double distSquared( const Kokkos::Array<double, n>& a,
 
 // n-dimensional Poisson disc sampling in a rectangular prism domain
 template <std::size_t n, class RNGType>
-void poissonDiscSampling( const Kokkos::Array<double, n>& extent, double r, int k,
-                          std::vector<Kokkos::Array<double, n>>& outPoints,
+void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
+                          std::vector<std::array<double, n>>& outPoints,
                           RNGType& gen )
 {
     // Precompute reused values for sampling
@@ -98,7 +98,7 @@ void poissonDiscSampling( const Kokkos::Array<double, n>& extent, double r, int 
 
     // Calculate shape of grid
     double cellSize = r / std::sqrt( static_cast<double>( n ) );
-    Kokkos::Array<int, n> gridShape = {};
+    std::array<int, n> gridShape = {};
     int totalCells = 1;
     for ( int axis = 0; axis < n; ++axis )
     {
@@ -113,15 +113,15 @@ void poissonDiscSampling( const Kokkos::Array<double, n>& extent, double r, int 
     std::vector<int> grid( totalCells, -1 );
 
     // Calculate grid search relative indices
-    std::vector<Kokkos::Array<int, n>> nbrIndicesRel;
+    std::vector<std::array<int, n>> nbrIndicesRel;
     makeNeighborRelativeIndices( nbrIndicesRel );
 
     // Choose first point
     std::uniform_real_distribution<double> coordDist( 0.0, 1.0 );
     auto coordGen = std::bind( coordDist, gen );
 
-    Kokkos::Array<double, n> x0 = {};
-    Kokkos::Array<int, n> idx0 = {};
+    std::array<double, n> x0 = {};
+    std::array<int, n> idx0 = {};
     for ( int axis = 0; axis < n; ++axis )
     {
         x0[axis] = coordGen() * extent[axis];
@@ -139,14 +139,14 @@ void poissonDiscSampling( const Kokkos::Array<double, n>& extent, double r, int 
         std::uniform_int_distribution<int> pointDist( 0, activeSet.size() - 1 );
         int seedIndexInActive = pointDist( gen );
         int seedIndex = activeSet[seedIndexInActive];
-        Kokkos::Array<double, n> seedX = outPoints[seedIndex];
+        std::array<double, n> seedX = outPoints[seedIndex];
 
         bool addedPoint = false;
 
         for ( int i = 0; i < k; ++i )
         {
-            Kokkos::Array<double, n> x = {};
-            Kokkos::Array<int, n> idx = {};
+            std::array<double, n> x = {};
+            std::array<int, n> idx = {};
 
             // Use inverse method to sample distance from seed
             double xR = std::pow( rn + coordGen() * ( rn2 - rn ),
@@ -172,10 +172,10 @@ void poissonDiscSampling( const Kokkos::Array<double, n>& extent, double r, int 
             }
 
             // Check if point is too close to any existing points
-            Kokkos::Array<int, n> checkIdx = idx;
+            std::array<int, n> checkIdx = idx;
             bool isClose = false;
 
-            for ( const Kokkos::Array<int, n>& relIdx : nbrIndicesRel )
+            for ( const std::array<int, n>& relIdx : nbrIndicesRel )
             {
                 for ( int axis = 0; axis < n; ++axis )
                 {
@@ -193,7 +193,7 @@ void poissonDiscSampling( const Kokkos::Array<double, n>& extent, double r, int 
                     continue;
                 }
 
-                const Kokkos::Array<double, n>& checkX = outPoints[checkPoint];
+                const std::array<double, n>& checkX = outPoints[checkPoint];
 
                 if ( distSquared( checkX, x ) > r * r )
                 {
@@ -227,8 +227,8 @@ void poissonDiscSampling( const Kokkos::Array<double, n>& extent, double r, int 
 // Poisson disc sampling
 template <std::size_t numGrains>
 void getPolycrystalGrains(
-    const Kokkos::Array<double, 3>& extent,
-    Kokkos::Array<Kokkos::Array<double, 3>, numGrains>& outLocations )
+    const std::array<double, 3>& extent,
+    std::array<std::array<double, 3>, numGrains>& outLocations )
 {
     // Initialize RNG
     std::random_device trueRng;
@@ -241,7 +241,7 @@ void getPolycrystalGrains(
     double radius =
         2.0 * std::pow( 0.75 * volume / PI / static_cast<double>( numGrains ),
                         1.0 / 3.0 );
-    std::vector<Kokkos::Array<double, 3>> testPoints;
+    std::vector<std::array<double, 3>> testPoints;
     do
     {
         testPoints.clear();
@@ -276,18 +276,26 @@ void crackPolycrystalExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    Kokkos::Array<double, 3> low_corner = inputs["low_corner"];
-    Kokkos::Array<double, 3> high_corner = inputs["high_corner"];
+    std::array<double, 3> low_corner = {
+        inputs["low_corner"][0];
+        inputs["low_corner"][1];
+        inputs["low_corner"][2]
+    };
+    std::array<double, 3> high_corner = {
+        inputs["high_corner"][0],
+        inputs["high_corner"][1],
+        inputs["high_corner"][2]
+    };
 
     // ====================================================
     //                Material parameters
     // ====================================================
-    Kokkos::Array<double, NUM_GRAINS> grainRho;
-    Kokkos::Array<double, NUM_GRAINS> E;
-    Kokkos::Array<double, NUM_GRAINS> nu;
-    Kokkos::Array<double, NUM_GRAINS> G0;
-    Kokkos::Array<double, NUM_GRAINS> K;
-    Kokkos::Array<double, NUM_GRAINS> G;
+    std::array<double, NUM_GRAINS> grainRho;
+    std::array<double, NUM_GRAINS> E;
+    std::array<double, NUM_GRAINS> nu;
+    std::array<double, NUM_GRAINS> G0;
+    std::array<double, NUM_GRAINS> K;
+    std::array<double, NUM_GRAINS> G;
 
     for ( int i = 0; i < NUM_GRAINS; ++i )
     {
@@ -305,8 +313,8 @@ void crackPolycrystalExample( const std::string filename )
     // ====================================================
     //                Polycrystal grains
     // ====================================================
-    Kokkos::Array<double, 3> extent = inputs["system_size"];
-    Kokkos::Array<Kokkos::Array<double, 3>, NUM_GRAINS> grainPos;
+    std::array<double, 3> extent = inputs["system_size"];
+    std::array<std::array<double, 3>, NUM_GRAINS> grainPos;
     getPolycrystalGrains( extent, grainPos );
 
     // Shift grains relative to low_corner
@@ -386,7 +394,7 @@ void crackPolycrystalExample( const std::string filename )
         int grainIndex = 0;
         for ( int i = 0; i < NUM_GRAINS; ++i )
         {
-            const Kokkos::Array<double, 3>& pos = grainPos[i];
+            const std::array<double, 3>& pos = grainPos[i];
             double dx = x( pid, 0 ) - pos[0];
             double dy = x( pid, 1 ) - pos[1];
             double dz = x( pid, 2 ) - pos[2];

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -331,7 +331,7 @@ void polycrystalExample( const std::string filename )
     // ====================================================
     using model_type = CabanaPD::PMB;
 
-    // Grain materials
+    // Grain force models
     CabanaPD::ForceModel force_model_within( model_type{}, horizon, K_within,
                                              G0_within );
     CabanaPD::ForceModel force_model_between( model_type{}, horizon, K_between,

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -318,11 +318,13 @@ void crackPolycrystalExample( const std::string filename )
     getPolycrystalGrains( extent, grainPos );
 
     // Shift grains relative to low_corner
+    std::cout << "Generated " << NUM_GRAINS << " polycrystal grains" << std::endl;
     for ( int i = 0; i < NUM_GRAINS; ++i )
     {
         grainPos[i] = { grainPos[i][0] + low_corner[0],
                         grainPos[i][1] + low_corner[1],
                         grainPos[i][2] + low_corner[2] };
+        std::cout << grainPos[i][0] << ", " << grainPos[i][1] << ", " grainPos[i][2] << std::endl;
     }
 
     // ====================================================

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -347,7 +347,7 @@ void polycrystalExample( const std::string filename )
     // ====================================================
     //                   Force models
     // ====================================================
-    using model_type = CabanaPD::LPS;
+    using model_type = CabanaPD::PMB;
 
     // Grain materials
     CabanaPD::ForceModel force_model_within( model_type{}, horizon, K_within, G_within,

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -13,6 +13,7 @@
 constexpr std::size_t NUM_GRAINS = 4;
 constexpr double PI = 3.141592653589793238462643383;
 
+// Get flat index into ND array
 template <std::size_t n>
 int indexND( const std::array<int, n>& index, const std::array<int, n>& shape )
 {
@@ -28,6 +29,7 @@ int indexND( const std::array<int, n>& index, const std::array<int, n>& shape )
     return outIndex;
 }
 
+// Check if ND array multi-index is valid
 template <std::size_t n>
 bool isValid( const std::array<int, n>& idx, const std::array<int, n>& shape )
 {
@@ -41,6 +43,7 @@ bool isValid( const std::array<int, n>& idx, const std::array<int, n>& shape )
     return true;
 }
 
+// Recursive helper function for makeNeighborRelativeIndices
 template <std::size_t n>
 void makeRelativeIndicesRecursive(
     int axis, std::array<int, n>& curIndex,
@@ -62,6 +65,7 @@ void makeRelativeIndicesRecursive(
     }
 }
 
+// Get ND array neighbor relative multi-indices
 template <std::size_t n>
 void makeNeighborRelativeIndices(
     std::vector<std::array<int, n>>& outRelativeIndices )
@@ -82,12 +86,13 @@ double distSquared( const std::array<double, n>& a,
     return r2;
 }
 
+// n-dimensional Poisson disc sampling in a rectangular prism domain
 template <std::size_t n, class RNGType>
 void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
                           std::vector<std::array<double, n>>& outPoints,
                           RNGType& gen )
 {
-    // Dimension of problem
+    // Precompute reused values for sampling
     double rn = std::pow( r, static_cast<double>( n ) );
     double rn2 = std::pow( 2.0 * r, static_cast<double>( n ) );
 
@@ -199,7 +204,7 @@ void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
                 break;
             }
 
-            // Use inverse method to sample distance from see
+            // New point is not too close to any existing, so add it
             if ( !isClose )
             {
                 outPoints.push_back( x );
@@ -218,6 +223,8 @@ void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
     }
 }
 
+// Generates numGrains random polycrystal grain centers using
+// Poisson disc sampling
 template <std::size_t numGrains>
 void getPolycrystalGrains(
     const std::array<double, 3>& extent,
@@ -252,8 +259,8 @@ void getPolycrystalGrains(
     }
 }
 
-// Simulate a crack interacting with an inclusion.
-void crackInclusionExample( const std::string filename )
+// Simulate a crack in a polycrystal
+void crackPolycrystalExample( const std::string filename )
 {
     // ====================================================
     //               Choose Kokkos spaces
@@ -438,7 +445,7 @@ void crackInclusionExample( const std::string filename )
             return 0.0;
     };
     auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
-        "output_incl_crack_y.txt", inputs, exec_space{}, solver.particles,
+        "output_polycrystal_crack_y.txt", inputs, exec_space{}, solver.particles,
         crack_y_func, box );
 
     // ====================================================

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -1,8 +1,8 @@
-#include <fstream>
-#include <iostream>
 #include <cmath>
-#include <random>
+#include <fstream>
 #include <functional>
+#include <iostream>
+#include <random>
 
 #include "mpi.h"
 
@@ -13,13 +13,13 @@
 constexpr std::size_t NUM_GRAINS = 4;
 constexpr double PI = 3.141592653589793238462643383;
 
-template<std::size_t n>
-int indexND(const std::array<int, n>& index, const std::array<int, n>& shape)
+template <std::size_t n>
+int indexND( const std::array<int, n>& index, const std::array<int, n>& shape )
 {
     int outIndex = 0;
     int stride = 1;
-    
-    for(int axis = n - 1; axis >= 0; --axis)
+
+    for ( int axis = n - 1; axis >= 0; --axis )
     {
         outIndex += index[axis] * stride;
         stride *= shape[axis];
@@ -28,12 +28,12 @@ int indexND(const std::array<int, n>& index, const std::array<int, n>& shape)
     return outIndex;
 }
 
-template<std::size_t n>
-bool isValid(const std::array<int, n>& idx, const std::array<int, n>& shape)
+template <std::size_t n>
+bool isValid( const std::array<int, n>& idx, const std::array<int, n>& shape )
 {
-    for(int i = 0; i < n; ++i)
+    for ( int i = 0; i < n; ++i )
     {
-        if(idx[i] < 0 || idx[i] >= shape[i])
+        if ( idx[i] < 0 || idx[i] >= shape[i] )
         {
             return false;
         }
@@ -41,127 +41,127 @@ bool isValid(const std::array<int, n>& idx, const std::array<int, n>& shape)
     return true;
 }
 
-template<std::size_t n>
+template <std::size_t n>
 void makeRelativeIndicesRecursive(
-    int axis,
-    std::array<int, n>& curIndex,
-    std::vector<std::array<int, n>>& outRelativeIndices
-)
+    int axis, std::array<int, n>& curIndex,
+    std::vector<std::array<int, n>>& outRelativeIndices )
 {
-    int maxDist = std::ceil(std::sqrt(static_cast<double>(n)));
-    for(int i = -maxDist; i <= maxDist; ++i)
+    int maxDist = std::ceil( std::sqrt( static_cast<double>( n ) ) );
+    for ( int i = -maxDist; i <= maxDist; ++i )
     {
         curIndex[axis] = i;
-        if(axis < n - 1)
+        if ( axis < n - 1 )
         {
-            makeRelativeIndicesRecursive(axis + 1, curIndex, outRelativeIndices);
+            makeRelativeIndicesRecursive( axis + 1, curIndex,
+                                          outRelativeIndices );
         }
         else
         {
-            outRelativeIndices.push_back(curIndex);
+            outRelativeIndices.push_back( curIndex );
         }
     }
 }
 
-template<std::size_t n>
-void makeNeighborRelativeIndices(std::vector<std::array<int, n>>& outRelativeIndices)
+template <std::size_t n>
+void makeNeighborRelativeIndices(
+    std::vector<std::array<int, n>>& outRelativeIndices )
 {
     std::array<int, n> curIndex = {};
-    makeRelativeIndicesRecursive(0, curIndex, outRelativeIndices);
+    makeRelativeIndicesRecursive( 0, curIndex, outRelativeIndices );
 }
 
-template<std::size_t n>
-double distSquared(const std::array<double, n>& a, const std::array<double, n>& b)
+template <std::size_t n>
+double distSquared( const std::array<double, n>& a,
+                    const std::array<double, n>& b )
 {
     double r2 = 0.0;
-    for(int axis = 0; axis < n; ++axis)
+    for ( int axis = 0; axis < n; ++axis )
     {
-        r2 += (a[axis] - b[axis]) * (a[axis] - b[axis]);
+        r2 += ( a[axis] - b[axis] ) * ( a[axis] - b[axis] );
     }
     return r2;
 }
 
-template<std::size_t n, class RNGType>
-void poissonDiscSampling(
-    const std::array<double, n>& extent,
-    double r,
-    int k,
-    std::vector<std::array<double, n>>& outPoints,
-    RNGType& gen
-)
+template <std::size_t n, class RNGType>
+void poissonDiscSampling( const std::array<double, n>& extent, double r, int k,
+                          std::vector<std::array<double, n>>& outPoints,
+                          RNGType& gen )
 {
     // Dimension of problem
-    double rn = std::pow(r, static_cast<double>(n));
-    double rn2 = std::pow(2.0 * r, static_cast<double>(n));
+    double rn = std::pow( r, static_cast<double>( n ) );
+    double rn2 = std::pow( 2.0 * r, static_cast<double>( n ) );
 
     // Calculate shape of grid
-    double cellSize = r / std::sqrt(static_cast<double>(n));
+    double cellSize = r / std::sqrt( static_cast<double>( n ) );
     std::array<int, n> gridShape = {};
     int totalCells = 1;
-    for(int axis = 0; axis < n; ++axis)
+    for ( int axis = 0; axis < n; ++axis )
     {
-        double axisCells = std::ceil(extent[axis] / cellSize);
-        
+        double axisCells = std::ceil( extent[axis] / cellSize );
+
         // Add an extra cell in each direction just in case
-        gridShape[axis] = 1 + static_cast<int>(axisCells);
+        gridShape[axis] = 1 + static_cast<int>( axisCells );
         totalCells *= gridShape[axis];
     }
-    
+
     // Initialize empty grid (as flat array)
-    std::vector<int> grid(totalCells, -1);
+    std::vector<int> grid( totalCells, -1 );
 
     // Calculate grid search relative indices
     std::vector<std::array<int, n>> nbrIndicesRel;
-    makeNeighborRelativeIndices(nbrIndicesRel);
+    makeNeighborRelativeIndices( nbrIndicesRel );
 
     // Choose first point
-    std::uniform_real_distribution<double> coordDist(0.0, 1.0);
-    auto coordGen = std::bind(coordDist, gen);
+    std::uniform_real_distribution<double> coordDist( 0.0, 1.0 );
+    auto coordGen = std::bind( coordDist, gen );
 
     std::array<double, n> x0 = {};
     std::array<int, n> idx0 = {};
-    for(int axis = 0; axis < n; ++axis)
+    for ( int axis = 0; axis < n; ++axis )
     {
-         x0[axis] = coordGen() * extent[axis];
-         idx0[axis] = static_cast<int>(std::floor(x0[axis] / cellSize));
+        x0[axis] = coordGen() * extent[axis];
+        idx0[axis] = static_cast<int>( std::floor( x0[axis] / cellSize ) );
     };
 
-    grid[indexND(idx0, gridShape)] = 0;  // Store x0 location in grid
-    outPoints.push_back(x0);
-    
+    grid[indexND( idx0, gridShape )] = 0; // Store x0 location in grid
+    outPoints.push_back( x0 );
+
     // Initialize active set
     std::vector<int> activeSet = { 0 };
 
-    while(activeSet.size() > 0)
+    while ( activeSet.size() > 0 )
     {
-        std::uniform_int_distribution<int> pointDist(0, activeSet.size() - 1);
-        int seedIndexInActive = pointDist(gen);
+        std::uniform_int_distribution<int> pointDist( 0, activeSet.size() - 1 );
+        int seedIndexInActive = pointDist( gen );
         int seedIndex = activeSet[seedIndexInActive];
         std::array<double, n> seedX = outPoints[seedIndex];
-        
+
         bool addedPoint = false;
 
-        for(int i = 0; i < k; ++i)
+        for ( int i = 0; i < k; ++i )
         {
             std::array<double, n> x = {};
             std::array<int, n> idx = {};
 
-            // Use inverse method to sample distance from seed 
-            double xR = std::pow(rn + coordGen() * (rn2 - rn), 1.0 / static_cast<double>(n));
-            
-            // Sample direction cosine angles uniformly in [0, pi] to get direction
+            // Use inverse method to sample distance from seed
+            double xR = std::pow( rn + coordGen() * ( rn2 - rn ),
+                                  1.0 / static_cast<double>( n ) );
+
+            // Sample direction cosine angles uniformly in [0, pi] to get
+            // direction
             bool failed = false;
-            for(int axis = 0; axis < n; ++axis)
+            for ( int axis = 0; axis < n; ++axis )
             {
-                x[axis] = seedX[axis] + xR * std::cos(coordGen() * PI);
-                idx[axis] = static_cast<int>(std::floor(x[axis] / cellSize));
-                if(x[axis] < 0 || x[axis] >= extent[axis])
+                x[axis] = seedX[axis] + xR * std::cos( coordGen() * PI );
+                idx[axis] =
+                    static_cast<int>( std::floor( x[axis] / cellSize ) );
+                if ( x[axis] < 0 || x[axis] >= extent[axis] )
                 {
                     failed = true;
-                    break;   
-                } 
+                    break;
+                }
             }
-            if(failed)
+            if ( failed )
             {
                 continue;
             }
@@ -169,83 +169,84 @@ void poissonDiscSampling(
             // Check if point is too close to any existing points
             std::array<int, n> checkIdx = idx;
             bool isClose = false;
-            
-            for(const std::array<int, n>& relIdx : nbrIndicesRel)
+
+            for ( const std::array<int, n>& relIdx : nbrIndicesRel )
             {
-                for(int axis = 0; axis < n; ++axis)
+                for ( int axis = 0; axis < n; ++axis )
                 {
                     checkIdx[axis] = idx[axis] + relIdx[axis];
                 }
 
-                if(!isValid(checkIdx, gridShape))
+                if ( !isValid( checkIdx, gridShape ) )
                 {
                     continue;
                 }
 
-                int checkPoint = grid[indexND(checkIdx, gridShape)];
-                if(checkPoint == -1)
+                int checkPoint = grid[indexND( checkIdx, gridShape )];
+                if ( checkPoint == -1 )
                 {
                     continue;
                 }
 
                 const std::array<double, n>& checkX = outPoints[checkPoint];
 
-                if(distSquared(checkX, x) > r * r)
+                if ( distSquared( checkX, x ) > r * r )
                 {
                     continue;
                 }
 
                 isClose = true;
                 break;
-            }            
+            }
 
             // Use inverse method to sample distance from see
-            if(!isClose)
+            if ( !isClose )
             {
-                outPoints.push_back(x);
-                activeSet.push_back(outPoints.size() - 1);
-                grid[indexND(idx, gridShape)] = outPoints.size() - 1;
+                outPoints.push_back( x );
+                activeSet.push_back( outPoints.size() - 1 );
+                grid[indexND( idx, gridShape )] = outPoints.size() - 1;
                 addedPoint = true;
                 break;
             }
-        } 
-        // If no point could be generated farther than r from existing points, remove
-        // seed point from active set
-        if(!addedPoint)
+        }
+        // If no point could be generated farther than r from existing points,
+        // remove seed point from active set
+        if ( !addedPoint )
         {
-            activeSet.erase(activeSet.begin() + seedIndexInActive);
+            activeSet.erase( activeSet.begin() + seedIndexInActive );
         }
     }
 }
 
-template<std::size_t numGrains>
+template <std::size_t numGrains>
 void getPolycrystalGrains(
     const std::array<double, 3>& extent,
-    std::array<std::array<double, 3>, numGrains>& outLocations
-)
+    std::array<std::array<double, 3>, numGrains>& outLocations )
 {
     // Initialize RNG
     std::random_device trueRng;
-    std::seed_seq randomSeed{trueRng(), trueRng(), trueRng(), trueRng(), trueRng(), trueRng(), trueRng(), trueRng()};
-    std::mt19937 gen(randomSeed);
-   
+    std::seed_seq randomSeed{ trueRng(), trueRng(), trueRng(), trueRng(),
+                              trueRng(), trueRng(), trueRng(), trueRng() };
+    std::mt19937 gen( randomSeed );
+
     // Generate random, evenly-spaced candidate grain locations
     double volume = extent[0] * extent[1] * extent[2];
-    double radius = 2.0 * std::pow(0.75 / PI / static_cast<double>(numGrains), 1.0/3.0);
+    double radius =
+        2.0 *
+        std::pow( 0.75 / PI / static_cast<double>( numGrains ), 1.0 / 3.0 );
     std::vector<std::array<double, 3>> testPoints;
     do
     {
         testPoints.clear();
-        poissonDiscSampling(extent, radius, 30, testPoints, gen);
+        poissonDiscSampling( extent, radius, 30, testPoints, gen );
         radius *= 0.95;
-    }
-    while(testPoints.size() < numGrains);
-    
-    // Randomly choose grains locations from candidates 
-    std::vector<std::size_t> indices(testPoints.size(), 0);
-    std::iota(indices.begin(), indices.end(), 0);
-    std::shuffle(indices.begin(), indices.end(), gen);
-    for(std::size_t i = 0; i < numGrains; ++i)
+    } while ( testPoints.size() < numGrains );
+
+    // Randomly choose grains locations from candidates
+    std::vector<std::size_t> indices( testPoints.size(), 0 );
+    std::iota( indices.begin(), indices.end(), 0 );
+    std::shuffle( indices.begin(), indices.end(), gen );
+    for ( std::size_t i = 0; i < numGrains; ++i )
     {
         outLocations[i] = testPoints[indices[i]];
     }
@@ -281,36 +282,34 @@ void crackInclusionExample( const std::string filename )
     std::array<double, NUM_GRAINS> K;
     std::array<double, NUM_GRAINS> G;
 
-    for(int i = 0; i < NUM_GRAINS; ++i)
+    for ( int i = 0; i < NUM_GRAINS; ++i )
     {
         grainRho[i] = inputs["density"][i];
         E[i] = inputs["elastic_modulus"][i];
         nu[i] = inputs["Poisson's_ratio"][i];
         G0[i] = inputs["fracture_energy"][i];
-        K[i] = E[i] / ( 3 * (1 - 2 * nu[i] ) );
-        G[i] = E[i] / (2 * (1 + nu[i] ) );
+        K[i] = E[i] / ( 3 * ( 1 - 2 * nu[i] ) );
+        G[i] = E[i] / ( 2 * ( 1 + nu[i] ) );
     }
 
     double horizon = inputs["horizon"];
     horizon += 1e-10;
-    
+
     // ====================================================
     //                Polycrystal grains
     // ====================================================
     std::array<double, 3> extent = inputs["system_size"];
     std::array<std::array<double, 3>, NUM_GRAINS> grainPos;
-    getPolycrystalGrains(extent, grainPos);
-    
+    getPolycrystalGrains( extent, grainPos );
+
     // Shift grains relative to low_corner
-    for( int i = 0; i < NUM_GRAINS; ++i )
+    for ( int i = 0; i < NUM_GRAINS; ++i )
     {
-        grainPos[i] = { 
-            grainPos[i][0] + low_corner[0],
-            grainPos[i][1] + low_corner[1],
-            grainPos[i][2] + low_corner[2]
-        };
+        grainPos[i] = { grainPos[i][0] + low_corner[0],
+                        grainPos[i][1] + low_corner[1],
+                        grainPos[i][2] + low_corner[2] };
     }
-    
+
     // ====================================================
     //                    Pre-notch
     // ====================================================
@@ -330,10 +329,14 @@ void crackInclusionExample( const std::string filename )
     using model_type = CabanaPD::LPS;
 
     // Grain materials
-    CabanaPD::ForceModel force_models0( model_type{}, horizon, K[0], G[0], G0[0] );
-    CabanaPD::ForceModel force_models1( model_type{}, horizon, K[1], G[1], G0[1] );
-    CabanaPD::ForceModel force_models2( model_type{}, horizon, K[2], G[2], G0[2] );
-    CabanaPD::ForceModel force_models3( model_type{}, horizon, K[3], G[3], G0[3] );
+    CabanaPD::ForceModel force_models0( model_type{}, horizon, K[0], G[0],
+                                        G0[0] );
+    CabanaPD::ForceModel force_models1( model_type{}, horizon, K[1], G[1],
+                                        G0[1] );
+    CabanaPD::ForceModel force_models2( model_type{}, horizon, K[2], G[2],
+                                        G0[2] );
+    CabanaPD::ForceModel force_models3( model_type{}, horizon, K[3], G[3],
+                                        G0[3] );
 
     // ====================================================
     //                 Particle generation
@@ -370,7 +373,7 @@ void crackInclusionExample( const std::string filename )
         if ( x( pid, 1 ) <= plane1.low[1] + horizon + 1e-10 ||
              x( pid, 1 ) >= plane2.high[1] - horizon - 1e-10 )
             nofail( pid ) = 1;
-        
+
         // Distance squared from nearest grain location
         double distSq = 0.0;
         int grainIndex = 0;
@@ -387,7 +390,7 @@ void crackInclusionExample( const std::string filename )
                 grainIndex = i;
             }
         }
-        
+
         // Density and material type
         type( pid ) = grainIndex;
         rho( pid ) = grainRho[grainIndex];
@@ -398,8 +401,8 @@ void crackInclusionExample( const std::string filename )
     //                   Create solver
     // ====================================================
     auto models = CabanaPD::createMultiForceModel(
-        particles, CabanaPD::AverageTag{}, force_models0,
-        force_models1, force_models2, force_models3 );
+        particles, CabanaPD::AverageTag{}, force_models0, force_models1,
+        force_models2, force_models3 );
     CabanaPD::Solver solver( inputs, particles, models );
 
     // ====================================================

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -13,201 +13,6 @@
 constexpr std::size_t NUM_GRAINS = 4;
 constexpr double PI = 3.141592653589793238462643383;
 
-// Simulate a crack interacting with an inclusion.
-void crackInclusionExample( const std::string filename )
-{
-    // ====================================================
-    //               Choose Kokkos spaces
-    // ====================================================
-    using exec_space = Kokkos::DefaultExecutionSpace;
-    using memory_space = typename exec_space::memory_space;
-
-    // ====================================================
-    //                   Read inputs
-    // ====================================================
-    CabanaPD::Inputs inputs( filename );
-
-    // ====================================================
-    //                  Discretization
-    // ====================================================
-    std::array<double, 3> low_corner = inputs["low_corner"];
-    std::array<double, 3> high_corner = inputs["high_corner"];
-
-    // ====================================================
-    //                Material parameters
-    // ====================================================
-    std::array<double, NUM_GRAINS> rho;
-    std::array<double, NUM_GRAINS> E;
-    std::array<double, NUM_GRAINS> nu;
-    std::array<double, NUM_GRAINS> G0;
-    std::array<double, NUM_GRAINS> K;
-    std::array<double, NUM_GRAINS> G;
-
-    for(int i = 0; i < NUM_GRAINS; ++i)
-    {
-        rho[i] = inputs["density"][i];
-        E[i] = inputs["elastic_modulus"][i];
-        nu[i] = inputs["Poisson's_ratio"][i];
-        G0[i] = inputs["fracture_energy"][i];
-        K[i] = E[i] / ( 3 * (1 - 2 * nu[i] ) );
-        G[i] = E[i] / (2 * (1 + nu[i] ) );
-    }
-
-    double horizon = inputs["horizon"];
-    horizon += 1e-10;
-    
-    // ====================================================
-    //                Polycrystal grains
-    // ====================================================
-    std::array<double, 3> extent = inputs["system_size"];
-    std::array<std::array<double, 3>, NUM_GRAINS> grainPos;
-    getPolycrystalGrains(extent, grainPos);
-    
-    // Shift grains relative to low_corner
-    for( int i = 0; i < NUM_GRAINS; ++i )
-    {
-        grainPos[i] = { 
-            grainPos[i][0] + low_corner[0],
-            grainPos[i][1] + low_corner[1],
-            grainPos[i][2] + low_corner[2]
-        }
-    }
-    
-    // ====================================================
-    //                    Pre-notch
-    // ====================================================
-    double height = inputs["system_size"][0];
-    double thickness = inputs["system_size"][2];
-    double L_prenotch = height / 2.0;
-    double y_prenotch = 0.5 * ( low_corner[1] + high_corner[1] );
-    Kokkos::Array<double, 3> p01 = { low_corner[0], y_prenotch, low_corner[2] };
-    Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
-    Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
-    Kokkos::Array<Kokkos::Array<double, 3>, 1> notch_positions = { p01 };
-    CabanaPD::Prenotch<1> prenotch( v1, v2, notch_positions );
-
-    // ====================================================
-    //                   Force models
-    // ====================================================
-    using model_type = CabanaPD::LPS;
-
-    // Grain materials
-    std::array<CabanaPD::ForceModel, NUM_GRAINS> force_models;
-    for ( int i = 0; i < num_grains; ++i )
-    {
-        force_models[i] = CabanaPD::ForceModel( model_type{}, horizon, K[i], G[i], G0[i] );
-    }
-
-    // ====================================================
-    //                 Particle generation
-    // ====================================================
-    // Note that individual inputs can be passed instead (see other examples).
-    CabanaPD::Particles particles( memory_space{}, model_type{} );
-    particles.domain( inputs );
-    particles.create( exec_space{} );
-
-    // ====================================================
-    //                Boundary conditions planes
-    // ====================================================
-    double dy = particles.dx[1];
-    CabanaPD::Region<CabanaPD::RectangularPrism> plane1(
-        low_corner[0], high_corner[0], low_corner[1] - dy, low_corner[1] + dy,
-        low_corner[2], high_corner[2] );
-    CabanaPD::Region<CabanaPD::RectangularPrism> plane2(
-        low_corner[0], high_corner[0], high_corner[1] - dy, high_corner[1] + dy,
-        low_corner[2], high_corner[2] );
-
-    // ====================================================
-    //            Custom particle initialization
-    // ====================================================
-    auto rho = particles.sliceDensity();
-    auto x = particles.sliceReferencePosition();
-    auto v = particles.sliceVelocity();
-    auto f = particles.sliceForce();
-    auto nofail = particles.sliceNoFail();
-    auto type = particles.sliceType();
-
-    auto init_functor = KOKKOS_LAMBDA( const int pid )
-    {
-        // No-fail zone
-        if ( x( pid, 1 ) <= plane1.low[1] + horizon + 1e-10 ||
-             x( pid, 1 ) >= plane2.high[1] - horizon - 1e-10 )
-            nofail( pid ) = 1;
-        
-        // Distance squared from nearest grain location
-        double distSq = 0.0;
-        int grainIndex = 0;
-        for ( int i = 0; i < NUM_GRAINS; ++i )
-        {
-            const std::array<double, 3>& pos = grainPos[i];
-            double dx = x( pid, 0 ) - pos[0];
-            double dy = x( pid, 1 ) - pos[1];
-            double dz = x( pid, 2 ) - pos[2];
-            double check = dx * dx + dy * dy + dz * dz;
-            if ( i == 0 || check < distSq )
-            {
-                distSq = check;
-                grainIndex = i;
-            }
-        }
-        
-        // Density and material type
-        type( pid ) = grainIndex;
-        rho( pid ) = rho[grainIndex];
-    };
-    particles.update( exec_space{}, init_functor );
-
-    // ====================================================
-    //                   Create solver
-    // ====================================================
-    auto models = CabanaPD::createMultiForceModel(
-        particles, CabanaPD::AverageTag{}, force_models[0],
-        force_models[1], force_models[2], force_models[3] );
-    CabanaPD::Solver solver( inputs, particles, models );
-
-    // ====================================================
-    //                Boundary conditions
-    // ====================================================
-    // Create BC last to ensure ghost particles are included.
-    double sigma0 = inputs["traction"];
-    double b0 = sigma0 / dy;
-    f = solver.particles.sliceForce();
-    x = solver.particles.sliceReferencePosition();
-    // Create a symmetric force BC in the y-direction.
-    auto bc_op = KOKKOS_LAMBDA( const int pid, const double )
-    {
-        auto ypos = x( pid, 1 );
-        auto sign = std::abs( ypos ) / ypos;
-        f( pid, 1 ) += b0 * sign;
-    };
-    auto bc = createBoundaryCondition( bc_op, exec_space{}, solver.particles,
-                                       true, plane1, plane2 );
-
-    // ====================================================
-    //                      Outputs
-    // ====================================================
-    // Output maximum y-extent of the crack.
-    CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
-    auto d = solver.particles.sliceDamage();
-    auto crack_y_func = KOKKOS_LAMBDA( const int p )
-    {
-        // Use a threshold of damage to only output damaged particles.
-        if ( d( p ) > 0.3 )
-            return x( p, 1 );
-        else
-            return 0.0;
-    };
-    auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
-        "output_incl_crack_y.txt", inputs, exec_space{}, solver.particles,
-        crack_y_func, box );
-
-    // ====================================================
-    //                   Simulation run
-    // ====================================================
-    solver.init( bc, prenotch );
-    solver.run( bc, output_yl );
-}
-
 template<std::size_t n>
 int indexND(const std::array<int, n>& index, const std::array<int, n>& shape)
 {
@@ -446,6 +251,199 @@ void getPolycrystalGrains(
     }
 }
 
+// Simulate a crack interacting with an inclusion.
+void crackInclusionExample( const std::string filename )
+{
+    // ====================================================
+    //               Choose Kokkos spaces
+    // ====================================================
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using memory_space = typename exec_space::memory_space;
+
+    // ====================================================
+    //                   Read inputs
+    // ====================================================
+    CabanaPD::Inputs inputs( filename );
+
+    // ====================================================
+    //                  Discretization
+    // ====================================================
+    std::array<double, 3> low_corner = inputs["low_corner"];
+    std::array<double, 3> high_corner = inputs["high_corner"];
+
+    // ====================================================
+    //                Material parameters
+    // ====================================================
+    std::array<double, NUM_GRAINS> grainRho;
+    std::array<double, NUM_GRAINS> E;
+    std::array<double, NUM_GRAINS> nu;
+    std::array<double, NUM_GRAINS> G0;
+    std::array<double, NUM_GRAINS> K;
+    std::array<double, NUM_GRAINS> G;
+
+    for(int i = 0; i < NUM_GRAINS; ++i)
+    {
+        grainRho[i] = inputs["density"][i];
+        E[i] = inputs["elastic_modulus"][i];
+        nu[i] = inputs["Poisson's_ratio"][i];
+        G0[i] = inputs["fracture_energy"][i];
+        K[i] = E[i] / ( 3 * (1 - 2 * nu[i] ) );
+        G[i] = E[i] / (2 * (1 + nu[i] ) );
+    }
+
+    double horizon = inputs["horizon"];
+    horizon += 1e-10;
+    
+    // ====================================================
+    //                Polycrystal grains
+    // ====================================================
+    std::array<double, 3> extent = inputs["system_size"];
+    std::array<std::array<double, 3>, NUM_GRAINS> grainPos;
+    getPolycrystalGrains(extent, grainPos);
+    
+    // Shift grains relative to low_corner
+    for( int i = 0; i < NUM_GRAINS; ++i )
+    {
+        grainPos[i] = { 
+            grainPos[i][0] + low_corner[0],
+            grainPos[i][1] + low_corner[1],
+            grainPos[i][2] + low_corner[2]
+        };
+    }
+    
+    // ====================================================
+    //                    Pre-notch
+    // ====================================================
+    double height = inputs["system_size"][0];
+    double thickness = inputs["system_size"][2];
+    double L_prenotch = height / 2.0;
+    double y_prenotch = 0.5 * ( low_corner[1] + high_corner[1] );
+    Kokkos::Array<double, 3> p01 = { low_corner[0], y_prenotch, low_corner[2] };
+    Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
+    Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
+    Kokkos::Array<Kokkos::Array<double, 3>, 1> notch_positions = { p01 };
+    CabanaPD::Prenotch<1> prenotch( v1, v2, notch_positions );
+
+    // ====================================================
+    //                   Force models
+    // ====================================================
+    using model_type = CabanaPD::LPS;
+
+    // Grain materials
+    CabanaPD::ForceModel force_models0( model_type{}, horizon, K[0], G[0], G0[0] );
+    CabanaPD::ForceModel force_models1( model_type{}, horizon, K[1], G[1], G0[1] );
+    CabanaPD::ForceModel force_models2( model_type{}, horizon, K[2], G[2], G0[2] );
+    CabanaPD::ForceModel force_models3( model_type{}, horizon, K[3], G[3], G0[3] );
+
+    // ====================================================
+    //                 Particle generation
+    // ====================================================
+    // Note that individual inputs can be passed instead (see other examples).
+    CabanaPD::Particles particles( memory_space{}, model_type{} );
+    particles.domain( inputs );
+    particles.create( exec_space{} );
+
+    // ====================================================
+    //                Boundary conditions planes
+    // ====================================================
+    double dy = particles.dx[1];
+    CabanaPD::Region<CabanaPD::RectangularPrism> plane1(
+        low_corner[0], high_corner[0], low_corner[1] - dy, low_corner[1] + dy,
+        low_corner[2], high_corner[2] );
+    CabanaPD::Region<CabanaPD::RectangularPrism> plane2(
+        low_corner[0], high_corner[0], high_corner[1] - dy, high_corner[1] + dy,
+        low_corner[2], high_corner[2] );
+
+    // ====================================================
+    //            Custom particle initialization
+    // ====================================================
+    auto rho = particles.sliceDensity();
+    auto x = particles.sliceReferencePosition();
+    auto v = particles.sliceVelocity();
+    auto f = particles.sliceForce();
+    auto nofail = particles.sliceNoFail();
+    auto type = particles.sliceType();
+
+    auto init_functor = KOKKOS_LAMBDA( const int pid )
+    {
+        // No-fail zone
+        if ( x( pid, 1 ) <= plane1.low[1] + horizon + 1e-10 ||
+             x( pid, 1 ) >= plane2.high[1] - horizon - 1e-10 )
+            nofail( pid ) = 1;
+        
+        // Distance squared from nearest grain location
+        double distSq = 0.0;
+        int grainIndex = 0;
+        for ( int i = 0; i < NUM_GRAINS; ++i )
+        {
+            const std::array<double, 3>& pos = grainPos[i];
+            double dx = x( pid, 0 ) - pos[0];
+            double dy = x( pid, 1 ) - pos[1];
+            double dz = x( pid, 2 ) - pos[2];
+            double check = dx * dx + dy * dy + dz * dz;
+            if ( i == 0 || check < distSq )
+            {
+                distSq = check;
+                grainIndex = i;
+            }
+        }
+        
+        // Density and material type
+        type( pid ) = grainIndex;
+        rho( pid ) = grainRho[grainIndex];
+    };
+    particles.update( exec_space{}, init_functor );
+
+    // ====================================================
+    //                   Create solver
+    // ====================================================
+    auto models = CabanaPD::createMultiForceModel(
+        particles, CabanaPD::AverageTag{}, force_models0,
+        force_models1, force_models2, force_models3 );
+    CabanaPD::Solver solver( inputs, particles, models );
+
+    // ====================================================
+    //                Boundary conditions
+    // ====================================================
+    // Create BC last to ensure ghost particles are included.
+    double sigma0 = inputs["traction"];
+    double b0 = sigma0 / dy;
+    f = solver.particles.sliceForce();
+    x = solver.particles.sliceReferencePosition();
+    // Create a symmetric force BC in the y-direction.
+    auto bc_op = KOKKOS_LAMBDA( const int pid, const double )
+    {
+        auto ypos = x( pid, 1 );
+        auto sign = std::abs( ypos ) / ypos;
+        f( pid, 1 ) += b0 * sign;
+    };
+    auto bc = createBoundaryCondition( bc_op, exec_space{}, solver.particles,
+                                       true, plane1, plane2 );
+
+    // ====================================================
+    //                      Outputs
+    // ====================================================
+    // Output maximum y-extent of the crack.
+    CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
+    auto d = solver.particles.sliceDamage();
+    auto crack_y_func = KOKKOS_LAMBDA( const int p )
+    {
+        // Use a threshold of damage to only output damaged particles.
+        if ( d( p ) > 0.3 )
+            return x( p, 1 );
+        else
+            return 0.0;
+    };
+    auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
+        "output_incl_crack_y.txt", inputs, exec_space{}, solver.particles,
+        crack_y_func, box );
+
+    // ====================================================
+    //                   Simulation run
+    // ====================================================
+    solver.init( bc, prenotch );
+    solver.run( bc, output_yl );
+}
 
 // Initialize MPI+Kokkos.
 int main( int argc, char* argv[] )

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -232,7 +232,7 @@ void getPolycrystalGrains(
 {
     // Initialize RNG (for now with FIXED seed)
     std::minstd_rand baseRng;
-    baseRng.seed(12345);
+    baseRng.seed( 12345 );
     std::seed_seq randomSeed{ baseRng(), baseRng(), baseRng(), baseRng(),
                               baseRng(), baseRng(), baseRng(), baseRng() };
     std::mt19937 gen( randomSeed );
@@ -277,16 +277,12 @@ void polycrystalExample( const std::string filename )
     // ====================================================
     //                  Discretization
     // ====================================================
-    std::array<double, 3> low_corner = {
-        inputs["low_corner"][0],
-        inputs["low_corner"][1],
-        inputs["low_corner"][2]
-    };
-    std::array<double, 3> high_corner = {
-        inputs["high_corner"][0],
-        inputs["high_corner"][1],
-        inputs["high_corner"][2]
-    };
+    std::array<double, 3> low_corner = { inputs["low_corner"][0],
+                                         inputs["low_corner"][1],
+                                         inputs["low_corner"][2] };
+    std::array<double, 3> high_corner = { inputs["high_corner"][0],
+                                          inputs["high_corner"][1],
+                                          inputs["high_corner"][2] };
 
     // ====================================================
     //                Material parameters
@@ -329,20 +325,6 @@ void polycrystalExample( const std::string filename )
                         grainPosStd[i][1] + low_corner[1],
                         grainPosStd[i][2] + low_corner[2] };
     }
-
-    // No pre-notch
-    // // ====================================================
-    // //                    Pre-notch
-    // // ====================================================
-    // double height = inputs["system_size"][0];
-    // double thickness = inputs["system_size"][2];
-    // double L_prenotch = height / 2.0;
-    // double y_prenotch = 0.5 * ( low_corner[1] + high_corner[1] );
-    // Kokkos::Array<double, 3> p01 = { low_corner[0], y_prenotch, low_corner[2] };
-    // Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
-    // Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
-    // Kokkos::Array<Kokkos::Array<double, 3>, 1> notch_positions = { p01 };
-    // CabanaPD::Prenotch<1> prenotch( v1, v2, notch_positions );
 
     // ====================================================
     //                   Force models
@@ -439,24 +421,6 @@ void polycrystalExample( const std::string filename )
     };
     auto bc = createBoundaryCondition( bc_op, exec_space{}, solver.particles,
                                        true, plane1, plane2 );
-
-    // // ====================================================
-    // //                      Outputs
-    // // ====================================================
-    // // Output maximum y-extent of the crack.
-    // CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
-    // auto d = solver.particles.sliceDamage();
-    // auto crack_y_func = KOKKOS_LAMBDA( const int p )
-    // {
-    //     // Use a threshold of damage to only output damaged particles.
-    //     if ( d( p ) > 0.3 )
-    //         return x( p, 1 );
-    //     else
-    //         return 0.0;
-    // };
-    // auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
-    //     "output_polycrystal_crack_y.txt", inputs, exec_space{},
-    //     solver.particles, crack_y_func, box );
 
     // ====================================================
     //                   Simulation run

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -319,13 +319,11 @@ void crackPolycrystalExample( const std::string filename )
     getPolycrystalGrains( extent, grainPos );
 
     // Shift grains relative to low_corner
-    std::cout << "Generated " << NUM_GRAINS << " polycrystal grains" << std::endl;
     for ( int i = 0; i < NUM_GRAINS; ++i )
     {
         grainPos[i] = { grainPos[i][0] + low_corner[0],
                         grainPos[i][1] + low_corner[1],
                         grainPos[i][2] + low_corner[2] };
-        std::cout << grainPos[i][0] << ", " << grainPos[i][1] << ", " << grainPos[i][2] << std::endl;
     }
 
     // ====================================================

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -232,8 +232,8 @@ void getPolycrystalGrains(
     // Generate random, evenly-spaced candidate grain locations
     double volume = extent[0] * extent[1] * extent[2];
     double radius =
-        2.0 *
-        std::pow( 0.75 * volume / PI / static_cast<double>( numGrains ), 1.0 / 3.0 );
+        2.0 * std::pow( 0.75 * volume / PI / static_cast<double>( numGrains ),
+                        1.0 / 3.0 );
     std::vector<std::array<double, 3>> testPoints;
     do
     {

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -417,8 +417,9 @@ void polycrystalExample( const std::string filename )
     // ====================================================
     //                   Create solver
     // ====================================================
+    CabanaPD::BinaryIndexing indexing;
     auto models = CabanaPD::createMultiForceModel(
-        particles, CabanaPD::AverageTag{}, force_model_within, force_model_between );
+        particles, indexing, force_model_within, force_model_between );
     CabanaPD::Solver solver( inputs, particles, models );
 
     // ====================================================

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -298,16 +298,16 @@ void polycrystalExample( const std::string filename )
     }
 
     // Within-grain parameters
-    double E_within = inputs["elastic_modulus_within"];
-    double nu_within = inputs["Poisson's_ratio_within"];
-    double G0_within = inputs["fracture_energy_within"];
+    double E_within = inputs["elastic_modulus"][0];
+    double nu_within = inputs["Poisson's_ratio"][0];
+    double G0_within = inputs["fracture_energy"][0];
     double K_within = E_within / ( 3 * ( 1 - 2 * nu_within ) );
     double G_within = E_within / ( 2 * ( 1 + nu_within ) );
 
     // Between-grain parameters
-    double E_between = inputs["elastic_modulus_between"];
-    double nu_between = inputs["Poisson's_ratio_between"];
-    double G0_between = inputs["fracture_energy_between"];
+    double E_between = inputs["elastic_modulus"][1];
+    double nu_between = inputs["Poisson's_ratio"][1];
+    double G0_between = inputs["fracture_energy"][1];
     double K_between = E_between / ( 3 * ( 1 - 2 * nu_between ) );
     double G_between = E_between / ( 2 * ( 1 + nu_between ) );
 

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -10,7 +10,7 @@
 
 #include <CabanaPD.hpp>
 
-constexpr std::size_t NUM_GRAINS = 4;
+constexpr std::size_t NUM_GRAINS = 16;
 constexpr double PI = 3.141592653589793238462643383;
 
 // Get flat index into ND array

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -231,7 +231,7 @@ void getPolycrystalGrains(
     std::array<std::array<double, 3>, numGrains>& outLocations )
 {
     // Initialize RNG (for now with FIXED seed)
-    std::mnistd_rand baseRng;
+    std::minstd_rand baseRng;
     baseRng.seed(12345);
     std::seed_seq randomSeed{ baseRng(), baseRng(), baseRng(), baseRng(),
                               baseRng(), baseRng(), baseRng(), baseRng() };

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -277,8 +277,8 @@ void polycrystalExample( const std::string filename )
     //                  Discretization
     // ====================================================
     std::array<double, 3> low_corner = {
-        inputs["low_corner"][0];
-        inputs["low_corner"][1];
+        inputs["low_corner"][0],
+        inputs["low_corner"][1],
         inputs["low_corner"][2]
     };
     std::array<double, 3> high_corner = {

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -260,7 +260,7 @@ void getPolycrystalGrains(
 }
 
 // Simulate a crack in a polycrystal
-void crackPolycrystalExample( const std::string filename )
+void polycrystalExample( const std::string filename )
 {
     // ====================================================
     //               Choose Kokkos spaces
@@ -469,7 +469,7 @@ int main( int argc, char* argv[] )
     MPI_Init( &argc, &argv );
     Kokkos::initialize( argc, argv );
 
-    crackInclusionExample( argv[1] );
+    polycrystalExample( argv[1] );
 
     Kokkos::finalize();
     MPI_Finalize();

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -330,18 +330,19 @@ void polycrystalExample( const std::string filename )
                         grainPosStd[i][2] + low_corner[2] };
     }
 
-    // ====================================================
-    //                    Pre-notch
-    // ====================================================
-    double height = inputs["system_size"][0];
-    double thickness = inputs["system_size"][2];
-    double L_prenotch = height / 2.0;
-    double y_prenotch = 0.5 * ( low_corner[1] + high_corner[1] );
-    Kokkos::Array<double, 3> p01 = { low_corner[0], y_prenotch, low_corner[2] };
-    Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
-    Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
-    Kokkos::Array<Kokkos::Array<double, 3>, 1> notch_positions = { p01 };
-    CabanaPD::Prenotch<1> prenotch( v1, v2, notch_positions );
+    // No pre-notch
+    // // ====================================================
+    // //                    Pre-notch
+    // // ====================================================
+    // double height = inputs["system_size"][0];
+    // double thickness = inputs["system_size"][2];
+    // double L_prenotch = height / 2.0;
+    // double y_prenotch = 0.5 * ( low_corner[1] + high_corner[1] );
+    // Kokkos::Array<double, 3> p01 = { low_corner[0], y_prenotch, low_corner[2] };
+    // Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
+    // Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
+    // Kokkos::Array<Kokkos::Array<double, 3>, 1> notch_positions = { p01 };
+    // CabanaPD::Prenotch<1> prenotch( v1, v2, notch_positions );
 
     // ====================================================
     //                   Force models
@@ -438,23 +439,23 @@ void polycrystalExample( const std::string filename )
     auto bc = createBoundaryCondition( bc_op, exec_space{}, solver.particles,
                                        true, plane1, plane2 );
 
-    // ====================================================
-    //                      Outputs
-    // ====================================================
-    // Output maximum y-extent of the crack.
-    CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
-    auto d = solver.particles.sliceDamage();
-    auto crack_y_func = KOKKOS_LAMBDA( const int p )
-    {
-        // Use a threshold of damage to only output damaged particles.
-        if ( d( p ) > 0.3 )
-            return x( p, 1 );
-        else
-            return 0.0;
-    };
-    auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
-        "output_polycrystal_crack_y.txt", inputs, exec_space{},
-        solver.particles, crack_y_func, box );
+    // // ====================================================
+    // //                      Outputs
+    // // ====================================================
+    // // Output maximum y-extent of the crack.
+    // CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
+    // auto d = solver.particles.sliceDamage();
+    // auto crack_y_func = KOKKOS_LAMBDA( const int p )
+    // {
+    //     // Use a threshold of damage to only output damaged particles.
+    //     if ( d( p ) > 0.3 )
+    //         return x( p, 1 );
+    //     else
+    //         return 0.0;
+    // };
+    // auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
+    //     "output_polycrystal_crack_y.txt", inputs, exec_space{},
+    //     solver.particles, crack_y_func, box );
 
     // ====================================================
     //                   Simulation run

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -386,8 +386,8 @@ void polycrystalExample( const std::string filename )
     auto init_functor = KOKKOS_LAMBDA( const int pid )
     {
         // No-fail zone
-        if ( x( pid, 1 ) <= plane1.low[1] + horizon + 1e-10 ||
-             x( pid, 1 ) >= plane2.high[1] - horizon - 1e-10 )
+        if ( x( pid, 1 ) <= plane1.low[1] + horizon ||
+             x( pid, 1 ) >= plane2.high[1] - horizon )
             nofail( pid ) = 1;
 
         // Distance squared from nearest grain location

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -1,0 +1,460 @@
+#include <fstream>
+#include <iostream>
+#include <cmath>
+#include <random>
+#include <functional>
+
+#include "mpi.h"
+
+#include <Kokkos_Core.hpp>
+
+#include <CabanaPD.hpp>
+
+constexpr std::size_t NUM_GRAINS = 4;
+constexpr double PI = 3.141592653589793238462643383;
+
+// Simulate a crack interacting with an inclusion.
+void crackInclusionExample( const std::string filename )
+{
+    // ====================================================
+    //               Choose Kokkos spaces
+    // ====================================================
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using memory_space = typename exec_space::memory_space;
+
+    // ====================================================
+    //                   Read inputs
+    // ====================================================
+    CabanaPD::Inputs inputs( filename );
+
+    // ====================================================
+    //                  Discretization
+    // ====================================================
+    std::array<double, 3> low_corner = inputs["low_corner"];
+    std::array<double, 3> high_corner = inputs["high_corner"];
+
+    // ====================================================
+    //                Material parameters
+    // ====================================================
+    std::array<double, NUM_GRAINS> rho;
+    std::array<double, NUM_GRAINS> E;
+    std::array<double, NUM_GRAINS> nu;
+    std::array<double, NUM_GRAINS> G0;
+    std::array<double, NUM_GRAINS> K;
+    std::array<double, NUM_GRAINS> G;
+
+    for(int i = 0; i < NUM_GRAINS; ++i)
+    {
+        rho[i] = inputs["density"][i];
+        E[i] = inputs["elastic_modulus"][i];
+        nu[i] = inputs["Poisson's_ratio"][i];
+        G0[i] = inputs["fracture_energy"][i];
+        K[i] = E[i] / ( 3 * (1 - 2 * nu[i] ) );
+        G[i] = E[i] / (2 * (1 + nu[i] ) );
+    }
+
+    double horizon = inputs["horizon"];
+    horizon += 1e-10;
+    
+    // ====================================================
+    //                Polycrystal grains
+    // ====================================================
+    std::array<double, 3> extent = inputs["system_size"];
+    std::array<std::array<double, 3>, NUM_GRAINS> grainPos;
+    getPolycrystalGrains(extent, grainPos);
+    
+    // Shift grains relative to low_corner
+    for( int i = 0; i < NUM_GRAINS; ++i )
+    {
+        grainPos[i] = { 
+            grainPos[i][0] + low_corner[0],
+            grainPos[i][1] + low_corner[1],
+            grainPos[i][2] + low_corner[2]
+        }
+    }
+    
+    // ====================================================
+    //                    Pre-notch
+    // ====================================================
+    double height = inputs["system_size"][0];
+    double thickness = inputs["system_size"][2];
+    double L_prenotch = height / 2.0;
+    double y_prenotch = 0.5 * ( low_corner[1] + high_corner[1] );
+    Kokkos::Array<double, 3> p01 = { low_corner[0], y_prenotch, low_corner[2] };
+    Kokkos::Array<double, 3> v1 = { L_prenotch, 0, 0 };
+    Kokkos::Array<double, 3> v2 = { 0, 0, thickness };
+    Kokkos::Array<Kokkos::Array<double, 3>, 1> notch_positions = { p01 };
+    CabanaPD::Prenotch<1> prenotch( v1, v2, notch_positions );
+
+    // ====================================================
+    //                   Force models
+    // ====================================================
+    using model_type = CabanaPD::LPS;
+
+    // Grain materials
+    std::array<CabanaPD::ForceModel, NUM_GRAINS> force_models;
+    for ( int i = 0; i < num_grains; ++i )
+    {
+        force_models[i] = CabanaPD::ForceModel( model_type{}, horizon, K[i], G[i], G0[i] );
+    }
+
+    // ====================================================
+    //                 Particle generation
+    // ====================================================
+    // Note that individual inputs can be passed instead (see other examples).
+    CabanaPD::Particles particles( memory_space{}, model_type{} );
+    particles.domain( inputs );
+    particles.create( exec_space{} );
+
+    // ====================================================
+    //                Boundary conditions planes
+    // ====================================================
+    double dy = particles.dx[1];
+    CabanaPD::Region<CabanaPD::RectangularPrism> plane1(
+        low_corner[0], high_corner[0], low_corner[1] - dy, low_corner[1] + dy,
+        low_corner[2], high_corner[2] );
+    CabanaPD::Region<CabanaPD::RectangularPrism> plane2(
+        low_corner[0], high_corner[0], high_corner[1] - dy, high_corner[1] + dy,
+        low_corner[2], high_corner[2] );
+
+    // ====================================================
+    //            Custom particle initialization
+    // ====================================================
+    auto rho = particles.sliceDensity();
+    auto x = particles.sliceReferencePosition();
+    auto v = particles.sliceVelocity();
+    auto f = particles.sliceForce();
+    auto nofail = particles.sliceNoFail();
+    auto type = particles.sliceType();
+
+    auto init_functor = KOKKOS_LAMBDA( const int pid )
+    {
+        // No-fail zone
+        if ( x( pid, 1 ) <= plane1.low[1] + horizon + 1e-10 ||
+             x( pid, 1 ) >= plane2.high[1] - horizon - 1e-10 )
+            nofail( pid ) = 1;
+        
+        // Distance squared from nearest grain location
+        double distSq = 0.0;
+        int grainIndex = 0;
+        for ( int i = 0; i < NUM_GRAINS; ++i )
+        {
+            const std::array<double, 3>& pos = grainPos[i];
+            double dx = x( pid, 0 ) - pos[0];
+            double dy = x( pid, 1 ) - pos[1];
+            double dz = x( pid, 2 ) - pos[2];
+            double check = dx * dx + dy * dy + dz * dz;
+            if ( i == 0 || check < distSq )
+            {
+                distSq = check;
+                grainIndex = i;
+            }
+        }
+        
+        // Density and material type
+        type( pid ) = grainIndex;
+        rho( pid ) = rho[grainIndex];
+    };
+    particles.update( exec_space{}, init_functor );
+
+    // ====================================================
+    //                   Create solver
+    // ====================================================
+    auto models = CabanaPD::createMultiForceModel(
+        particles, CabanaPD::AverageTag{}, force_models[0],
+        force_models[1], force_models[2], force_models[3] );
+    CabanaPD::Solver solver( inputs, particles, models );
+
+    // ====================================================
+    //                Boundary conditions
+    // ====================================================
+    // Create BC last to ensure ghost particles are included.
+    double sigma0 = inputs["traction"];
+    double b0 = sigma0 / dy;
+    f = solver.particles.sliceForce();
+    x = solver.particles.sliceReferencePosition();
+    // Create a symmetric force BC in the y-direction.
+    auto bc_op = KOKKOS_LAMBDA( const int pid, const double )
+    {
+        auto ypos = x( pid, 1 );
+        auto sign = std::abs( ypos ) / ypos;
+        f( pid, 1 ) += b0 * sign;
+    };
+    auto bc = createBoundaryCondition( bc_op, exec_space{}, solver.particles,
+                                       true, plane1, plane2 );
+
+    // ====================================================
+    //                      Outputs
+    // ====================================================
+    // Output maximum y-extent of the crack.
+    CabanaPD::Region<CabanaPD::RectangularPrism> box( low_corner, high_corner );
+    auto d = solver.particles.sliceDamage();
+    auto crack_y_func = KOKKOS_LAMBDA( const int p )
+    {
+        // Use a threshold of damage to only output damaged particles.
+        if ( d( p ) > 0.3 )
+            return x( p, 1 );
+        else
+            return 0.0;
+    };
+    auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
+        "output_incl_crack_y.txt", inputs, exec_space{}, solver.particles,
+        crack_y_func, box );
+
+    // ====================================================
+    //                   Simulation run
+    // ====================================================
+    solver.init( bc, prenotch );
+    solver.run( bc, output_yl );
+}
+
+template<std::size_t n>
+int indexND(const std::array<int, n>& index, const std::array<int, n>& shape)
+{
+    int outIndex = 0;
+    int stride = 1;
+    
+    for(int axis = n - 1; axis >= 0; --axis)
+    {
+        outIndex += index[axis] * stride;
+        stride *= shape[axis];
+    }
+
+    return outIndex;
+}
+
+template<std::size_t n>
+bool isValid(const std::array<int, n>& idx, const std::array<int, n>& shape)
+{
+    for(int i = 0; i < n; ++i)
+    {
+        if(idx[i] < 0 || idx[i] >= shape[i])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+template<std::size_t n>
+void makeRelativeIndicesRecursive(
+    int axis,
+    std::array<int, n>& curIndex,
+    std::vector<std::array<int, n>>& outRelativeIndices
+)
+{
+    int maxDist = std::ceil(std::sqrt(static_cast<double>(n)));
+    for(int i = -maxDist; i <= maxDist; ++i)
+    {
+        curIndex[axis] = i;
+        if(axis < n - 1)
+        {
+            makeRelativeIndicesRecursive(axis + 1, curIndex, outRelativeIndices);
+        }
+        else
+        {
+            outRelativeIndices.push_back(curIndex);
+        }
+    }
+}
+
+template<std::size_t n>
+void makeNeighborRelativeIndices(std::vector<std::array<int, n>>& outRelativeIndices)
+{
+    std::array<int, n> curIndex = {};
+    makeRelativeIndicesRecursive(0, curIndex, outRelativeIndices);
+}
+
+template<std::size_t n>
+double distSquared(const std::array<double, n>& a, const std::array<double, n>& b)
+{
+    double r2 = 0.0;
+    for(int axis = 0; axis < n; ++axis)
+    {
+        r2 += (a[axis] - b[axis]) * (a[axis] - b[axis]);
+    }
+    return r2;
+}
+
+template<std::size_t n, class RNGType>
+void poissonDiscSampling(
+    const std::array<double, n>& extent,
+    double r,
+    int k,
+    std::vector<std::array<double, n>>& outPoints,
+    RNGType& gen
+)
+{
+    // Dimension of problem
+    double rn = std::pow(r, static_cast<double>(n));
+    double rn2 = std::pow(2.0 * r, static_cast<double>(n));
+
+    // Calculate shape of grid
+    double cellSize = r / std::sqrt(static_cast<double>(n));
+    std::array<int, n> gridShape = {};
+    int totalCells = 1;
+    for(int axis = 0; axis < n; ++axis)
+    {
+        double axisCells = std::ceil(extent[axis] / cellSize);
+        
+        // Add an extra cell in each direction just in case
+        gridShape[axis] = 1 + static_cast<int>(axisCells);
+        totalCells *= gridShape[axis];
+    }
+    
+    // Initialize empty grid (as flat array)
+    std::vector<int> grid(totalCells, -1);
+
+    // Calculate grid search relative indices
+    std::vector<std::array<int, n>> nbrIndicesRel;
+    makeNeighborRelativeIndices(nbrIndicesRel);
+
+    // Choose first point
+    std::uniform_real_distribution<double> coordDist(0.0, 1.0);
+    auto coordGen = std::bind(coordDist, gen);
+
+    std::array<double, n> x0 = {};
+    std::array<int, n> idx0 = {};
+    for(int axis = 0; axis < n; ++axis)
+    {
+         x0[axis] = coordGen() * extent[axis];
+         idx0[axis] = static_cast<int>(std::floor(x0[axis] / cellSize));
+    };
+
+    grid[indexND(idx0, gridShape)] = 0;  // Store x0 location in grid
+    outPoints.push_back(x0);
+    
+    // Initialize active set
+    std::vector<int> activeSet = { 0 };
+
+    while(activeSet.size() > 0)
+    {
+        std::uniform_int_distribution<int> pointDist(0, activeSet.size() - 1);
+        int seedIndexInActive = pointDist(gen);
+        int seedIndex = activeSet[seedIndexInActive];
+        std::array<double, n> seedX = outPoints[seedIndex];
+        
+        bool addedPoint = false;
+
+        for(int i = 0; i < k; ++i)
+        {
+            std::array<double, n> x = {};
+            std::array<int, n> idx = {};
+
+            // Use inverse method to sample distance from seed 
+            double xR = std::pow(rn + coordGen() * (rn2 - rn), 1.0 / static_cast<double>(n));
+            
+            // Sample direction cosine angles uniformly in [0, pi] to get direction
+            bool failed = false;
+            for(int axis = 0; axis < n; ++axis)
+            {
+                x[axis] = seedX[axis] + xR * std::cos(coordGen() * PI);
+                idx[axis] = static_cast<int>(std::floor(x[axis] / cellSize));
+                if(x[axis] < 0 || x[axis] >= extent[axis])
+                {
+                    failed = true;
+                    break;   
+                } 
+            }
+            if(failed)
+            {
+                continue;
+            }
+
+            // Check if point is too close to any existing points
+            std::array<int, n> checkIdx = idx;
+            bool isClose = false;
+            
+            for(const std::array<int, n>& relIdx : nbrIndicesRel)
+            {
+                for(int axis = 0; axis < n; ++axis)
+                {
+                    checkIdx[axis] = idx[axis] + relIdx[axis];
+                }
+
+                if(!isValid(checkIdx, gridShape))
+                {
+                    continue;
+                }
+
+                int checkPoint = grid[indexND(checkIdx, gridShape)];
+                if(checkPoint == -1)
+                {
+                    continue;
+                }
+
+                const std::array<double, n>& checkX = outPoints[checkPoint];
+
+                if(distSquared(checkX, x) > r * r)
+                {
+                    continue;
+                }
+
+                isClose = true;
+                break;
+            }            
+
+            // Use inverse method to sample distance from see
+            if(!isClose)
+            {
+                outPoints.push_back(x);
+                activeSet.push_back(outPoints.size() - 1);
+                grid[indexND(idx, gridShape)] = outPoints.size() - 1;
+                addedPoint = true;
+                break;
+            }
+        } 
+        // If no point could be generated farther than r from existing points, remove
+        // seed point from active set
+        if(!addedPoint)
+        {
+            activeSet.erase(activeSet.begin() + seedIndexInActive);
+        }
+    }
+}
+
+template<std::size_t numGrains>
+void getPolycrystalGrains(
+    const std::array<double, 3>& extent,
+    std::array<std::array<double, 3>, numGrains>& outLocations
+)
+{
+    // Initialize RNG
+    std::random_device trueRng;
+    std::seed_seq randomSeed{trueRng(), trueRng(), trueRng(), trueRng(), trueRng(), trueRng(), trueRng(), trueRng()};
+    std::mt19937 gen(randomSeed);
+   
+    // Generate random, evenly-spaced candidate grain locations
+    double volume = extent[0] * extent[1] * extent[2];
+    double radius = 2.0 * std::pow(0.75 / PI / static_cast<double>(numGrains), 1.0/3.0);
+    std::vector<std::array<double, 3>> testPoints;
+    do
+    {
+        testPoints.clear();
+        poissonDiscSampling(extent, radius, 30, testPoints, gen);
+        radius *= 0.95;
+    }
+    while(testPoints.size() < numGrains);
+    
+    // Randomly choose grains locations from candidates 
+    std::vector<std::size_t> indices(testPoints.size(), 0);
+    std::iota(indices.begin(), indices.end(), 0);
+    std::shuffle(indices.begin(), indices.end(), gen);
+    for(std::size_t i = 0; i < numGrains; ++i)
+    {
+        outLocations[i] = testPoints[indices[i]];
+    }
+}
+
+
+// Initialize MPI+Kokkos.
+int main( int argc, char* argv[] )
+{
+    MPI_Init( &argc, &argv );
+    Kokkos::initialize( argc, argv );
+
+    crackInclusionExample( argv[1] );
+
+    Kokkos::finalize();
+    MPI_Finalize();
+}

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -230,10 +230,11 @@ void getPolycrystalGrains(
     const std::array<double, 3>& extent,
     std::array<std::array<double, 3>, numGrains>& outLocations )
 {
-    // Initialize RNG
-    std::random_device trueRng;
-    std::seed_seq randomSeed{ trueRng(), trueRng(), trueRng(), trueRng(),
-                              trueRng(), trueRng(), trueRng(), trueRng() };
+    // Initialize RNG (for now with FIXED seed)
+    std::mnistd_rand baseRng;
+    baseRng.seed(12345);
+    std::seed_seq randomSeed{ baseRng(), baseRng(), baseRng(), baseRng(),
+                              baseRng(), baseRng(), baseRng(), baseRng() };
     std::mt19937 gen( randomSeed );
 
     // Generate random, evenly-spaced candidate grain locations

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -445,8 +445,8 @@ void crackPolycrystalExample( const std::string filename )
             return 0.0;
     };
     auto output_yl = CabanaPD::createOutputTimeSeries<Kokkos::Max<double>>(
-        "output_polycrystal_crack_y.txt", inputs, exec_space{}, solver.particles,
-        crack_y_func, box );
+        "output_polycrystal_crack_y.txt", inputs, exec_space{},
+        solver.particles, crack_y_func, box );
 
     // ====================================================
     //                   Simulation run

--- a/examples/mechanics/polycrystal.cpp
+++ b/examples/mechanics/polycrystal.cpp
@@ -233,7 +233,7 @@ void getPolycrystalGrains(
     double volume = extent[0] * extent[1] * extent[2];
     double radius =
         2.0 *
-        std::pow( 0.75 / PI / static_cast<double>( numGrains ), 1.0 / 3.0 );
+        std::pow( 0.75 * volume / PI / static_cast<double>( numGrains ), 1.0 / 3.0 );
     std::vector<std::array<double, 3>> testPoints;
     do
     {


### PR DESCRIPTION
Adds an example of fracture in a polycrystal with four grains. The geometry and material properties are the same as in the CrackInclusion example (though this can be modified via the input JSON file), and the grain geometry is generated randomly by sampling Voronoi cell centers using Poisson disc sampling.

Although I have tested the code that generates the grain geometry separately, I have not yet been able to run the example (due, I think, to an issue with finding the right HDF5-related libraries), so there is likely still some debugging to be done before this is ready to be merged.