### PR TITLE
Allow checking if a returned index is within range

### DIFF
--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -243,7 +243,7 @@ struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
           ... );
     }
 
-    KOKKOS_INLINE_FUNCTION int getIndex( const int i, const int j ) const
+    KOKKOS_INLINE_FUNCTION unsigned getIndex( const int i, const int j ) const
     {
         return indexing( type( i ), type( j ) );
     }
@@ -258,6 +258,10 @@ struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
             const int, Args...>;
 
         auto t = getIndex( i, j );
+        if ( t > Indexing::MaxValidIndex )
+            Kokkos::abort( "CabanaPD: Indexing computed an index that is out "
+                           "of its valid range" );
+
         // Call individual model.
         // if inside the pack
         if ( static_cast<unsigned>( t ) < ParameterPackType::size )

--- a/src/CabanaPD_ForceModelsMulti.hpp
+++ b/src/CabanaPD_ForceModelsMulti.hpp
@@ -264,7 +264,7 @@ struct ForceModelsImpl<MaterialType, Indexing, ParameterPackType,
 
         // Call individual model.
         // if inside the pack
-        if ( static_cast<unsigned>( t ) < ParameterPackType::size )
+        if ( t < ParameterPackType::size )
             return run_functor_for_index_in_pack_with_args(
                 IdentityFunctor{}, t, models, tag, i, j, args... );
         else

--- a/src/CabanaPD_Indexing.hpp
+++ b/src/CabanaPD_Indexing.hpp
@@ -19,6 +19,8 @@ template <unsigned NumBaseModels>
 struct DiagonalIndexing
 {
     static_assert( NumBaseModels > 0, "NumBaseModels must be larger than 0" );
+    static constexpr unsigned MaxValidIndex =
+        ( NumBaseModels * NumBaseModels + NumBaseModels ) / 2;
 
     KOKKOS_FUNCTION unsigned operator()( unsigned firstType,
                                          unsigned secondType ) const
@@ -44,6 +46,8 @@ struct DiagonalIndexing
 // Index same type as 0 and differing types as 1.
 struct BinaryIndexing
 {
+    static constexpr unsigned MaxValidIndex =
+        Kokkos::Experimental::finite_max_v<unsigned>;
     KOKKOS_FUNCTION unsigned operator()( unsigned firstType,
                                          unsigned secondType ) const
     {
@@ -55,6 +59,7 @@ template <unsigned NumBaseModels>
 struct FullIndexing
 {
     static_assert( NumBaseModels > 0, "NumBaseModels must be larger than 0" );
+    static constexpr unsigned MaxValidIndex = NumBaseModels * NumBaseModels;
 
     KOKKOS_FUNCTION unsigned operator()( unsigned firstType,
                                          unsigned secondType ) const


### PR DESCRIPTION
This PR adds a way to check for a given indexing what the maximum valid value of the output index is.

This is used in the multimaterial implementation to decide if we want to definitely abort because we are outside of the valid range of the indexing. If we are within range, we continue to either calling the respective model or whatever is defined as operation that should be done for indices that are larger than the number of models.
The default operation for indices larger than the number of models is aborting, but that is a customization point.

E.g. one could envision a multimaterial case that defines a subset of all combinations of materials as actual models and has a default that returns a force of 0 for any indexing outside of the defined subset. For example a layered sphere where only some layers interact mechanically or a polycrystal where only models for neighbouring crystals are defined